### PR TITLE
docs: header-doc parity pass

### DIFF
--- a/include/ferret/axis.hpp
+++ b/include/ferret/axis.hpp
@@ -7,18 +7,31 @@
 
 namespace ferret {
 
+// Declarative parameter axis used by a Benchmark's axes() method. Three
+// kinds: Range (inclusive linear), Log2Range (powers of two up to hi),
+// Values (literal list). expand() materializes the chosen kind into a
+// concrete int64_t value list.
 class Axis {
  public:
   enum class Kind { Range, Log2Range, Values };
 
+  // Closed interval [lo, hi]. Step is 1.
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
   static Axis range(std::string name, int64_t lo, int64_t hi);
+
+  // {lo, lo*2, lo*4, ...} up to the largest power of two <= hi.
+  // Delegates to expand_log2_range; throws std::invalid_argument when
+  // lo <= 0.
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
   static Axis log2_range(std::string name, int64_t lo, int64_t hi);
+
+  // Uses the supplied list verbatim; no validation.
   static Axis values(std::string name, std::vector<int64_t> vs);
 
   const std::string& name() const { return name_; }
   Kind kind() const { return kind_; }
+
+  // May throw on Log2Range via expand_log2_range.
   std::vector<int64_t> expand() const;
 
  private:

--- a/include/ferret/benchmark.hpp
+++ b/include/ferret/benchmark.hpp
@@ -24,23 +24,54 @@ struct BenchOption {
 
 using BenchOptions = std::vector<BenchOption>;
 
+// Base class for one microbenchmark. Subclasses are constructed via
+// BenchmarkRegistry::create. The runner calls axes() and options() once
+// at startup; then, for every parameter point produced by sweep::expand,
+// it calls sites_per_kernel(), iterations(), and emit_kernel() in that
+// order, JIT-compiles the kernel, and times it via runner::measure.
 class Benchmark {
  public:
   virtual ~Benchmark() = default;
+
+  // Must equal the string passed to FERRET_BENCHMARK.
   virtual std::string name() const = 0;
+
+  // Order is significant — defines CSV column order and the sweep-nesting
+  // (the first axis varies slowest in the output).
   virtual SweepAxes axes() const = 0;
+
+  // Scalar non-swept knobs surfaced as `--<name>=<v>`. Default is {} for
+  // benchmarks with no per-bench options.
   virtual BenchOptions options() const { return {}; }
+
+  // Per-site normalization divisor the runner divides ticks by. Must be
+  // > 0; zero is rejected with exit code 2.
   virtual size_t sites_per_kernel(const Params& p) const = 0;
+
+  // Outer-loop iteration count compiled into the kernel to amortize the
+  // runner's tick-read overhead. Must be > 0.
   virtual size_t iterations(const Params& p) const = 0;
+
+  // Emit the benchmark kernel into `c`. The kernel must end with a
+  // return. Any sljit error set on `c` propagates to
+  // JittedKernel::ok() == false. ISA-level parameter rejections should
+  // `throw std::invalid_argument` *before* mutating `c` (see the
+  // kMinBranchBytes / kBranchAlign validation in
+  // direct_branch_footprint.cpp).
   virtual void emit_kernel(sljit_compiler* c, const Params& p) = 0;
 };
 
+// Static singleton registry. Benchmark subclasses normally register
+// themselves at file scope via the FERRET_BENCHMARK macro; the registry
+// is then queried by `ferret list` and `ferret run`.
 class BenchmarkRegistry {
  public:
   using Factory = std::function<std::unique_ptr<Benchmark>()>;
 
   static void register_benchmark(std::string name, Factory factory);
   static std::unique_ptr<Benchmark> create(const std::string& name);
+
+  // Returns the registered names sorted lexicographically.
   static std::vector<std::string> names();
 };
 

--- a/include/ferret/csv.hpp
+++ b/include/ferret/csv.hpp
@@ -10,6 +10,9 @@
 
 namespace ferret {
 
+// Writes one CSV row per measurement to the supplied ostream. Streaming
+// — no internal buffering. Caller owns the ostream lifetime; CsvWriter
+// does not flush on destruction.
 class CsvWriter {
  public:
   // freq_hz: when set, the writer emits cycles_per_site_* and freq_hz
@@ -17,7 +20,15 @@ class CsvWriter {
   CsvWriter(std::ostream& os, std::string benchmark_name, std::vector<std::string> axis_columns,
             std::optional<double> freq_hz);
 
+  // Call exactly once before any write_row. Columns: `benchmark`, the
+  // supplied axis columns in order, `ticks_min, ticks_median, iters,
+  // sites_per_iter, reps`, `ns_per_site_min, ns_per_site_median`, and —
+  // when freq_hz was supplied — `cycles_per_site_min,
+  // cycles_per_site_median, freq_hz`.
   void write_header();
+
+  // Emit one row. When MeasurementRow::jit_failed is true, every timing
+  // column is empty; the axis columns are still written.
   void write_row(const Params& p, const MeasurementRow& m, double ticks_per_ns);
 
  private:

--- a/include/ferret/params.hpp
+++ b/include/ferret/params.hpp
@@ -13,6 +13,8 @@ namespace ferret {
 // because every benchmark axis is integral.
 class Params {
  public:
+  // First insertion appends to the iteration order returned by keys();
+  // subsequent overwrites update the value without reordering.
   void set(const std::string& key, int64_t value);
 
   // Negative int64 would silently wrap when T is unsigned; reject explicitly.


### PR DESCRIPTION
## Summary

PR2 of the readability/quality/docs refactor (spec: \`docs/superpowers/specs/2026-05-12-readability-quality-docs-refactor-design.md\`).

Four pure-doc commits bringing four public headers to documentation parity with the rest of \`include/ferret/\`:

- **\`docs(benchmark.hpp): document the Benchmark vtable contract\`** — class-level lifecycle block + per-virtual contract docs (axes ordering, sites/iterations preconditions, emit_kernel ISA-validation idiom) + BenchmarkRegistry block.
- **\`docs(axis.hpp): document Axis and its builders\`** — class block + one-line docs on each of \`range\` / \`log2_range\` / \`values\` / \`expand\`.
- **\`docs(csv.hpp): document CsvWriter contract\`** — class block (ostream ownership, no buffering) + \`write_header\` column list + \`write_row\` jit_failed behavior.
- **\`docs(params.hpp): document set() insertion-order semantics\`** — one comment block clarifying first-insert-appends, overwrites-don't-reorder.

No code changes. Binary is bit-identical to baseline. 57 insertions across 4 headers.

Every claim cross-checked against the implementation (\`grep\`-confirmed during review):
- \`BenchmarkRegistry::names()\` sorted lexicographically → \`std::ranges::sort(out)\` in \`src/benchmark_registry.cpp\`.
- \`axes()\` order matches CSV column order → \`column_names\` helper in \`src/run_command.cpp\`.
- \`sites_per_kernel\`/\`iterations\` = 0 → exit code 2 → \`run_command.cpp\` measure_all + run().
- \`emit_kernel\` ISA-validation idiom → \`kMinBranchBytes\`/\`kBranchAlign\` block in \`direct_branch_footprint.cpp\`.
- \`range\` closed interval / \`log2_range\` throws on \`lo <= 0\` / \`values\` no validation → \`src/axis.cpp\`.
- \`Params::set\` insertion-order semantics → \`src/axis.cpp\`.
- CSV column list + \`jit_failed\` empty-cells → \`src/output/csv.cpp\`.

This branch is independent of PR #6 (PR1). It can be reviewed and merged in any order relative to PR1.

## Test plan
- [x] \`ctest --test-dir build --output-on-failure\` green on every commit (112/112, 1 platform-skipped)
- [x] \`./scripts/lint.sh\` clean on every commit
- [x] Pure-comment diffs — no behavior change possible
- [ ] CI matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)