### PR TITLE
ci: sanitizer support + compiler matrix + -Werror policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,22 +8,43 @@ on:
 
 jobs:
   build-test:
-    name: build-test (${{ matrix.os }})
+    name: build-test (${{ matrix.cc }} on ${{ matrix.os }})
     strategy:
       fail-fast: false
+      # Explicit include cells so we can pair compilers with OSes without
+      # generating unwanted combinations. FERRET_WERROR is ON by default,
+      # so every cell here doubles as a warning-cleanliness check.
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
+        include:
+          # --- Linux x86_64 ---
+          - { os: ubuntu-latest, cc: gcc-13, cxx: g++-13, apt: "gcc-13 g++-13" }
+          - { os: ubuntu-latest, cc: gcc-14, cxx: g++-14, apt: "gcc-14 g++-14" }
+          - { os: ubuntu-latest, cc: clang-17, cxx: clang++-17, apt: "clang-17" }
+          - { os: ubuntu-latest, cc: clang-18, cxx: clang++-18, apt: "clang-18" }
+          # --- Linux aarch64 ---
+          - { os: ubuntu-24.04-arm, cc: gcc-14, cxx: g++-14, apt: "gcc-14 g++-14" }
+          - { os: ubuntu-24.04-arm, cc: clang-18, cxx: clang++-18, apt: "clang-18" }
+          # --- macOS arm64 (Apple Clang from Xcode) ---
+          - { os: macos-latest, cc: clang, cxx: clang++, apt: "" }
     runs-on: ${{ matrix.os }}
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: install ninja (linux)
+      - name: install toolchain + ninja (linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y ninja-build
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build ${{ matrix.apt }}
 
       - name: install ninja (macos)
         if: runner.os == 'macOS'
         run: brew install ninja
+
+      - name: print compiler version
+        run: ${{ matrix.cxx }} --version
 
       - name: configure
         run: cmake -S . -B build -GNinja

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,17 @@
+{
+  "printWidth": 120,
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": false,
+  "endOfLine": "lf",
+  "overrides": [
+    {
+      "files": ["*.yml", "*.yaml"],
+      "options": {
+        "tabWidth": 2,
+        "singleQuote": false,
+        "bracketSpacing": true
+      }
+    }
+  ]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,25 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# --- Warning policy ---
+# Scoped to ferret's own targets via the ferret_warnings INTERFACE library;
+# vendored deps (gtest/CLI11/spdlog/sljit) are deliberately excluded so a
+# warning regression upstream cannot fail our build. FERRET_WERROR is ON
+# by default so CI catches regressions without extra workflow plumbing;
+# turn it OFF (-DFERRET_WERROR=OFF) for a one-off local build.
+option(FERRET_WERROR "Treat warnings as errors for ferret targets" ON)
+
+add_library(ferret_warnings INTERFACE)
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang")
+  target_compile_options(ferret_warnings INTERFACE
+    -Wall -Wextra -Wpedantic
+    $<$<BOOL:${FERRET_WERROR}>:-Werror>)
+elseif(MSVC)
+  target_compile_options(ferret_warnings INTERFACE
+    /W4
+    $<$<BOOL:${FERRET_WERROR}>:/WX>)
+endif()
+
 # --- Sanitizers ---
 # Off by default — production and timing-sensitive runs are unchanged.
 # Flags are added via add_compile_options / add_link_options before
@@ -136,6 +155,7 @@ add_library(ferret_core STATIC
 )
 target_include_directories(ferret_core PUBLIC include)
 target_link_libraries(ferret_core PUBLIC sljit::sljit spdlog::spdlog)
+target_link_libraries(ferret_core PRIVATE ferret_warnings)
 target_compile_features(ferret_core PUBLIC cxx_std_20)
 
 add_executable(ferret
@@ -147,6 +167,7 @@ target_link_libraries(ferret PRIVATE
   ferret_core
   CLI11::CLI11
   sljit::sljit
+  ferret_warnings
 )
 
 install(TARGETS ferret RUNTIME DESTINATION bin)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(test_params_axis test_params_axis.cpp)
 target_link_libraries(test_params_axis PRIVATE
   ferret_core
   GTest::gtest GTest::gtest_main
+  ferret_warnings
 )
 gtest_discover_tests(test_params_axis)
 
@@ -21,6 +22,7 @@ add_executable(test_sweep test_sweep.cpp)
 target_link_libraries(test_sweep PRIVATE
   ferret_core
   GTest::gtest GTest::gtest_main
+  ferret_warnings
 )
 gtest_discover_tests(test_sweep)
 
@@ -28,6 +30,7 @@ add_executable(test_cli_axis test_cli_axis.cpp)
 target_link_libraries(test_cli_axis PRIVATE
   ferret_core
   GTest::gtest GTest::gtest_main
+  ferret_warnings
 )
 gtest_discover_tests(test_cli_axis)
 
@@ -35,6 +38,7 @@ add_executable(test_timing test_timing.cpp)
 target_link_libraries(test_timing PRIVATE
   ferret_core
   GTest::gtest GTest::gtest_main
+  ferret_warnings
 )
 gtest_discover_tests(test_timing)
 
@@ -42,6 +46,7 @@ add_executable(test_pinning test_pinning.cpp)
 target_link_libraries(test_pinning PRIVATE
   ferret_core
   GTest::gtest GTest::gtest_main
+  ferret_warnings
 )
 gtest_discover_tests(test_pinning)
 
@@ -50,6 +55,7 @@ target_link_libraries(test_benchmark_registry PRIVATE
   ferret_core
   sljit::sljit
   GTest::gtest GTest::gtest_main
+  ferret_warnings
 )
 gtest_discover_tests(test_benchmark_registry)
 
@@ -57,6 +63,7 @@ add_executable(test_csv test_csv.cpp)
 target_link_libraries(test_csv PRIVATE
   ferret_core
   GTest::gtest GTest::gtest_main
+  ferret_warnings
 )
 gtest_discover_tests(test_csv)
 
@@ -64,6 +71,7 @@ add_executable(test_runner test_runner.cpp)
 target_link_libraries(test_runner PRIVATE
   ferret_core
   GTest::gtest GTest::gtest_main
+  ferret_warnings
 )
 gtest_discover_tests(test_runner)
 
@@ -71,6 +79,7 @@ add_executable(test_padding test_padding.cpp)
 target_link_libraries(test_padding PRIVATE
   ferret_core
   GTest::gtest GTest::gtest_main
+  ferret_warnings
 )
 gtest_discover_tests(test_padding)
 
@@ -78,6 +87,7 @@ add_executable(test_permute test_permute.cpp)
 target_link_libraries(test_permute PRIVATE
   ferret_core
   GTest::gtest GTest::gtest_main
+  ferret_warnings
 )
 gtest_discover_tests(test_permute)
 
@@ -86,6 +96,7 @@ target_link_libraries(test_jit PRIVATE
   ferret_core
   sljit::sljit
   GTest::gtest GTest::gtest_main
+  ferret_warnings
 )
 gtest_discover_tests(test_jit)
 
@@ -93,6 +104,7 @@ add_executable(test_freq test_freq.cpp)
 target_link_libraries(test_freq PRIVATE
   ferret_core
   GTest::gtest GTest::gtest_main
+  ferret_warnings
 )
 gtest_discover_tests(test_freq)
 
@@ -103,6 +115,7 @@ target_compile_definitions(test_integration PRIVATE
 add_dependencies(test_integration ferret)
 target_link_libraries(test_integration PRIVATE
   GTest::gtest GTest::gtest_main
+  ferret_warnings
 )
 # Per-test wall-clock timeout enforced by CTest itself (portable across
 # Linux/macOS/BSD without depending on a `timeout` binary). 30 s is much


### PR DESCRIPTION
## Summary

- **Sanitizers** (`acad848`, `c7ca19d`): add `FERRET_SANITIZER` CMake option (`address` / `undefined` / `address+undefined` / `thread`) plumbed into compile/link flags before FetchContent so vendored deps are instrumented too. Linux-only CI matrix runs the suite under ASan+UBSan and TSan, with halt_on_error/exitcode so any finding fails the job. Failure step dumps `/tmp/ferret_*_err.txt` so integration-test sanitizer reports land in the CI log instead of vanishing.
- **JIT RAII** (`d992e72`): wrap the sljit compiler + generated code in RAII so exceptions on the JIT path don't leak `sljit_compiler`/`sljit_code`.
- **Compiler matrix + -Werror** (`f5b8ea2`): add `FERRET_WERROR` option (ON by default) applied via a `ferret_warnings` INTERFACE library — `-Wall -Wextra -Wpedantic -Werror` hits ferret_core/ferret/tests but **not** the FetchContent vendored deps (gtest/CLI11/spdlog/sljit). Expand `build.yml` to a 7-cell matrix: `ubuntu-latest` × {gcc-13, gcc-14, clang-17, clang-18}, `ubuntu-24.04-arm` × {gcc-14, clang-18}, `macos-latest` × Apple Clang. No source changes were needed — the codebase already compiles clean under the new policy.
- **Prettier config** (`efc6a3b`): 120-char width, 2-space indent, LF, double-quoted strings.

## Test plan

- [x] 112/112 tests pass under macOS clang-21 (Nix devshell) with `FERRET_WERROR=ON`
- [x] gcc-14 cross-build compiles clean with `-Werror` (test discovery on darwin is environmental, not a build issue)
- [x] `FERRET_SANITIZER=address+undefined` build compiles clean with `-Werror` on
- [ ] CI green across all 7 compiler matrix cells
- [ ] CI green across 4 sanitizer cells (ASan+UBSan and TSan × x86_64 and aarch64)
- [ ] CI green on `lint` and `nix` workflows (no behavior change expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)