### PR TITLE
docs: external docs pass — architecture, writing-a-benchmark, README index

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ cmake --build build
 ctest --test-dir build --output-on-failure
 ```
 
+## Documentation
+
+- [`docs/architecture.md`](docs/architecture.md) — codebase overview and module map.
+- [`docs/writing-a-benchmark.md`](docs/writing-a-benchmark.md) — guide for adding a new benchmark.
+
 ## Use
 
 ### List benchmarks
@@ -56,6 +61,16 @@ ctest --test-dir build --output-on-failure
 ```sh
 build/ferret list
 ```
+
+### Benchmarks
+
+Each benchmark probes one frontend structure. Use the table to pick the
+one matching the question you're asking.
+
+| Name                          | Targets                                  | Notes                                                                            |
+|-------------------------------|------------------------------------------|----------------------------------------------------------------------------------|
+| `dependent_chain_throughput`  | running core frequency / 1-IPC baseline  | dependent ADD chain                                                              |
+| `direct_branch_footprint`     | direct-jump BTB capacity                 | N unconditional branches; `--sattolo_permute=1` defeats spatial I-cache prefetch |
 
 ### The two-step cycle workflow
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,22 @@
+# Ferret Documentation
+
+## Live documentation
+
+These docs reflect current behavior. Edit them when behavior changes.
+
+- [`architecture.md`](architecture.md) — codebase overview and module
+  map.
+- [`writing-a-benchmark.md`](writing-a-benchmark.md) — guide for adding
+  a new benchmark.
+- [`../README.md`](../README.md) — user-facing usage, build, and the
+  two-step cycle workflow.
+
+## Historical artifacts
+
+The `superpowers/specs/` and `superpowers/plans/` directories hold
+point-in-time design and implementation records. They are kept for
+git-archaeology context — to see what we were thinking and what we
+chose not to do at a given moment.
+
+**They are not current documentation.** If a spec disagrees with the
+code, the code is right and the spec is frozen.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,68 @@
+# Ferret Architecture
+
+Ferret JIT-emits microbenchmarks at runtime, times them with
+free-running tick counters, sweeps a parameter axis, and writes one CSV
+row per parameter point. This document is the live map of the codebase;
+the per-feature specs under `superpowers/specs/` are point-in-time
+records and may be out of date.
+
+## End-to-end flow
+
+```
+main.cpp (CLI11 wiring)
+  → ferret::list_command()        → stdout
+  → ferret::run(RunOptions)
+      → BenchmarkRegistry::create  // factory lookup
+      → classify_overrides         // axes vs options
+      → sweep::expand              // cartesian product
+      → measure_all
+          ↳ JittedKernel           // sljit emit + codegen
+          ↳ runner::measure        // warmup + reps timed
+      → emit_csv via CsvWriter
+```
+
+## Modules
+
+Every public header lives under `include/ferret/`. The list is
+alphabetical; each line is one sentence on responsibility.
+
+- `axis.hpp` — declarative parameter axis (Range / Log2Range / Values)
+  used by benchmarks to describe what to sweep.
+- `benchmark.hpp` — base class benchmark authors subclass, plus the
+  registry and registration macro.
+- `cli_axis.hpp` — parses CLI values like `1..32768`, `16,32,64`, or
+  `--option=42` into axis or option values.
+- `csv.hpp` — writes one CSV row per measurement to a caller-owned
+  ostream.
+- `freq.hpp` — parses `--freq=4.521GHz` and similar suffixed numbers
+  into hertz.
+- `jit.hpp` — RAII handle for an sljit-compiled kernel.
+- `log.hpp` — spdlog-backed logger aliased as `flog::` at every use
+  site (avoids the `::log(double)` collision from `<math.h>`).
+- `padding.hpp` — emits architecture-correct NOPs to pad branch sites.
+- `params.hpp` — insertion-ordered key/int64 map carrying one parameter
+  point through the runner and into the CSV.
+- `permute.hpp` — Sattolo's algorithm, a single Hamiltonian cycle over
+  `{0..n-1}`, used by benchmarks that want to defeat sequential
+  prefetch.
+- `pinning.hpp` — best-effort core pin, priority boost, and memory lock.
+- `run_command.hpp` — `ferret::run(RunOptions)` and `list_command()`,
+  the two CLI entry points exposed by `main.cpp`.
+- `runner.hpp` — `runner::measure` runs warmup + N timed reps and
+  returns ticks_min, ticks_median.
+- `sweep.hpp` — cross-product over each axis's expanded values, with
+  optional per-axis overrides.
+- `timing.hpp` — per-arch `arch_now_ticks()` (rdtscp on x86_64,
+  cntvct_el0 on aarch64) and a lazily-calibrated `ticks_per_ns()`.
+
+## Adding a benchmark
+
+See `writing-a-benchmark.md`. The two existing benchmarks under
+`benchmarks/` are worked examples of the frequency-probe and
+parameter-sweep patterns.
+
+## Usage
+
+See `../README.md` for the command-line interface and the two-step
+cycle workflow (probe frequency, then run the actual benchmark on the
+same core).

--- a/docs/writing-a-benchmark.md
+++ b/docs/writing-a-benchmark.md
@@ -1,0 +1,152 @@
+# Writing a Benchmark
+
+A new Ferret benchmark is one C++ file under `benchmarks/`. It
+subclasses `ferret::Benchmark`, overrides six pure virtuals, and
+registers itself at file scope. The runner does the rest.
+
+## The vtable
+
+`Benchmark` (declared in `include/ferret/benchmark.hpp`) requires:
+
+- **`name()`** — must equal the string passed to `FERRET_BENCHMARK`.
+  `ferret list` and `ferret run <name>` both look it up by this string.
+- **`axes()`** — returns the swept axes. Order is significant: the
+  first axis varies slowest in the CSV output and the first column to
+  the right of `benchmark` is the first axis. Use
+  `Axis::range(...)`, `Axis::log2_range(...)`, or
+  `Axis::values(...)` (declared in `include/ferret/axis.hpp`).
+- **`options()`** — returns scalar non-swept knobs. Each appears as a
+  `--<name>=<v>` CLI flag and is recorded in the CSV one column after
+  the axes. Default to `{}` if your benchmark has no per-bench options.
+- **`sites_per_kernel(p)`** — divisor the runner uses to convert
+  `ticks` into per-site latency. Must be > 0; the runner rejects zero
+  with exit code 2.
+- **`iterations(p)`** — outer-loop count compiled into the kernel.
+  Amortizes the tick-read overhead at the runner level. Must be > 0.
+- **`emit_kernel(c, p)`** — emits the actual measurement kernel into
+  `c` via sljit. The kernel must end with a return. If a parameter
+  point is invalid at the ISA level (e.g., `spacing_bytes` too small),
+  `throw std::invalid_argument` *before* touching `c` so the compiler
+  state stays clean. Any sljit error set on `c` propagates to
+  `JittedKernel::ok() == false`.
+
+## Registration
+
+At the bottom of the `.cpp` file, after the `struct` definition:
+
+```cpp
+FERRET_BENCHMARK("my_bench", MyBench);
+```
+
+The macro registers a factory at static-init time, so `ferret list`
+sees the new name automatically. Add the new file to the executable's
+source list in the top-level `CMakeLists.txt`:
+
+```cmake
+add_executable(ferret
+  src/main.cpp
+  benchmarks/dependent_chain_throughput.cpp
+  benchmarks/direct_branch_footprint.cpp
+  benchmarks/my_bench.cpp        # <-- new
+)
+```
+
+## Worked example A — frequency-probe pattern
+
+`benchmarks/dependent_chain_throughput.cpp` is the simplest possible
+benchmark: a single-valued axis and a one-shot kernel.
+
+```cpp
+struct DependentChainThroughput : Benchmark {
+  static constexpr int UNROLL = 1024;
+  [[nodiscard]] std::string name() const override { return "dependent_chain_throughput"; }
+  [[nodiscard]] SweepAxes axes() const override {
+    return {Axis::values("chain_length", {100'000'000})};
+  }
+  [[nodiscard]] size_t sites_per_kernel(const Params& p) const override {
+    return p.get<size_t>("chain_length");
+  }
+  [[nodiscard]] size_t iterations(const Params& /*p*/) const override { return 1; }
+  // ... emit_kernel emits chain_length dependent ADDs ...
+};
+```
+
+Why each choice:
+
+- **`iterations = 1`**: the kernel itself executes `chain_length` ops;
+  no outer loop is needed.
+- **`sites_per_kernel = chain_length`**: the runner divides ticks by
+  `iterations * sites_per_kernel` = `chain_length`, yielding
+  ns-per-op = ns-per-cycle on a 1-IPC core (every ADD is dependent on
+  the previous, so IPC is exactly 1 on every common high-perf or
+  in-order ARM core).
+- **`UNROLL = 1024`**: the inner loop body is a 1024-ADD straight-line
+  block; the outer loop runs `chain_length / 1024` times plus a
+  straight-line tail of `chain_length % 1024` ADDs. Total ops per
+  `fn()` invocation == `chain_length` exactly.
+
+## Worked example B — parameter-sweep pattern
+
+`benchmarks/direct_branch_footprint.cpp` has two axes and one option,
+plus ISA-level pre-flight validation.
+
+```cpp
+struct DirectBranchFootprint : Benchmark {
+  [[nodiscard]] SweepAxes axes() const override {
+    return {
+        Axis::log2_range("branches", 1, 1 << 15),
+        Axis::log2_range("spacing_bytes", 16, 128),
+    };
+  }
+  [[nodiscard]] BenchOptions options() const override {
+    return {BenchOption{.name = "sattolo_permute", .default_value = 0}};
+  }
+  [[nodiscard]] size_t sites_per_kernel(const Params& p) const override {
+    return p.get<size_t>("branches");
+  }
+  [[nodiscard]] size_t iterations(const Params& p) const override {
+    return std::max<size_t>(1, 10'000'000 / p.get<size_t>("branches"));
+  }
+  void emit_kernel(sljit_compiler* c, const Params& p) override {
+    auto spacing = p.get<size_t>("spacing_bytes");
+    if (spacing < kMinBranchBytes) {
+      throw std::invalid_argument("spacing_bytes=...");  // before touching `c`
+    }
+    // ... emit branches, optionally Sattolo-permuted ...
+  }
+};
+```
+
+Key idioms:
+
+- **Two `log2_range` axes** — `branches=1..32768` expands to
+  `{1, 2, 4, 8, ..., 32768}`; `spacing_bytes=16..128` to
+  `{16, 32, 64, 128}`. The framework takes the cartesian product.
+- **`sattolo_permute` option** — surfaced as `--sattolo_permute=0|1`.
+  Stored in every CSV row, optionally rewires branch targets as a
+  uniform random Hamiltonian cycle (see `permute.hpp`).
+- **`iterations` adapts to `branches`** — capped at 10 M ops total per
+  kernel invocation so smaller `branches` values still get reasonable
+  measurement counts.
+- **ISA validation before any sljit state changes** — the alignment and
+  minimum-encoding checks happen up front; bad params throw cleanly and
+  leave no partial compiler state behind.
+- **`emit_nops(c, n)`** — pads each branch out to the requested
+  `spacing_bytes` using arch-correct NOP encodings (see `padding.hpp`).
+
+## Smoke-testing a new benchmark
+
+After building:
+
+```sh
+build/ferret list                                     # confirm registration
+build/ferret run my_bench --reps=3 --warmup=1         # confirm it runs end-to-end
+```
+
+If the new benchmark has axes, supply explicit overrides while
+iterating (`--my_axis=1,2,4`) so the smoke run finishes in seconds.
+
+The framework's own integration suite picks up new benchmarks
+automatically — `ctest --test-dir build --output-on-failure` will
+exercise registration. If you want behavior-level coverage, add a
+gtest under `tests/` linking `ferret_core`.


### PR DESCRIPTION
## Summary

PR3 of the readability/quality/docs refactor (spec: \`docs/superpowers/specs/2026-05-12-readability-quality-docs-refactor-design.md\`).

Four pure-markdown commits:

- **\`docs(architecture): add module overview\`** — \`docs/architecture.md\` with overview paragraph, end-to-end ASCII flow diagram (signatures omitted so the diagram stays valid regardless of PR ordering), and an alphabetical module table covering all 15 headers in \`include/ferret/\`.
- **\`docs(benchmarks): add writing-a-benchmark guide\`** — \`docs/writing-a-benchmark.md\` with full vtable walkthrough, registration recipe, and two worked examples annotated from the existing benchmarks (frequency-probe pattern from \`dependent_chain_throughput\`, parameter-sweep pattern from \`direct_branch_footprint\` including the ISA-validation idiom).
- **\`docs(readme): add benchmark to microarch mapping and link new docs\`** — README gets a new "Documentation" section after Build and a "Benchmarks" subsection inside Use mapping each benchmark to the microarch structure it targets.
- **\`docs: add docs/README index distinguishing current docs from spec history\`** — \`docs/README.md\` index distinguishing live docs (architecture.md, writing-a-benchmark.md, ../README.md) from frozen \`superpowers/specs/\` and \`superpowers/plans/\` artifacts.

No code changes. Binary is bit-identical to baseline.

This branch is independent of PR #6 (PR1) and PR #8 (PR2). The architecture diagram intentionally omits PR1-introduced \`MeasureOptions\` signature detail so it remains valid before or after PR1 lands.

## Test plan
- [x] Every doc cross-reference resolves (\`docs/architecture.md\`, \`docs/writing-a-benchmark.md\`, \`docs/README.md\`, \`README.md\` links all check out)
- [x] Every code/CLI example matches the real source (\`FERRET_BENCHMARK\` macro signature, \`build/ferret list\`, \`build/ferret run ... --reps=3 --warmup=1\` confirmed against the actual binary)
- [x] All 15 headers under \`include/ferret/\` appear in \`architecture.md\`'s module table; nothing extra
- [ ] CI matrix green (markdown-only; expected pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)