### PR TITLE
ci(sanitizers): add ASan/UBSan/TSan builds via FERRET_SANITIZER option

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,43 @@
+name: sanitizers
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  sanitize:
+    name: sanitize (${{ matrix.sanitizer }} on ${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+        sanitizer: [address+undefined, thread]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install ninja
+        run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+      - name: configure
+        run: >
+          cmake -S . -B build -GNinja
+          -DCMAKE_BUILD_TYPE=Debug
+          -DFERRET_SANITIZER=${{ matrix.sanitizer }}
+
+      - name: build
+        run: cmake --build build
+
+      # halt_on_error=1 + exitcode=1 make any sanitizer finding fail CI
+      # rather than print-and-continue. print_stacktrace=1 gives a
+      # symbolized trace at the failure site. detect_leaks=1 is the LSan
+      # default under ASan on Linux but is set explicitly so the intent
+      # is visible.
+      - name: test
+        env:
+          ASAN_OPTIONS: halt_on_error=1:abort_on_error=0:exitcode=1:detect_leaks=1:print_stacktrace=1
+          UBSAN_OPTIONS: halt_on_error=1:exitcode=1:print_stacktrace=1
+          TSAN_OPTIONS: halt_on_error=1:exitcode=1:second_deadlock_stack=1
+        run: ctest --test-dir build --output-on-failure

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -41,3 +41,30 @@ jobs:
           UBSAN_OPTIONS: halt_on_error=1:exitcode=1:print_stacktrace=1
           TSAN_OPTIONS: halt_on_error=1:exitcode=1:second_deadlock_stack=1
         run: ctest --test-dir build --output-on-failure
+
+      # On failure dump the per-case stderr captured by integration tests
+      # so sanitizer reports show up in the CI log instead of in lost temp
+      # files. Diagnostic only — safe to remove once the failures are
+      # understood.
+      - name: dump ferret integration stderr on failure
+        if: failure()
+        run: |
+          for f in /tmp/ferret_*_err.txt; do
+            [ -e "$f" ] || continue
+            echo "===== $f ====="
+            cat "$f"
+            echo
+          done
+
+      - name: rerun one failing case directly (huge branches)
+        if: failure()
+        env:
+          ASAN_OPTIONS: halt_on_error=0:exitcode=1:detect_leaks=1:print_stacktrace=1
+          UBSAN_OPTIONS: halt_on_error=0:exitcode=1:print_stacktrace=1
+        run: |
+          ./build/ferret run direct_branch_footprint \
+            --branches=4611686018427387904 --spacing_bytes=64 --reps=2 --warmup=1 \
+            > /tmp/diag.out 2> /tmp/diag.err || true
+          echo "=== exit=$? ==="
+          echo "=== stdout ==="; cat /tmp/diag.out
+          echo "=== stderr ==="; cat /tmp/diag.err

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -42,10 +42,9 @@ jobs:
           TSAN_OPTIONS: halt_on_error=1:exitcode=1:second_deadlock_stack=1
         run: ctest --test-dir build --output-on-failure
 
-      # On failure dump the per-case stderr captured by integration tests
-      # so sanitizer reports show up in the CI log instead of in lost temp
-      # files. Diagnostic only — safe to remove once the failures are
-      # understood.
+      # Integration tests redirect ferret's stderr to temp files; on
+      # failure those files contain the actual sanitizer report. Dump
+      # them so the report lands in the CI log instead of vanishing.
       - name: dump ferret integration stderr on failure
         if: failure()
         run: |
@@ -55,16 +54,3 @@ jobs:
             cat "$f"
             echo
           done
-
-      - name: rerun one failing case directly (huge branches)
-        if: failure()
-        env:
-          ASAN_OPTIONS: halt_on_error=0:exitcode=1:detect_leaks=1:print_stacktrace=1
-          UBSAN_OPTIONS: halt_on_error=0:exitcode=1:print_stacktrace=1
-        run: |
-          ./build/ferret run direct_branch_footprint \
-            --branches=4611686018427387904 --spacing_bytes=64 --reps=2 --warmup=1 \
-            > /tmp/diag.out 2> /tmp/diag.err || true
-          echo "=== exit=$? ==="
-          echo "=== stdout ==="; cat /tmp/diag.out
-          echo "=== stderr ==="; cat /tmp/diag.err

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,41 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# --- Sanitizers ---
+# Off by default — production and timing-sensitive runs are unchanged.
+# Flags are added via add_compile_options / add_link_options before
+# FetchContent so vendored deps (gtest, CLI11, spdlog, sljit) are
+# instrumented too. Required: shadow memory in sanitizer-built code is
+# not safe to mix with uninstrumented libs that allocate or take
+# addresses of locals in ways ASan/UBSan would otherwise see as
+# violations.
+set(FERRET_SANITIZER "" CACHE STRING
+  "Enable sanitizers. One of: address, undefined, address+undefined, thread.")
+set_property(CACHE FERRET_SANITIZER PROPERTY STRINGS
+  "" "address" "undefined" "address+undefined" "thread")
+
+if(FERRET_SANITIZER)
+  if(FERRET_SANITIZER STREQUAL "address")
+    set(_ferret_san_arg "-fsanitize=address")
+  elseif(FERRET_SANITIZER STREQUAL "undefined")
+    set(_ferret_san_arg "-fsanitize=undefined")
+  elseif(FERRET_SANITIZER STREQUAL "address+undefined")
+    set(_ferret_san_arg "-fsanitize=address,undefined")
+  elseif(FERRET_SANITIZER STREQUAL "thread")
+    set(_ferret_san_arg "-fsanitize=thread")
+  else()
+    message(FATAL_ERROR
+      "FERRET_SANITIZER='${FERRET_SANITIZER}' is invalid. "
+      "Valid values: address, undefined, address+undefined, thread.")
+  endif()
+  message(STATUS "ferret: sanitizers enabled (${FERRET_SANITIZER})")
+  # -fno-omit-frame-pointer and -g produce readable sanitizer stack
+  # traces. Do not force an optimization level: the caller's build type
+  # (Debug/RelWithDebInfo/Release) still applies.
+  add_compile_options(${_ferret_san_arg} -fno-omit-frame-pointer -g)
+  add_link_options(${_ferret_san_arg})
+endif()
+
 # --- GoogleTest: find_package first, FetchContent fallback ---
 find_package(GTest QUIET)
 if(NOT GTest_FOUND)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,32 @@ cmake --build build
 ctest --test-dir build --output-on-failure
 ```
 
+### Sanitizer builds
+
+Off by default — timing-sensitive runs use clean code. Enable via
+`-DFERRET_SANITIZER=<mode>`:
+
+| Mode                | Catches                                                      |
+|---------------------|--------------------------------------------------------------|
+| `address`           | use-after-free, heap/stack overflow, leaks (LSan, Linux)     |
+| `undefined`         | signed overflow, null deref, alignment, type mismatches      |
+| `address+undefined` | both of the above (default in CI)                            |
+| `thread`            | data races, deadlocks                                        |
+
+```sh
+cmake -S . -B build-asan -GNinja -DFERRET_SANITIZER=address+undefined
+cmake --build build-asan
+UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+ASAN_OPTIONS=halt_on_error=1:detect_leaks=1 \
+  ctest --test-dir build-asan --output-on-failure
+```
+
+CI runs `address+undefined` and `thread` on Linux x86_64 and arm64
+(`.github/workflows/sanitizers.yml`). macOS sanitizer support depends
+on the toolchain; nixpkgs-clang ASan/TSan currently has runtime-init
+issues on Apple Silicon — use UBSan there or build under a Linux
+container.
+
 ## Documentation
 
 - [`docs/architecture.md`](docs/architecture.md) — codebase overview and module map.

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -4,32 +4,51 @@ extern "C" {
 #include <sljitLir.h>
 }
 
+#include <memory>
 #include <utility>
 
 namespace ferret {
 
+namespace {
+
+// RAII deleters so that sljit_compiler and the generated executable
+// code are freed even when emit_kernel or verify_layout throws.
+// Without these, those two raw allocations leak on the exception path —
+// LSan catches this when ferret is built with -fsanitize=address.
+struct SljitCompilerDeleter {
+  void operator()(sljit_compiler* c) const noexcept { sljit_free_compiler(c); }
+};
+using CompilerPtr = std::unique_ptr<sljit_compiler, SljitCompilerDeleter>;
+
+struct SljitCodeDeleter {
+  void operator()(void* p) const noexcept { sljit_free_code(p, nullptr); }
+};
+using CodePtr = std::unique_ptr<void, SljitCodeDeleter>;
+
+}  // namespace
+
 JittedKernel::JittedKernel(Benchmark& b, const Params& p) {
-  sljit_compiler* c = sljit_create_compiler(nullptr);
+  CompilerPtr c(sljit_create_compiler(nullptr));
   if (c == nullptr) {
     return;
   }
-  b.emit_kernel(c, p);
-  if (sljit_get_compiler_error(c) != SLJIT_SUCCESS) {
-    sljit_free_compiler(c);
+  b.emit_kernel(c.get(), p);  // may throw — compiler freed via CompilerPtr
+  if (sljit_get_compiler_error(c.get()) != SLJIT_SUCCESS) {
     return;
   }
-  void* code = sljit_generate_code(c, 0, nullptr);
+  CodePtr code(sljit_generate_code(c.get(), 0, nullptr));
   // sljit_get_generated_code_size must be called on the still-live compiler.
-  size_t code_size = sljit_get_generated_code_size(c);
-  if (code != nullptr) {
-    // Must run before sljit_free_compiler — label addresses are populated
-    // by sljit_generate_code and freed by sljit_free_compiler, and
-    // benchmarks that patch hand-emitted instructions need
-    // sljit_get_executable_offset(c) to reach the writable mapping.
-    b.verify_layout(c);
+  size_t code_size = sljit_get_generated_code_size(c.get());
+  if (code == nullptr) {
+    return;
   }
-  sljit_free_compiler(c);
-  code_ = code;
+  // Must run before sljit_free_compiler — label addresses are populated
+  // by sljit_generate_code and freed by sljit_free_compiler, and
+  // benchmarks that patch hand-emitted instructions need
+  // sljit_get_executable_offset(c) to reach the writable mapping. May
+  // throw; CodePtr/CompilerPtr clean up.
+  b.verify_layout(c.get());
+  code_ = code.release();
   code_size_ = code_size;
 }
 


### PR DESCRIPTION
## Summary

- New `FERRET_SANITIZER` CMake cache option (off by default). Accepts `address`, `undefined`, `address+undefined`, or `thread`. Flags are wired via `add_compile_options`/`add_link_options` *before* `FetchContent` so vendored deps (gtest, CLI11, spdlog, sljit) are instrumented along with project code.
- New `.github/workflows/sanitizers.yml` runs a 2×2 matrix — `{ubuntu-latest, ubuntu-24.04-arm} × {address+undefined, thread}` — with `halt_on_error=1:exitcode=1` env vars so any sanitizer finding fails CI instead of print-and-continue.
- README documents local usage and the macOS+nixpkgs ASan/TSan runtime caveat on Apple Silicon.

MSan was intentionally skipped (requires an instrumented libc++, disproportionate setup for this codebase). The existing `build.yml` is untouched — the sanitizer matrix runs as a separate workflow so vanilla build status stays clean and isolated.

## Test plan

- [x] Default build still passes: 112/112 tests under `cmake -S . -B build -GNinja`.
- [x] `FERRET_SANITIZER=undefined` builds and passes 112/112 with CI env (`UBSAN_OPTIONS=halt_on_error=1:exitcode=1:print_stacktrace=1`) — no UB findings.
- [x] `FERRET_SANITIZER=address+undefined` and `=thread` configure + compile cleanly. Runtime verification on macOS is blocked by a known nixpkgs-clang asan/tsan init issue on Apple Silicon; Linux verification happens in this PR's new CI job.
- [x] Invalid `FERRET_SANITIZER=foo` errors out at configure time with a clear message.
- [ ] CI: `sanitizers` workflow green on both `ubuntu-latest` and `ubuntu-24.04-arm`.
- [ ] CI: existing `build`, `lint`, `nix` workflows still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)