### PR TITLE
plot: reject empty facet axes

### DIFF
--- a/scripts/ferret_plot/kinds/facets.py
+++ b/scripts/ferret_plot/kinds/facets.py
@@ -37,9 +37,13 @@ def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> Figure:
         raise PlotError(f"--y={args.y!r} is the same as --facet; pick a different axis")
     xcol, ycol = resolve_heatmap_xy(df, args, defaults, exclude=frozenset({facet}))
 
-    facet_values = sorted(df[facet].dropna().unique().tolist())
+    facet_values = df[facet].dropna().unique().tolist()
     if not facet_values:
         raise PlotError(f"--facet={facet!r} has no non-NaN values to plot")
+    try:
+        facet_values = sorted(facet_values)
+    except TypeError:
+        facet_values = sorted(facet_values, key=str)
     n = len(facet_values)
     ncols = max(1, math.ceil(math.sqrt(n)))
     nrows = math.ceil(n / ncols)

--- a/scripts/ferret_plot/kinds/facets.py
+++ b/scripts/ferret_plot/kinds/facets.py
@@ -38,6 +38,8 @@ def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> Figure:
     xcol, ycol = resolve_heatmap_xy(df, args, defaults, exclude=frozenset({facet}))
 
     facet_values = sorted(df[facet].dropna().unique().tolist())
+    if not facet_values:
+        raise PlotError(f"--facet={facet!r} has no non-NaN values to plot")
     n = len(facet_values)
     ncols = max(1, math.ceil(math.sqrt(n)))
     nrows = math.ceil(n / ncols)

--- a/tests/python/test_facets.py
+++ b/tests/python/test_facets.py
@@ -46,6 +46,12 @@ class TestFacetsMakeFigure:
         with pytest.raises(PlotError, match="--facet"):
             facets_kind.make_figure(df, _args(facet=None))
 
+    def test_facet_with_only_nan_values_raises_plot_error(self):
+        df = three_axis_df()
+        df["variant"] = None
+        with pytest.raises(PlotError, match="no non-NaN values"):
+            facets_kind.make_figure(df, _args(facet="variant"))
+
     def test_two_axis_csv_raises(self):
         df = dbf_df()
         with pytest.raises(PlotError, match="at least 2 varying axis columns"):

--- a/tests/python/test_facets.py
+++ b/tests/python/test_facets.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pandas as pd
 import pytest
 from conftest import make_args
 from ferret_plot.errors import PlotError
@@ -51,6 +52,34 @@ class TestFacetsMakeFigure:
         df["variant"] = None
         with pytest.raises(PlotError, match="no non-NaN values"):
             facets_kind.make_figure(df, _args(facet="variant"))
+
+    def test_mixed_type_facet_values_do_not_crash_sorting(self):
+        variants = (1, "a")
+        rows = []
+        for branch in (1, 2):
+            for spacing in (16, 32):
+                for variant in variants:
+                    rows.append(
+                        {
+                            "benchmark": "synthetic_three_axis",
+                            "branches": branch,
+                            "spacing_bytes": spacing,
+                            "variant": variant,
+                            "ticks_min": 1000,
+                            "ticks_median": 1000,
+                            "iters": 1,
+                            "sites_per_iter": branch,
+                            "reps": 7,
+                            "ns_per_site_min": 0.5 + branch * 0.01 + spacing * 0.001 + (0.1 if variant == "a" else 0.0),
+                            "ns_per_site_median": 0.5
+                            + branch * 0.01
+                            + spacing * 0.001
+                            + (0.1 if variant == "a" else 0.0),
+                        }
+                    )
+        df = pd.DataFrame(rows)
+        fig = facets_kind.make_figure(df, _args(facet="variant"))
+        assert len(_heatmap_axes(fig)) == len(variants)
 
     def test_two_axis_csv_raises(self):
         df = dbf_df()


### PR DESCRIPTION
## Summary
- Reject facet plots when the selected facet column has no non-NaN values instead of reaching an invalid subplot layout
- Keep facet value ordering robust for mixed-type facet columns by falling back to string ordering when native sorting is not supported
- Add regression coverage for both empty and mixed-type facet inputs

## Verification
- nix develop -c python3 -m pytest tests/python
- nix develop -c ./scripts/lint.sh
- nix develop -c cmake --build build-lint
- nix develop -c ctest --test-dir build-lint --output-on-failure