### PR TITLE
feat(jit): log generated kernel size before each measurement

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,7 +86,7 @@ JittedKernel jit_compile(ferret::Benchmark& b, const ferret::Params& p) {
   void* code = sljit_generate_code(c, 0, nullptr);
   size_t code_size = sljit_get_generated_code_size(c);
   sljit_free_compiler(c);
-  return {code, code_size};
+  return {.code = code, .code_size = code_size};
 }
 
 void jit_free(JittedKernel& k) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,6 +70,7 @@ double parse_freq(const std::string& s) {
 
 struct JittedKernel {
   void* code = nullptr;
+  size_t code_size = 0;
 };
 
 JittedKernel jit_compile(ferret::Benchmark& b, const ferret::Params& p) {
@@ -83,8 +84,9 @@ JittedKernel jit_compile(ferret::Benchmark& b, const ferret::Params& p) {
     return {};
   }
   void* code = sljit_generate_code(c, 0, nullptr);
+  size_t code_size = sljit_get_generated_code_size(c);
   sljit_free_compiler(c);
-  return {code};
+  return {code, code_size};
 }
 
 void jit_free(JittedKernel& k) {
@@ -248,6 +250,7 @@ int do_run(const std::string& name, const std::map<std::string, std::string>& cl
         m.sites = pre_sites;
         flog::warn("sljit_error on params; emitting empty row");
       } else {
+        flog::info("jit kernel: {} bytes", kern.code_size);
         auto fn = reinterpret_cast<void (*)()>(kern.code);
         m = ferret::runner::measure(fn, pre_iters, pre_sites, K, warmup);
         jit_free(kern);


### PR DESCRIPTION
## Summary
- Record \`sljit_get_generated_code_size\` while the compiler is still alive and stash it on \`JittedKernel\`.
- Emit a single info-level line per kernel — \`jit kernel: N bytes\` — right before \`runner::measure\` runs.
- Default warn output is unchanged; pass \`--log-level=info\` to see the sizes.

## Why
Useful for sanity-checking layout-controlled benchmarks (e.g. direct_branch_footprint) where the post-reduce code size is the quantity under study and you want to confirm it before reading the cycle counts.

## Test plan
- [ ] \`./build/ferret run direct_branch_footprint --log-level=info --branches=1,4,16 --spacing_bytes=64 --reps=1 --out=/tmp/x.csv\` — sees three \`jit kernel: …\` info lines, sizes grow with N.
- [ ] Same command without \`--log-level=info\` — no info lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)