### PR TITLE
ci(dependabot): add dependency update workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Python tooling for this repo is pinned through the Nix devShell, so
+  # Dependabot only needs to manage workflow actions and flake inputs here.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      nix:
+        patterns:
+          - "*"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/nix-installer-action@v22
 
       - name: configure + lint (in devshell, pinned tool versions)
         run: |

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/nix-installer-action@v22
       - name: flake check
         run: nix flake check
       - name: build

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/nix-installer-action@v22
 
       - name: run ferret_plot pytest suite (in devshell)
         run: nix develop --command ./scripts/test_py.sh


### PR DESCRIPTION
Add Dependabot config for GitHub Actions and Nix flake updates, and pin the Nix installer action so workflow dependency bumps can be tracked.

Validation: YAML parse check passed for the new config and touched workflows.