### PR TITLE
fix(plot): smart tick decimation and thinner lines for dense sweeps

### DIFF
--- a/scripts/ferret_plot/formatting.py
+++ b/scripts/ferret_plot/formatting.py
@@ -2,10 +2,68 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+import math
+import numbers
+from collections.abc import Iterable, Sequence
 
 import matplotlib.ticker as mticker
 from matplotlib.axis import Axis
+
+# Soft caps on explicit ticks at the figure widths we use (figsize 8" / 4"
+# per cell). Generic data hits the lower cap once K/M/G suffixing widens
+# labels; power-of-2 data tolerates more because its labels stay short and
+# align on a clean grid the eye already expects.
+MAX_EXPLICIT_TICKS = 10
+MAX_POW2_TICKS = 16
+# Anchor on existing powers of 2 once at least this many appear in the
+# sweep. Three is enough to read as a power-of-2 grid (octave, octave) —
+# below that, striding gives a more uniform look.
+MIN_POW2_ANCHORS = 3
+_POW2_EPS = 1e-9
+
+
+def _log2_int(v: object) -> int | None:
+    """Return n if v == 2**n for non-negative integer n, else None.
+
+    Accepts any ``numbers.Real`` so numpy scalars (e.g. ``np.int64``)
+    coming straight from a DataFrame column are recognized too.
+    """
+    if isinstance(v, bool) or not isinstance(v, numbers.Real) or v <= 0:
+        return None
+    lv = math.log2(float(v))
+    rounded = round(lv)
+    if abs(lv - rounded) > _POW2_EPS or rounded < 0:
+        return None
+    return int(rounded)
+
+
+def decimate_indices(labels: Sequence[object]) -> list[int]:
+    """Pick which positions in ``labels`` to keep as ticks.
+
+    When the value set contains enough powers of 2 (covers both pure
+    pow-of-2 sweeps and dense log sweeps that interpolate between
+    octaves like 32, 35, 38, …, 64, …), tick only on those powers —
+    further strided in log2 space if there are too many. Everything
+    else falls back to fixed-stride decimation. The last index is
+    always kept so the visible extent matches the data.
+    """
+    n = len(labels)
+    if n <= MAX_EXPLICIT_TICKS:
+        return list(range(n))
+
+    pow2 = [(i, lv) for i, v in enumerate(labels) if (lv := _log2_int(v)) is not None]
+    if len(pow2) >= MIN_POW2_ANCHORS:
+        if len(pow2) > MAX_POW2_TICKS:
+            anchor, last = pow2[0][1], pow2[-1][1]
+            stride = max(1, math.ceil((last - anchor) / (MAX_POW2_TICKS - 1)))
+            pow2 = [(i, lv) for i, lv in pow2 if (lv - anchor) % stride == 0]
+        return [i for i, _ in pow2]
+
+    stride = math.ceil(n / MAX_EXPLICIT_TICKS)
+    kept = list(range(0, n, stride))
+    if kept[-1] != n - 1:
+        kept.append(n - 1)
+    return kept
 
 
 def human_readable(x, _pos: int | None = None) -> str:
