### PR TITLE
build(python): add pip requirements for non-Nix users

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -29,6 +29,16 @@ cmake --build build
 ctest --test-dir build --output-on-failure
 ```
 
+Scripts under `scripts/` need matplotlib, numpy, and pandas (plus
+pytest and ruff for tests). Nix users get these via `flake.nix`;
+otherwise:
+
+```sh
+python3 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt      # runtime
+pip install -r requirements-dev.txt  # + pytest, ruff
+```
+
 ## Sanitizer builds
 
 Off by default — timing-sensitive runs use clean code. Enable via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Test + lint deps — Nix users: see flake.nix.
+-r requirements.txt
+pytest
+ruff>=0.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Runtime deps for scripts/ — Nix users: see flake.nix.
+matplotlib
+numpy
+pandas


### PR DESCRIPTION
## Summary
- The flake provides matplotlib/numpy/pandas/pytest/ruff to Nix users, but there was no parallel path for pip users.
- Add `requirements.txt` (runtime: matplotlib, numpy, pandas) and `requirements-dev.txt` (adds pytest + ruff>=0.14).
- Document the venv + `pip install -r ...` recipe in `docs/build.md` under "Plain CMake".

## Test plan
- [x] `scripts/test_py.sh` passes under `nix develop` (79/79).
- [x] `ruff format --check` and `ruff check` clean.
- [ ] On a non-Nix host: `python3 -m venv .venv && pip install -r requirements-dev.txt && bash scripts/test_py.sh` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)