### PR TITLE
tooling polish: sljit pin via flake.lock, macOS sanitizers, explicit numpy

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -19,8 +19,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
         sanitizer: [address+undefined, thread]
+        exclude:
+          # TSan on macOS arm64 (Apple clang) is patchy across Xcode
+          # versions; ASan+UBSan already covers the leak/UB regressions
+          # we care about on Apple Silicon. Revisit if TSan becomes a
+          # first-class need on this platform.
+          - { os: macos-latest, sanitizer: thread }
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     steps:
@@ -28,8 +34,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: install ninja
+      - name: install ninja (linux)
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y ninja-build
+
+      - name: install ninja (macos)
+        if: runner.os == 'macOS'
+        run: brew install ninja
 
       - name: configure
         run: >

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -53,12 +53,14 @@ jobs:
 
       # halt_on_error=1 + exitcode=1 make any sanitizer finding fail CI
       # rather than print-and-continue. print_stacktrace=1 gives a
-      # symbolized trace at the failure site. detect_leaks=1 is the LSan
-      # default under ASan on Linux but is set explicitly so the intent
-      # is visible.
+      # symbolized trace at the failure site. Leak detection: on Linux,
+      # LSan is enabled by default under ASan, so it runs without being
+      # named here; on macOS, ASan is not bundled with LSan and naming
+      # detect_leaks at all aborts startup ("detect_leaks is not
+      # supported on this platform"), so we deliberately do not set it.
       - name: test
         env:
-          ASAN_OPTIONS: halt_on_error=1:abort_on_error=0:exitcode=1:detect_leaks=1:print_stacktrace=1
+          ASAN_OPTIONS: halt_on_error=1:abort_on_error=0:exitcode=1:print_stacktrace=1
           UBSAN_OPTIONS: halt_on_error=1:exitcode=1:print_stacktrace=1
           TSAN_OPTIONS: halt_on_error=1:exitcode=1:second_deadlock_stack=1
         run: ctest --test-dir build --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,13 +112,19 @@ if(SLJIT_INCLUDE_DIR AND SLJIT_LIBRARY)
   )
 else()
   include(FetchContent)
+  # Pin to the same sljit revision as the Nix flake input so Nix-built
+  # ferret and FetchContent-fallback ferret link against identical
+  # sources. flake.lock is the single source of truth; Dependabot bumps
+  # it weekly.
+  file(READ "${CMAKE_SOURCE_DIR}/flake.lock" _ferret_flake_lock)
+  string(JSON _ferret_sljit_rev GET "${_ferret_flake_lock}" nodes sljit-src locked rev)
   # SOURCE_SUBDIR set to a non-existent directory so MakeAvailable
   # populates the source tree without calling add_subdirectory —
   # sljit's own CMakeLists builds a test exe with Windows-only link
   # flags (-Wl,--stack,...) that break Linux/macOS builds.
   FetchContent_Declare(sljit_fetched
     GIT_REPOSITORY https://github.com/zherczeg/sljit.git
-    GIT_TAG d9902b1ba06f477dcb89137dae8c8649fb58b7fb
+    GIT_TAG ${_ferret_sljit_rev}
     SOURCE_SUBDIR  do_not_use_upstream_cmake
   )
   FetchContent_MakeAvailable(sljit_fetched)

--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,7 @@
               ps:
                 with ps; [
                   matplotlib
+                  numpy
                   pandas
                   pytest
                 ]


### PR DESCRIPTION
## Summary

Three small, independent tooling/CI/env fixes surfaced by a review of the recent work.

- **build(cmake)**: the FetchContent fallback hard-coded the sljit commit SHA, duplicating the one in the Nix flake input. Dependabot bumps the flake weekly, so the two could silently drift. Now `CMakeLists.txt` reads `nodes.sljit-src.locked.rev` from `flake.lock` via `string(JSON ...)` — `flake.lock` is the single source of truth.
- **ci(sanitizers)**: matrix only covered Linux x86_64 and Linux aarch64. macOS arm64 is a supported tier per the README and Apple clang has ASan+UBSan, so add a `macos-latest` cell. Skip TSan on macOS — Apple-clang TSan on arm64 is uneven across Xcode versions; ASan+UBSan covers the regressions we care about there.
- **nix(devshell)**: `scripts/ferret_plot/kinds/{facets,_shared}.py` and `tests/python/test_columns.py` import numpy directly. The devshell only had it transitively via matplotlib/pandas; align with `requirements.txt` and declare numpy explicitly so a future nixpkgs roll can't quietly break python tests.

## Test plan

- [x] `cmake -P` snippet verified `string(JSON ...)` extracts `d9902b1ba06f477dcb89137dae8c8649fb58b7fb` from `flake.lock` (same SHA the file previously hard-coded)
- [x] Local `cmake --build` + `ctest` → 178/178 passing on the branch
- [ ] CI sanitizers workflow runs cleanly on the new `macos-latest × address+undefined` cell
- [ ] CI build matrix unchanged (no sljit drift, no behavior change for non-Nix builders)
- [ ] CI python workflow unchanged (numpy was already transitively present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)