@@ -37,15 +95,14 @@ def apply_axis(axis: Axis, values: Iterable[float], *, scale: str = "log") -> No
     depth=1..64). The human_readable formatter is preserved so K/M/G
     suffixing stays consistent across plot kinds.
     """
-    # axis_name is a class attribute on matplotlib's XAxis/YAxis ('x' / 'y');
-    # stable in practice across matplotlib releases.
     if scale == "log":
+        # axis_name is matplotlib's stable 'x'/'y' discriminator across
+        # XAxis/YAxis subclasses; safer than passing a separate flag.
         if axis.axis_name == "x":
             axis.axes.set_xscale("log", base=2)
         else:
             axis.axes.set_yscale("log", base=2)
-        # Callers pass df[col].unique(), which is already deduplicated; sort
-        # only — values come from pandas in first-occurrence order.
-        axis.set_ticks(sorted(values))
+        sorted_values = sorted(values)
+        axis.set_ticks([sorted_values[i] for i in decimate_indices(sorted_values)])
         axis.set_minor_formatter(mticker.NullFormatter())
     axis.set_major_formatter(mticker.FuncFormatter(human_readable))

--- a/scripts/ferret_plot/kinds/_shared.py
+++ b/scripts/ferret_plot/kinds/_shared.py
@@ -12,7 +12,7 @@ from matplotlib.image import AxesImage
 
 from ferret_plot.columns import varying_axis_columns
 from ferret_plot.errors import PlotError
-from ferret_plot.formatting import human_readable
+from ferret_plot.formatting import decimate_indices, human_readable
 from ferret_plot.registry import BenchmarkDefaults
 
 
@@ -81,10 +81,14 @@ def render_heatmap_cell(  # noqa: PLR0913
     data = np.ma.masked_invalid(pivot.values)
     im = ax.imshow(data, aspect="auto", origin="lower", norm=norm, cmap="viridis")
     im.cmap.set_bad(color="lightgrey")
-    ax.set_xticks(range(len(pivot.columns)))
-    ax.set_xticklabels([human_readable(v) for v in pivot.columns])
-    ax.set_yticks(range(len(pivot.index)))
-    ax.set_yticklabels([human_readable(v) for v in pivot.index])
+    # Decimate against the labels so power-of-2 sweeps keep ticks on actual
+    # powers of 2; positions and label strings stay in lockstep via the index.
+    x_idx = decimate_indices(list(pivot.columns))
+    ax.set_xticks(x_idx)
+    ax.set_xticklabels([human_readable(pivot.columns[i]) for i in x_idx])
+    y_idx = decimate_indices(list(pivot.index))
+    ax.set_yticks(y_idx)
+    ax.set_yticklabels([human_readable(pivot.index[i]) for i in y_idx])
     ax.set_xlabel(xcol)
     ax.set_ylabel(ycol)
     return im

--- a/scripts/ferret_plot/kinds/line.py
+++ b/scripts/ferret_plot/kinds/line.py
@@ -52,10 +52,10 @@ def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> Figure:
         for keys, sub in df.groupby(series_cols):
             label_keys = keys if isinstance(keys, tuple) else (keys,)
             label = ", ".join(f"{c}={v}" for c, v in zip(series_cols, label_keys, strict=True))
-            ax.plot(sub[xcol], sub[metric.column], marker="o", markersize=3, label=label)
+            ax.plot(sub[xcol], sub[metric.column], marker="o", markersize=2, linewidth=1.0, label=label)
         ax.legend()
     else:
-        ax.plot(df[xcol], df[metric.column], marker="o", markersize=3)
+        ax.plot(df[xcol], df[metric.column], marker="o", markersize=2, linewidth=1.0)
 
     apply_axis(ax.xaxis, df[xcol].unique(), scale=xscale)
     ax.set_xlabel(xcol)


### PR DESCRIPTION
## Summary
- Dense sweeps (e.g. 65 branches values from 32..8192 with 8 points per octave) used to set every unique value as an explicit tick on log-scale line plots and heatmap cells, smearing labels into each other.
- `decimate_indices` in `formatting.py` now picks tick positions by anchoring on whichever **powers of 2 are present in the value set** — covering both pure pow-of-2 sweeps (1, 2, 4, …) and dense log sweeps that interpolate between octaves. >16 powers ⇒ further strided in log2 space so survivors still land on real powers. Sequences without enough pow-2 anchors fall back to fixed-stride decimation capped at 10 ticks.
- Line/marker sizes drop to `markersize=2`, `linewidth=1.0` so individual points stay distinguishable.

## Example (`btb.csv`, 65 unique branches values 32..8192)
Before: 65 x-ticks, labels overlapping.
After: 9 x-ticks at exactly the powers of 2 present in the sweep — `32, 64, 128, 256, 512, 1024, 2048, 4096, 8192`.

Applies to both `line` and `heatmap` / `facets` subcommands (heatmap goes through `decimate_indices` on the pivot labels so positions and labels stay in lockstep).

## Test plan
- [x] `bash scripts/test_py.sh` — 79/79 passing
- [x] `ruff check scripts/ferret_plot` — clean
- [x] Visual smoke test: rendered `line` and `heatmap` against `btb.csv` (dense log sweep) and confirmed ticks land on powers of 2.
- [x] Existing fixtures (`dbf_df` 4×3, `dct_df` 3-point, `nced_df` 5-point linear) all render with unchanged tick layout where they previously fit under the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)