### PR TITLE
ci(dependabot): add 7-day cooldown to dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "deps"
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:
@@ -21,6 +23,8 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "deps"
+    cooldown:
+      default-days: 7
     groups:
       nix:
         patterns:


### PR DESCRIPTION
## Summary
- Adds `cooldown: { default-days: 7 }` to both `github-actions` and `nix` updaters in `.github/dependabot.yml`
- Resolves [code scanning alert #2](https://github.com/eastonman/ferret/security/code-scanning/2) (`zizmor/dependabot-cooldown`)
- Defers PRs for newly released versions by 7 days, mitigating supply-chain risk from compromised fresh releases

## Test plan
- [x] `uvx zizmor@1.25.2 .github/dependabot.yml` — `No findings to report`
- [x] `uvx zizmor@1.25.2 .` (whole repo) — `No findings to report (5 suppressed)`
- [ ] Confirm CI zizmor workflow passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)