### PR TITLE
ci: harden workflows, add CodeQL and zizmor static analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,9 @@ jobs:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: install toolchain + ninja (linux)
         if: runner.os == 'Linux'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     name: build-test (${{ matrix.cc }} on ${{ matrix.os }})
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       # Explicit include cells so we can pair compilers with OSes without

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,68 @@
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly Monday 06:00 UTC. CodeQL's rule set evolves; the cron run
+    # catches new findings even when no code changes have landed.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      # SARIF upload to the Security tab.
+      security-events: write
+      # Required by codeql-action on private repos to read workflow runs.
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { language: c-cpp,  build-mode: manual }
+          - { language: python, build-mode: none }
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install toolchain (c-cpp only)
+        if: matrix.language == 'c-cpp'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build clang-18
+
+      - name: init CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      # FERRET_WERROR=OFF so a future CodeQL-instrumented build cannot
+      # fail on a warning that the build workflow already polices on
+      # seven (compiler × OS) cells. CodeQL needs a successful build to
+      # extract its database; warning enforcement is a separate signal.
+      - name: build (c-cpp only)
+        if: matrix.language == 'c-cpp'
+        env:
+          CC: clang-18
+          CXX: clang++-18
+        run: |
+          cmake -S . -B build -GNinja -DFERRET_WERROR=OFF
+          cmake --build build
+
+      - name: analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,9 @@ jobs:
           - { language: c-cpp,  build-mode: manual }
           - { language: python, build-mode: none }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: install toolchain (c-cpp only)
         if: matrix.language == 'c-cpp'
@@ -44,7 +46,7 @@ jobs:
           sudo apt-get install -y ninja-build clang-18
 
       - name: init CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@458d36d7d4f47d0dd16ca424c1d3cda0060f1360  # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -63,6 +65,6 @@ jobs:
           cmake --build build
 
       - name: analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@458d36d7d4f47d0dd16ca424c1d3cda0060f1360  # v3
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,7 @@ jobs:
           - { language: c-cpp,  build-mode: manual }
           - { language: python, build-mode: none }
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,10 +6,18 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   format-lint:
     name: format-lint
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@v22

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,8 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25  # v22
 
       - name: configure + lint (in devshell, pinned tool versions)
         run: |

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -19,8 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25  # v22
       - name: flake check
         run: nix flake check
       - name: build

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -6,10 +6,18 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   nix:
     name: nix
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@v22

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,8 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
-      - uses: DeterminateSystems/nix-installer-action@v22
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25  # v22
 
       - name: run ferret_plot pytest suite (in devshell)
         run: nix develop --command ./scripts/test_py.sh

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,10 +6,18 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pytest:
     name: pytest
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@v22

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -24,7 +24,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: install ninja
         run: sudo apt-get update && sudo apt-get install -y ninja-build

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sanitize:
     name: sanitize (${{ matrix.sanitizer }} on ${{ matrix.os }})
@@ -15,6 +22,7 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm]
         sanitizer: [address+undefined, thread]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,37 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly Monday 06:00 UTC. zizmor's rule set evolves; cron catches
+    # new findings even when no workflow changes have landed.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # SARIF upload to the Security tab.
+      security-events: write
+      # Required by zizmor-action for online audits (impostor-commit,
+      # known-vulnerable-actions). Token is GITHUB_TOKEN, scoped read.
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d  # v0.5.6

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -30,7 +30,7 @@ jobs:
       actions: read
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

Audit-driven CI hardening across all GitHub Actions workflows. Four
self-contained commits, no production code or build behavior changes.

- **Workflow hygiene** — workflow-level `permissions: contents: read`
  (least-privilege `GITHUB_TOKEN`), `concurrency:` groups so a fresh
  push to a PR cancels the in-flight run, and per-job `timeout-minutes`
  so a hung step caps at a sane bound instead of GitHub's 6-hour
  default.
- **SHA-pinned actions** — every `uses:` reference now points at a
  40-char commit SHA with the resolved semver as a trailing comment.
  Removes the risk that a compromised upstream tag silently lands in
  CI. Dependabot's existing `github-actions` ecosystem manages SHA
  pins in this format with no extra config.
- **`persist-credentials: false`** on every `actions/checkout` — none
  of these workflows `git push`, so writing `GITHUB_TOKEN` into
  `.git/config` was latent attack surface.
- **CodeQL** — new `codeql.yml` running c-cpp + python static analysis
  on push, PR, and a weekly Monday cron. c-cpp uses `build-mode:
  manual` with clang-18 + ninja matching `build.yml`'s clang-18 cell;
  `FERRET_WERROR=OFF` so the analysis build cannot fail on a warning
  that the seven-cell build matrix already polices.
- **zizmor** — new `zizmor.yml` running the eponymous workflow static
  analyzer (template injection, dangerous triggers, impostor commits,
  cache poisoning, etc. — categories that actionlint does not cover).
  SARIF lands on the Security tab via the action's built-in upload.

## Verification

Local pre-push checks:

- `actionlint 1.7.9` on all 7 workflows -> clean
- `zizmor 1.19.0 --offline` on all 7 workflows -> 0 findings, 5
  pedantic suppressed

## Test plan

- [ ] CI matrix (build, lint, nix, python, sanitizers) still green on
  this PR
- [ ] New `codeql` job completes and uploads SARIF
- [ ] New `zizmor` job completes and reports 0 findings
- [ ] Push two commits in quick succession; verify the first run is
  cancelled by the `concurrency:` group
- [ ] Confirm Security tab receives both CodeQL and zizmor SARIF
- [ ] Next Dependabot run proposes SHA-pin updates rather than tag
  bumps (sanity check on the pin format)

Generated with [Claude Code](https://claude.com/claude-code)