### PR TITLE
feat(bias_conditional_branch_count): SC bias-table capacity probe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,10 +192,11 @@ target_compile_features(ferret_core PUBLIC cxx_std_20)
 
 add_executable(ferret
   src/main.cpp
+  benchmarks/bias_conditional_branch_count.cpp
+  benchmarks/branch_history_footprint.cpp
   benchmarks/dependent_chain_throughput.cpp
   benchmarks/direct_branch_footprint.cpp
   benchmarks/nested_call_depth.cpp
-  benchmarks/branch_history_footprint.cpp
 )
 target_link_libraries(ferret PRIVATE
   ferret_core

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ CLI flags and axis syntax: [`docs/cli.md`](docs/cli.md).
 | [`direct_branch_footprint`](docs/benchmarks/direct_branch_footprint.md)          | direct-jump BTB capacity                 |
 | [`nested_call_depth`](docs/benchmarks/nested_call_depth.md)                      | Return Address Stack (RAS) depth         |
 | [`branch_history_footprint`](docs/benchmarks/branch_history_footprint.md)        | conditional-branch direction-predictor capacity |
+| [`bias_conditional_branch_count`](docs/benchmarks/bias_conditional_branch_count.md) | SC bias-table capacity (TAGE-SC-L)    |
 
 Each benchmark page has the kernel structure, CLI surface, and reading-the-curves guide.
 

--- a/benchmarks/bias_conditional_branch_count.cpp
+++ b/benchmarks/bias_conditional_branch_count.cpp
@@ -1,0 +1,251 @@
+extern "C" {
+#include <sljitLir.h>
+}
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "ferret/bench_helpers.hpp"
+#include "ferret/benchmark.hpp"
+#include "ferret/padding.hpp"
+#include "ferret/permute.hpp"
+
+namespace ferret {
+
+struct BiasConditionalBranchCount;
+
+namespace {
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+constexpr size_t kMinSiteBytes = 8;
+#elif defined(__x86_64__) || defined(_M_X64)
+constexpr size_t kMinSiteBytes = 6;
+#else
+#error "ferret v1 supports only x86_64 and aarch64"
+#endif
+
+// Extra mix constants layered onto mix_seed() so direction assignment
+// depends on (seed, branches, nt_branch_pct) only, and outcome fill
+// adds (pattern_period, bias_pct). Two independent streams keep the
+// per-branch direction set stable across `total_outcomes` sweeps at a
+// fixed (branches, nt_branch_pct, seed) — load-bearing for the
+// experimental design (spec §7.3).
+constexpr uint64_t kNtPctMix   = 0xD6E8FEB86659FD93ULL;
+constexpr uint64_t kBiasPctMix = 0x94D049BB133111EBULL;
+
+}  // namespace
+
+namespace bias_conditional_branch_count_internal {
+
+std::vector<uint8_t> assign_directions(size_t branches, int64_t nt_branch_pct, uint64_t seed) {
+  std::vector<uint8_t> dirs(branches, 0U);
+  if (branches == 0) {
+    return dirs;
+  }
+  size_t nt_count = static_cast<size_t>(static_cast<int64_t>(branches) * nt_branch_pct / 100);
+  if (nt_count == 0) {
+    return dirs;
+  }
+  if (nt_count >= branches) {
+    std::fill(dirs.begin(), dirs.end(), uint8_t{1});
+    return dirs;
+  }
+  std::vector<size_t> idxs(branches);
+  for (size_t i = 0; i < branches; ++i) {
+    idxs[i] = i;
+  }
+  uint64_t mixed = mix_seed(seed, branches, static_cast<uint64_t>(nt_branch_pct)) ^ kNtPctMix;
+  std::mt19937_64 rng(mixed);
+  for (size_t i = 0; i < nt_count; ++i) {
+    std::uniform_int_distribution<size_t> dist(i, branches - 1);
+    size_t j = dist(rng);
+    std::swap(idxs[i], idxs[j]);
+    dirs[idxs[i]] = 1U;
+  }
+  return dirs;
+}
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+std::vector<uint32_t> generate_pattern_fill(size_t branches, size_t pattern_period, int64_t bias_pct,
+                                             int64_t nt_branch_pct, uint64_t seed) {
+  std::vector<uint32_t> flat(branches * pattern_period, 0U);
+  if (branches == 0 || pattern_period == 0) {
+    return flat;
+  }
+  auto dirs = assign_directions(branches, nt_branch_pct, seed);
+
+  uint64_t dir_mix = mix_seed(seed, branches, static_cast<uint64_t>(nt_branch_pct)) ^ kNtPctMix;
+  uint64_t fill_mix = mix_seed(dir_mix, pattern_period, static_cast<uint64_t>(bias_pct)) ^ kBiasPctMix;
+  std::mt19937_64 rng(fill_mix);
+
+  // Q14 fixed-point Bernoulli draw. r ∈ [0, 0x3fff]; the branch is
+  // taken iff r < prob_taken_q14. At bias_pct=100, prob_taken_q14 =
+  // 16384 so r < 16384 is always true → always taken. At bias_pct=0,
+  // prob_taken_q14 = 0 → never taken.
+  auto prob_taken_q14 = [&](bool nt_preferred) -> uint32_t {
+    int64_t pct = nt_preferred ? (100 - bias_pct) : bias_pct;
+    return static_cast<uint32_t>(pct * 16384 / 100);
+  };
+
+  for (size_t t = 0; t < pattern_period; ++t) {
+    for (size_t j = 0; j < branches; ++j) {
+      uint32_t r = static_cast<uint32_t>(rng() & 0x3fffU);
+      flat[t * branches + j] = (r < prob_taken_q14(dirs[j] != 0U)) ? 1U : 0U;
+    }
+  }
+  return flat;
+}
+
+struct LayoutSnapshot {
+  std::vector<sljit_label*> labels;
+  size_t branches;
+  size_t spacing;
+};
+
+namespace {
+const BiasConditionalBranchCount* g_last_emitted = nullptr;
+}  // namespace
+
+LayoutSnapshot last_layout_snapshot();
+
+}  // namespace bias_conditional_branch_count_internal
+
+struct BiasConditionalBranchCount : Benchmark {
+  std::vector<uint32_t> flat_;
+  std::vector<sljit_label*> last_labels_;
+  size_t last_branches_ = 0;
+  size_t last_spacing_ = 0;
+
+  [[nodiscard]] std::string name() const override { return "bias_conditional_branch_count"; }
+
+  [[nodiscard]] SweepAxes axes() const override {
+    return {
+        Axis::geom_range("branches", 1, 1 << 13, /*samples_per_octave=*/1),
+        Axis::geom_range("total_outcomes", 1 << 13, 1 << 20, /*samples_per_octave=*/1),
+    };
+  }
+
+  [[nodiscard]] BenchOptions options() const override {
+    return {
+        BenchOption{.name = "bias_pct", .default_value = 95},
+        BenchOption{.name = "nt_branch_pct", .default_value = 50},
+        BenchOption{.name = "spacing_bytes", .default_value = 16},
+    };
+  }
+
+  [[nodiscard]] size_t sites_per_kernel(const Params& p) const override { return p.get<size_t>("branches"); }
+
+  [[nodiscard]] size_t iterations(const Params& p) const override {
+    return compute_iterations(10'000'000, p.get<size_t>("branches"));
+  }
+
+  void emit_kernel(sljit_compiler* c, const Params& p) override;
+  void verify_layout(sljit_compiler* c) override;
+};
+
+void BiasConditionalBranchCount::emit_kernel(sljit_compiler* c, const Params& p) {
+  auto branches = p.get<size_t>("branches");
+  auto total_outcomes = p.get<size_t>("total_outcomes");
+  auto bias_pct = p.get<int64_t>("bias_pct");
+  auto nt_branch_pct = p.get<int64_t>("nt_branch_pct");
+  auto spacing = p.get<size_t>("spacing_bytes");
+  auto seed = static_cast<uint64_t>(p.get<int64_t>("seed"));
+
+  if (branches < 1) {
+    throw std::invalid_argument("branches must be >= 1");
+  }
+  if (total_outcomes < 1) {
+    throw std::invalid_argument("total_outcomes must be >= 1");
+  }
+  if (total_outcomes < branches) {
+    throw std::invalid_argument("total_outcomes (" + std::to_string(total_outcomes) +
+                                ") must be >= branches (" + std::to_string(branches) +
+                                ") so pattern_period >= 1");
+  }
+  if (bias_pct < 0 || bias_pct > 100) {
+    throw std::invalid_argument("bias_pct must be in [0, 100]; got " + std::to_string(bias_pct));
+  }
+  if (nt_branch_pct < 0 || nt_branch_pct > 100) {
+    throw std::invalid_argument("nt_branch_pct must be in [0, 100]; got " + std::to_string(nt_branch_pct));
+  }
+  if (spacing < kMinSiteBytes) {
+    throw std::invalid_argument("spacing_bytes=" + std::to_string(spacing) +
+                                " is smaller than the minimum site encoding (" + std::to_string(kMinSiteBytes) +
+                                " bytes) on this architecture");
+  }
+
+  size_t pattern_period = total_outcomes / branches;
+  size_t iters = iterations(p);
+
+  flat_ = bias_conditional_branch_count_internal::generate_pattern_fill(branches, pattern_period, bias_pct,
+                                                                          nt_branch_pct, seed);
+
+  // sljit prologue: 3 scratches + 2 saveds.
+  // SLJIT_S0 = flat_base, SLJIT_S1 = hist_idx, SLJIT_R0 = iter counter.
+  // SLJIT_R1 = row_ptr (recomputed per outer iter), SLJIT_R2 = loaded value.
+  sljit_emit_enter(c, 0, SLJIT_ARGS0V(), /*scratches=*/3, /*saved=*/2, /*local_size=*/0);
+  sljit_emit_op1(c, SLJIT_MOV, SLJIT_S0, 0, SLJIT_IMM, reinterpret_cast<sljit_sw>(flat_.data()));
+  sljit_emit_op1(c, SLJIT_MOV, SLJIT_S1, 0, SLJIT_IMM, 0);
+
+  emit_outer_loop(c, SLJIT_R0, iters, [&] {
+    // row_ptr = flat_base + hist_idx * (branches * 4)
+    sljit_emit_op2(c, SLJIT_MUL, SLJIT_R1, 0, SLJIT_S1, 0, SLJIT_IMM, static_cast<sljit_sw>(branches * 4));
+    sljit_emit_op2(c, SLJIT_ADD, SLJIT_R1, 0, SLJIT_R1, 0, SLJIT_S0, 0);
+
+    last_labels_.clear();
+    last_labels_.reserve(branches + 1);
+
+    for (size_t j = 0; j < branches; ++j) {
+      last_labels_.push_back(sljit_emit_label(c));
+      sljit_emit_op1(c, SLJIT_MOV_U32, SLJIT_R2, 0, SLJIT_MEM1(SLJIT_R1), static_cast<sljit_sw>(j * 4));
+      sljit_jump* jmp = sljit_emit_cmp(c, SLJIT_NOT_EQUAL | SLJIT_32, SLJIT_R2, 0, SLJIT_IMM, 0);
+      sljit_label* after = sljit_emit_label(c);
+      sljit_set_label(jmp, after);
+      emit_nops(c, spacing - kMinSiteBytes);
+    }
+    last_labels_.push_back(sljit_emit_label(c));
+
+    // hist_idx wrap.
+    sljit_emit_op2(c, SLJIT_ADD, SLJIT_S1, 0, SLJIT_S1, 0, SLJIT_IMM, 1);
+    sljit_emit_op2u(c, SLJIT_SUB | SLJIT_SET_Z, SLJIT_S1, 0, SLJIT_IMM, static_cast<sljit_sw>(pattern_period));
+    sljit_jump* skip_reset = sljit_emit_jump(c, SLJIT_NOT_ZERO);
+    sljit_emit_op1(c, SLJIT_MOV, SLJIT_S1, 0, SLJIT_IMM, 0);
+    sljit_label* after_wrap = sljit_emit_label(c);
+    sljit_set_label(skip_reset, after_wrap);
+  });
+
+  sljit_emit_return_void(c);
+
+  last_branches_ = branches;
+  last_spacing_ = spacing;
+  bias_conditional_branch_count_internal::g_last_emitted = this;
+}
+
+void BiasConditionalBranchCount::verify_layout(sljit_compiler* /*c*/) {
+  if (last_branches_ == 0 || last_labels_.empty()) {
+    return;
+  }
+  verify_uniform_spacing(last_labels_, last_spacing_, /*strict=*/false, "bias_conditional_branch_count");
+}
+
+namespace bias_conditional_branch_count_internal {
+
+LayoutSnapshot last_layout_snapshot() {
+  if (g_last_emitted == nullptr) {
+    return {};
+  }
+  return {.labels = g_last_emitted->last_labels_,
+          .branches = g_last_emitted->last_branches_,
+          .spacing = g_last_emitted->last_spacing_};
+}
+
+}  // namespace bias_conditional_branch_count_internal
+
+FERRET_BENCHMARK("bias_conditional_branch_count", BiasConditionalBranchCount);
+
+}  // namespace ferret

--- a/docs/benchmarks/bias_conditional_branch_count.md
+++ b/docs/benchmarks/bias_conditional_branch_count.md
@@ -1,0 +1,132 @@
+# `bias_conditional_branch_count` — SC bias-table capacity probe
+
+`N` data-dependent conditional branches, half biased toward taken
+(Bernoulli(p)) and half toward not-taken (Bernoulli(1-p)), each driven
+by a long aperiodic outcome stream of total length `total_outcomes`
+shared across all branches. Pattern period per branch =
+`total_outcomes / branches`.
+
+The benchmark is designed to expose the **SC (Statistical Corrector)
+bias-table capacity** in TAGE-SC-L–style direction predictors by
+holding tagged-table pressure roughly constant (set by
+`total_outcomes`) while varying the number of distinct PCs (set by
+`branches`). Mixed-direction biases produce destructive aliasing in
+the SC bias table once `branches` exceeds the bias-table's effective
+entry count.
+
+## Kernel structure
+
+Identical to `branch_history_footprint`: one outer loop, `N` sites
+each loading a `uint32_t` outcome from the per-row buffer, comparing
+against zero, and branching to the immediately-following instruction.
+Architecturally a no-op; only the direction predictor is exercised.
+
+```
+   PC                  site (>= spacing_bytes apart)
+ 0x0000   ┌──────────────────────────────────────┐
+          │  MOV  r2, [row_ptr + 0]              │
+          │  CMP  r2, 0                          │
+          │  JNE  .Lnext_0                       │ ──┐
+          │ .Lnext_0:                            │ ◄─┘
+          │  <NOP pad>                           │
+ base+1×spacing+  ┌─────────────────────────────┐
+          │  MOV  r2, [row_ptr + 4]              │
+          │  CMP  r2, 0                          │
+          │  JNE  .Lnext_1                       │ ──┐
+          │ .Lnext_1:                            │ ◄─┘
+          │  <NOP pad>                           │
+ base+2×spacing+  ┌─────────────────────────────┐
+          │   ...                                │
+          ├──────────────────────────────────────┤
+          │  ADD  hist_idx, hist_idx, 1          │
+          │  CMP  hist_idx, pattern_period       │
+          │  SUBS iters, iters, 1; B.NE loop_top │
+          └──────────────────────────────────────┘
+```
+
+- The pattern buffer is `flat[pattern_period][branches]` (transposed).
+- Each of the `branches` PCs is assigned a *preferred* direction (T or
+  NT). At default `nt_branch_pct=50`, half prefer each.
+- Outcomes are i.i.d. Bernoulli(`bias_pct/100`) toward the branch's
+  preferred direction. Direction assignment is seed-deterministic and
+  stable across `total_outcomes` values for a given `(branches,
+  nt_branch_pct, seed)`.
+
+## Per-benchmark options
+
+| flag                   | meaning                                                  |
+| ---------------------- | -------------------------------------------------------- |
+| `--bias_pct=95`        | Per-branch bias magnitude (0..100). Default 95.          |
+| `--nt_branch_pct=50`   | Percent of branches assigned NT-preferred. Default 50.   |
+| `--spacing_bytes=16`   | Minimum PC stride per site (min 8 AArch64 / 6 x86_64).   |
+
+## CLI surface
+
+| flag                       | meaning                                                   |
+| -------------------------- | --------------------------------------------------------- |
+| `--branches=A..B[@k]`      | Geometric sweep, default `1..8192`.                       |
+| `--total_outcomes=A..B[@k]`| Geometric sweep, default `8192..1048576`.                 |
+| `--bias_pct=N`             | See above. Default 95.                                    |
+| `--nt_branch_pct=N`        | See above. Default 50.                                    |
+| `--spacing_bytes=N`        | Default 16.                                               |
+| `--seed=…`                 | Seeds direction assignment + outcome fill.                |
+
+`total_outcomes` must be `>= branches` for every Cartesian point
+(`pattern_period >= 1`). Widen one and you may need to widen the
+other.
+
+See [`../cli.md`](../cli.md) for global flags.
+
+## Reading the curves
+
+Plot a surface with `branches` on one axis and `total_outcomes` on
+the other:
+
+```sh
+python3 scripts/plot.py surface /tmp/sc.csv --out=/tmp/sc.png
+```
+
+Expected shape: an **L-shaped high-cycles region** in the upper-right
+corner of the plane.
+
+- **Lower-left plateau:** flat at the predictor-saturated floor.
+  Tagged tables memorize the short pattern (low `total_outcomes`) or
+  SC bias has room for every PC (low `branches`).
+- **Cliff along `branches`:** vertical wall — the SC bias-table
+  capacity. Below: SC corrects; above: destructive aliasing in SC
+  slots pulls saturated counters toward zero and mispredict rate
+  climbs.
+- **Cliff along `total_outcomes`:** horizontal wall — the tagged-table
+  effective memorization threshold. Below: tagged tables learn the
+  cyclic pattern; above: they churn perpetually.
+- **Upper-right plateau:** both predictors fail; cycles/site at the
+  high-mispredict ceiling.
+
+The SC fingerprint: the **vertical cliff position is invariant to
+`total_outcomes`** (above the tagged-table threshold). If the cliff
+slides diagonally with `total_outcomes`, the cliff is tagged-table-
+pressure-dominated and the SC reading is confounded on this CPU.
+
+## Caveats
+
+- **Per-row L1d footprint at high `branches`.** With `uint32_t`
+  outcomes, the per-row footprint is `branches * 4` bytes. At
+  `branches = 8192` that's 32 KB — at or just past the L1d ceiling
+  on most current cores. Cycles/site beyond that point may combine
+  the SC-bias cliff with L1d-miss effects.
+- **T0 may produce a small secondary cliff.** TAGE's base bimodal
+  table is also PC-indexed; when `branches` exceeds T0 capacity, T0
+  also aliases. SC bias normally corrects this, so the dominant
+  cliff is SC's.
+- **Other SC sub-components (GHIST/PATH/IMLI)** may partially correct
+  what BIAS cannot. The aperiodic / history-independent design
+  minimizes their contribution.
+- **Outer-loop tax at `branches=1`.** Read the leftmost column as a
+  tax baseline. Same caveat as `branch_history_footprint`.
+- **Apple Silicon pinning.** See project README discipline section.
+
+## Related docs
+
+- Construction rationale: [design spec](../superpowers/specs/2026-05-20-bias-conditional-branch-count-design.md).
+- Sister benchmark: [`branch_history_footprint`](branch_history_footprint.md) — direction-predictor capacity, generic.
+- Project two-step workflow: [project README](../../README.md).

--- a/docs/superpowers/plans/2026-05-20-bias-conditional-branch-count.md
+++ b/docs/superpowers/plans/2026-05-20-bias-conditional-branch-count.md
@@ -1,0 +1,1452 @@
+# bias_conditional_branch_count Implementation Plan
+
+> **Post-rebase note (2026-05-20):** This plan was authored against the
+> pre-`bench_helpers` codebase and proposed a dedicated
+> `branch_chain_emit` module. After rebasing onto `origin/main` (which
+> landed `include/ferret/bench_helpers.hpp` and refactored every
+> existing benchmark to use it), the actual implementation drops the
+> proposed module and follows the upstream pattern instead:
+> `emit_outer_loop` + `compute_iterations` + `verify_uniform_spacing`
+> + `mix_seed`, with the per-site chain inlined in the benchmark file
+> the same way `branch_history_footprint` does. Task 1 (the
+> `branch_chain_emit` extraction) becomes a no-op. Tasks 2–7 still
+> describe the right *shape* of work, but the file paths and shared
+> helper names reference upstream `bench_helpers` instead of the
+> proposed module.
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add ferret's fifth benchmark, `bias_conditional_branch_count`, which sweeps `(branches, total_outcomes)` and emits mixed-direction biased conditional branches whose long aperiodic outcome patterns expose the **SC bias-table capacity** in TAGE-SC-L–style direction predictors.
+
+**Architecture:** The branch-chain sljit emitter currently inlined in `benchmarks/branch_history_footprint.cpp` is extracted into a shared helper (`include/ferret/branch_chain_emit.hpp` + `src/branch_chain_emit.cpp`) consumed by both `branch_history_footprint` and the new `bias_conditional_branch_count`. The new benchmark differs only in its pattern-fill routine (per-branch direction assignment + Bernoulli(`bias_pct`) outcomes) and its axes/options. Per-bench options: `bias_pct` (default 95), `nt_branch_pct` (default 50), `spacing_bytes` (default 16). Total buffer size is bounded by `total_outcomes` (≤ 4 MB at default-axis max).
+
+**Tech Stack:** C++20, sljit (JIT IR), GoogleTest, CMake. Uses the existing per-site instruction sequences (`SLJIT_MOV_U32 + SLJIT_NOT_EQUAL` cmp-jump on both arches, via sljit high-level ops — same as `branch_history_footprint`).
+
+**Spec:** [`docs/superpowers/specs/2026-05-20-bias-conditional-branch-count-design.md`](../specs/2026-05-20-bias-conditional-branch-count-design.md)
+
+**Worktree:** Work happens in the existing checkout at `/Users/easton/WorkingSpace/project/ferret/feat/sc-bias-table` on branch `sc-bias-table` — no new worktree.
+
+---
+
+## File Map
+
+| Path | Action | Responsibility |
+| ---- | ------ | -------------- |
+| `include/ferret/branch_chain_emit.hpp` | Create | Public declaration of the shared branch-chain emitter (config + result structs, `emit_branch_chain`, `verify_branch_chain_layout`, `branch_chain_min_site_bytes`) |
+| `src/branch_chain_emit.cpp` | Create | Implementation of the shared emitter (moved verbatim from `branch_history_footprint.cpp::emit_kernel` + `verify_layout`) |
+| `benchmarks/branch_history_footprint.cpp` | Modify | Drop the inlined emitter; call shared helper; keep the pattern-fill (`generate_pattern_fill`) and the per-instance state |
+| `benchmarks/bias_conditional_branch_count.cpp` | Create | New benchmark: axes (`branches`, `total_outcomes`), options (`bias_pct`, `nt_branch_pct`, `spacing_bytes`), direction-assignment + outcome-fill routines, `emit_kernel` calling shared helper |
+| `tests/test_bias_conditional_branch_count.cpp` | Create | Unit tests for axes/options/validation/direction-assignment/outcome-distribution/layout |
+| `tests/test_branch_history_footprint.cpp` | Verify | Existing tests must still pass after the emitter extraction (lock-in regression guard) |
+| `tests/test_integration.cpp` | Modify | Append `Integration.BiasConditionalBranchCount*` smoke tests |
+| `CMakeLists.txt` | Modify | Add `src/branch_chain_emit.cpp` to `ferret_core` source list and `benchmarks/bias_conditional_branch_count.cpp` to the `ferret` executable source list |
+| `tests/CMakeLists.txt` | Modify | Add `test_bias_conditional_branch_count` target |
+| `docs/benchmarks/bias_conditional_branch_count.md` | Create | Per-benchmark doc page (kernel structure, options, reading the surface) |
+| `README.md` | Modify | Add row to the benchmarks table |
+
+---
+
+## Pre-flight (do once before Task 1)
+
+- [ ] **Verify branch and clean tree**
+
+```bash
+git status
+git branch --show-current
+```
+
+Expected: `On branch sc-bias-table`, working tree clean.
+
+- [ ] **Verify the spec exists and the build is green at baseline**
+
+```bash
+test -f docs/superpowers/specs/2026-05-20-bias-conditional-branch-count-design.md && echo "spec OK"
+nix develop --command cmake -S . -B build -GNinja
+nix develop --command cmake --build build
+nix develop --command ctest --test-dir build --output-on-failure
+```
+
+Expected: `spec OK`, clean build, all existing tests pass. If tests fail at baseline, **stop and surface to user** — do not proceed.
+
+---
+
+### Task 1: Extract the shared branch-chain emitter
+
+The current `benchmarks/branch_history_footprint.cpp::emit_kernel` contains the sljit chain emission (prologue, row_ptr update, per-site load+cmp+jmp, history wrap, loop tail, return). Move that into a shared helper. Keep pattern generation in the benchmark.
+
+**Files:**
+- Create: `include/ferret/branch_chain_emit.hpp`
+- Create: `src/branch_chain_emit.cpp`
+- Modify: `benchmarks/branch_history_footprint.cpp`
+- Modify: `CMakeLists.txt`
+
+- [ ] **Step 1: Create the header**
+
+Create `include/ferret/branch_chain_emit.hpp`:
+
+```cpp
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+struct sljit_compiler;
+struct sljit_label;
+
+namespace ferret {
+
+struct BranchChainEmitConfig {
+  const uint32_t* flat_base;
+  std::size_t branches;
+  std::size_t pattern_period;
+  std::size_t spacing_bytes;
+  std::size_t iterations;
+};
+
+struct BranchChainEmitResult {
+  std::vector<sljit_label*> site_labels;  // size == branches + 1 (last entry = chain exit)
+};
+
+// Emits one outer-loop branch-chain kernel into `c`. Caller has already
+// validated that `flat_base != nullptr`, `branches >= 1`,
+// `pattern_period >= 1`, `iterations >= 1`, and
+// `spacing_bytes >= branch_chain_min_site_bytes()`. Mutates `c` only after
+// argument checks pass.
+BranchChainEmitResult emit_branch_chain(sljit_compiler* c,
+                                         const BranchChainEmitConfig& cfg);
+
+// Post-codegen verification. `result` is the value returned by
+// `emit_branch_chain` for the same compiler. Throws std::runtime_error if
+// any site lies closer than `cfg.spacing_bytes` from the previous site.
+void verify_branch_chain_layout(const BranchChainEmitResult& result,
+                                 std::size_t branches,
+                                 std::size_t spacing_bytes);
+
+// Floor on the per-site byte width across all sljit encodings on this arch.
+// Used by benchmark validation: spacing_bytes must be >= this value.
+std::size_t branch_chain_min_site_bytes();
+
+}  // namespace ferret
+```
+
+- [ ] **Step 2: Create the implementation**
+
+Create `src/branch_chain_emit.cpp`:
+
+```cpp
+#include "ferret/branch_chain_emit.hpp"
+
+#include <stdexcept>
+#include <string>
+
+extern "C" {
+#include <sljitLir.h>
+}
+
+#include "ferret/padding.hpp"
+
+namespace ferret {
+
+namespace {
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+constexpr std::size_t kMinSiteBytes = 8;
+#elif defined(__x86_64__) || defined(_M_X64)
+constexpr std::size_t kMinSiteBytes = 6;
+#else
+#error "ferret v1 supports only x86_64 and aarch64"
+#endif
+
+}  // namespace
+
+std::size_t branch_chain_min_site_bytes() { return kMinSiteBytes; }
+
+BranchChainEmitResult emit_branch_chain(sljit_compiler* c,
+                                         const BranchChainEmitConfig& cfg) {
+  BranchChainEmitResult result;
+
+  // sljit prologue: 3 scratches + 2 saveds.
+  // SLJIT_S0 = flat_base, SLJIT_S1 = hist_idx, SLJIT_R0 = iter counter,
+  // SLJIT_R1 = row_ptr, SLJIT_R2 = loaded value.
+  sljit_emit_enter(c, 0, SLJIT_ARGS0V(), /*scratches=*/3, /*saved=*/2, /*local_size=*/0);
+  sljit_emit_op1(c, SLJIT_MOV, SLJIT_S0, 0, SLJIT_IMM, reinterpret_cast<sljit_sw>(cfg.flat_base));
+  sljit_emit_op1(c, SLJIT_MOV, SLJIT_S1, 0, SLJIT_IMM, 0);
+  sljit_emit_op1(c, SLJIT_MOV, SLJIT_R0, 0, SLJIT_IMM, static_cast<sljit_sw>(cfg.iterations));
+
+  sljit_label* loop_top = sljit_emit_label(c);
+
+  // row_ptr = flat_base + hist_idx * (branches * 4)
+  sljit_emit_op2(c, SLJIT_MUL, SLJIT_R1, 0, SLJIT_S1, 0, SLJIT_IMM, static_cast<sljit_sw>(cfg.branches * 4));
+  sljit_emit_op2(c, SLJIT_ADD, SLJIT_R1, 0, SLJIT_R1, 0, SLJIT_S0, 0);
+
+  result.site_labels.reserve(cfg.branches + 1);
+
+  for (std::size_t j = 0; j < cfg.branches; ++j) {
+    result.site_labels.push_back(sljit_emit_label(c));
+
+    sljit_emit_op1(c, SLJIT_MOV_U32, SLJIT_R2, 0, SLJIT_MEM1(SLJIT_R1), static_cast<sljit_sw>(j * 4));
+    sljit_jump* jmp = sljit_emit_cmp(c, SLJIT_NOT_EQUAL | SLJIT_32, SLJIT_R2, 0, SLJIT_IMM, 0);
+    sljit_label* after = sljit_emit_label(c);
+    sljit_set_label(jmp, after);
+
+    emit_nops(c, cfg.spacing_bytes - kMinSiteBytes);
+  }
+  result.site_labels.push_back(sljit_emit_label(c));
+
+  // hist_idx = (hist_idx + 1 == pattern_period) ? 0 : hist_idx + 1
+  sljit_emit_op2(c, SLJIT_ADD, SLJIT_S1, 0, SLJIT_S1, 0, SLJIT_IMM, 1);
+  sljit_emit_op2u(c, SLJIT_SUB | SLJIT_SET_Z, SLJIT_S1, 0, SLJIT_IMM, static_cast<sljit_sw>(cfg.pattern_period));
+  sljit_jump* skip_reset = sljit_emit_jump(c, SLJIT_NOT_ZERO);
+  sljit_emit_op1(c, SLJIT_MOV, SLJIT_S1, 0, SLJIT_IMM, 0);
+  sljit_label* after_wrap = sljit_emit_label(c);
+  sljit_set_label(skip_reset, after_wrap);
+
+  // dec iters; back-edge.
+  sljit_emit_op2(c, SLJIT_SUB | SLJIT_SET_Z, SLJIT_R0, 0, SLJIT_R0, 0, SLJIT_IMM, 1);
+  sljit_jump* back = sljit_emit_jump(c, SLJIT_NOT_ZERO);
+  sljit_set_label(back, loop_top);
+
+  sljit_emit_return_void(c);
+
+  return result;
+}
+
+void verify_branch_chain_layout(const BranchChainEmitResult& result,
+                                 std::size_t branches,
+                                 std::size_t spacing_bytes) {
+  if (branches == 0 || result.site_labels.empty()) {
+    return;
+  }
+  sljit_uw base = sljit_get_label_addr(result.site_labels[0]);
+  for (std::size_t i = 1; i <= branches; ++i) {
+    sljit_uw addr = sljit_get_label_addr(result.site_labels[i]);
+    auto actual = static_cast<std::size_t>(addr - base);
+    std::size_t expected_min = i * spacing_bytes;
+    if (actual < expected_min) {
+      throw std::runtime_error("branch_chain: site " + std::to_string(i) + " at offset " +
+                               std::to_string(actual) + ", expected at least " +
+                               std::to_string(expected_min));
+    }
+  }
+}
+
+}  // namespace ferret
+```
+
+- [ ] **Step 3: Add `src/branch_chain_emit.cpp` to `ferret_core`**
+
+Edit `CMakeLists.txt`. Find the `ferret_core` library definition (the `add_library(ferret_core ...)` block, around line 150). Append `src/branch_chain_emit.cpp` to its source list, alphabetically near `src/axis.cpp` / `src/cli_axis.cpp`.
+
+For example, if the current list is:
+
+```cmake
+add_library(ferret_core
+  src/axis.cpp
+  src/benchmark_registry.cpp
+  src/cli_axis.cpp
+  ...
+  src/permute.cpp
+)
+```
+
+insert `src/branch_chain_emit.cpp` between `src/benchmark_registry.cpp` and `src/cli_axis.cpp` so the list stays alphabetical.
+
+- [ ] **Step 4: Refactor `branch_history_footprint.cpp` to call the helper**
+
+Edit `benchmarks/branch_history_footprint.cpp`. Replace its `emit_kernel` and `verify_layout` with calls into the shared helper. Keep `generate_pattern_fill`, `LayoutSnapshot`, `last_layout_snapshot`, the per-instance state, and the validation throws.
+
+Full new contents of the file:
+
+```cpp
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "ferret/benchmark.hpp"
+#include "ferret/branch_chain_emit.hpp"
+
+namespace ferret {
+
+struct BranchHistoryFootprint;
+
+namespace branch_history_footprint_internal {
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+std::vector<uint32_t> generate_pattern_fill(size_t branches, size_t history_len, int64_t pattern, uint64_t seed) {
+  std::vector<uint32_t> flat(branches * history_len, 0U);
+  if (pattern == 0) {
+    return flat;
+  }
+  uint64_t mixed = seed ^ (static_cast<uint64_t>(branches) * 0x9E3779B97F4A7C15ULL) ^
+                   (static_cast<uint64_t>(history_len) * 0xBF58476D1CE4E5B9ULL);
+  std::mt19937_64 rng(mixed);
+  for (auto& v : flat) {
+    v = static_cast<uint32_t>(rng() & 1U);
+  }
+  return flat;
+}
+
+struct LayoutSnapshot {
+  std::vector<sljit_label*> labels;
+  size_t branches;
+  size_t spacing;
+};
+
+namespace {
+const BranchHistoryFootprint* g_last_emitted = nullptr;
+}  // namespace
+
+LayoutSnapshot last_layout_snapshot();
+
+}  // namespace branch_history_footprint_internal
+
+struct BranchHistoryFootprint : Benchmark {
+  std::vector<uint32_t> flat_;
+  BranchChainEmitResult last_emit_;
+  size_t last_branches_ = 0;
+  size_t last_spacing_ = 0;
+
+  [[nodiscard]] std::string name() const override { return "branch_history_footprint"; }
+
+  [[nodiscard]] SweepAxes axes() const override {
+    return {
+        Axis::geom_range("branches", 1, 1 << 9, /*samples_per_octave=*/1),
+        Axis::geom_range("history_len", 4, 1 << 12, /*samples_per_octave=*/1),
+    };
+  }
+
+  [[nodiscard]] BenchOptions options() const override {
+    return {
+        BenchOption{.name = "pattern", .default_value = 1},
+        BenchOption{.name = "spacing_bytes", .default_value = 16},
+    };
+  }
+
+  [[nodiscard]] size_t sites_per_kernel(const Params& p) const override { return p.get<size_t>("branches"); }
+
+  [[nodiscard]] size_t iterations(const Params& p) const override {
+    return std::max<size_t>(1, 10'000'000 / p.get<size_t>("branches"));
+  }
+
+  void emit_kernel(sljit_compiler* c, const Params& p) override;
+  void verify_layout(sljit_compiler* c) override;
+};
+
+void BranchHistoryFootprint::emit_kernel(sljit_compiler* c, const Params& p) {
+  auto branches = p.get<size_t>("branches");
+  auto history_len = p.get<size_t>("history_len");
+  auto pattern = p.get<int64_t>("pattern");
+  auto spacing = p.get<size_t>("spacing_bytes");
+  auto seed = static_cast<uint64_t>(p.get<int64_t>("seed"));
+
+  if (branches < 1) {
+    throw std::invalid_argument("branches must be >= 1");
+  }
+  if (history_len < 1) {
+    throw std::invalid_argument("history_len must be >= 1");
+  }
+  if (pattern != 0 && pattern != 1) {
+    throw std::invalid_argument("pattern must be 0 (zero) or 1 (random); got " + std::to_string(pattern));
+  }
+  if (spacing < branch_chain_min_site_bytes()) {
+    throw std::invalid_argument("spacing_bytes=" + std::to_string(spacing) +
+                                " is smaller than the minimum site encoding (" +
+                                std::to_string(branch_chain_min_site_bytes()) +
+                                " bytes) on this architecture");
+  }
+
+  size_t iters = iterations(p);
+
+  flat_ = branch_history_footprint_internal::generate_pattern_fill(branches, history_len, pattern, seed);
+
+  last_emit_ = emit_branch_chain(c, BranchChainEmitConfig{
+                                        .flat_base = flat_.data(),
+                                        .branches = branches,
+                                        .pattern_period = history_len,
+                                        .spacing_bytes = spacing,
+                                        .iterations = iters,
+                                    });
+
+  last_branches_ = branches;
+  last_spacing_ = spacing;
+  branch_history_footprint_internal::g_last_emitted = this;
+}
+
+void BranchHistoryFootprint::verify_layout(sljit_compiler* /*c*/) {
+  if (last_branches_ == 0 || last_emit_.site_labels.empty()) {
+    return;
+  }
+  verify_branch_chain_layout(last_emit_, last_branches_, last_spacing_);
+}
+
+namespace branch_history_footprint_internal {
+
+LayoutSnapshot last_layout_snapshot() {
+  if (g_last_emitted == nullptr) {
+    return {};
+  }
+  return {.labels = g_last_emitted->last_emit_.site_labels,
+          .branches = g_last_emitted->last_branches_,
+          .spacing = g_last_emitted->last_spacing_};
+}
+
+}  // namespace branch_history_footprint_internal
+
+FERRET_BENCHMARK("branch_history_footprint", BranchHistoryFootprint);
+
+}  // namespace ferret
+```
+
+Note: `last_emit_` is a public field of `BranchHistoryFootprint` so the snapshot accessor can read `site_labels` without a friend declaration. The `g_last_emitted` mechanism is preserved verbatim.
+
+- [ ] **Step 5: Build and run existing tests as the lock-in regression guard**
+
+```bash
+nix develop --command cmake --build build
+nix develop --command ctest --test-dir build --output-on-failure
+```
+
+Expected: all existing tests pass, including every `BranchHistoryFootprint.*` and `Integration.BranchHistoryFootprint*` test. If anything fails, **stop and fix before continuing** — the refactor must be observably no-op.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add include/ferret/branch_chain_emit.hpp src/branch_chain_emit.cpp benchmarks/branch_history_footprint.cpp CMakeLists.txt
+git commit --no-gpg-sign -m "$(cat <<'EOF'
+refactor(branch_chain_emit): extract shared sljit branch-chain emitter
+
+Factors emit_kernel/verify_layout out of branch_history_footprint into
+a reusable helper consumed by both that benchmark and the upcoming
+bias_conditional_branch_count benchmark.
+EOF
+)"
+```
+
+---
+
+### Task 2: Scaffold the new benchmark + first registry test
+
+**Files:**
+- Create: `benchmarks/bias_conditional_branch_count.cpp`
+- Create: `tests/test_bias_conditional_branch_count.cpp`
+- Modify: `tests/CMakeLists.txt`
+- Modify: `CMakeLists.txt`
+
+- [ ] **Step 1: Write the failing registry test**
+
+Create `tests/test_bias_conditional_branch_count.cpp`:
+
+```cpp
+#include <gtest/gtest.h>
+
+#include "ferret/benchmark.hpp"
+
+TEST(BiasConditionalBranchCount, RegistryLookupReturnsBenchmark) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->name(), "bias_conditional_branch_count");
+}
+```
+
+- [ ] **Step 2: Add the test target to CMake**
+
+Edit `tests/CMakeLists.txt`. Find the `test_branch_history_footprint` block (around line 105) and add **after** it:
+
+```cmake
+add_executable(test_bias_conditional_branch_count
+  test_bias_conditional_branch_count.cpp
+  ../benchmarks/bias_conditional_branch_count.cpp
+)
+target_link_libraries(test_bias_conditional_branch_count PRIVATE
+  ferret_core
+  sljit::sljit
+  GTest::gtest GTest::gtest_main
+)
+gtest_discover_tests(test_bias_conditional_branch_count)
+```
+
+- [ ] **Step 3: Create a stub benchmark that registers**
+
+Create `benchmarks/bias_conditional_branch_count.cpp`:
+
+```cpp
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "ferret/benchmark.hpp"
+#include "ferret/branch_chain_emit.hpp"
+
+namespace ferret {
+
+struct BiasConditionalBranchCount : Benchmark {
+  std::vector<uint32_t> flat_;
+  BranchChainEmitResult last_emit_;
+  size_t last_branches_ = 0;
+  size_t last_spacing_ = 0;
+
+  [[nodiscard]] std::string name() const override { return "bias_conditional_branch_count"; }
+
+  [[nodiscard]] SweepAxes axes() const override {
+    return {
+        Axis::geom_range("branches", 1, 1 << 13, /*samples_per_octave=*/1),
+        Axis::geom_range("total_outcomes", 1 << 13, 1 << 20, /*samples_per_octave=*/1),
+    };
+  }
+
+  [[nodiscard]] BenchOptions options() const override {
+    return {
+        BenchOption{.name = "bias_pct", .default_value = 95},
+        BenchOption{.name = "nt_branch_pct", .default_value = 50},
+        BenchOption{.name = "spacing_bytes", .default_value = 16},
+    };
+  }
+
+  [[nodiscard]] size_t sites_per_kernel(const Params& p) const override { return p.get<size_t>("branches"); }
+
+  [[nodiscard]] size_t iterations(const Params& p) const override {
+    return std::max<size_t>(1, 10'000'000 / p.get<size_t>("branches"));
+  }
+
+  void emit_kernel(sljit_compiler* c, const Params& p) override {
+    (void)c;
+    (void)p;
+    throw std::runtime_error("not implemented yet");
+  }
+};
+
+FERRET_BENCHMARK("bias_conditional_branch_count", BiasConditionalBranchCount);
+
+}  // namespace ferret
+```
+
+- [ ] **Step 4: Wire into the `ferret` executable**
+
+Edit `CMakeLists.txt`. Find `add_executable(ferret ...)` (around line 167). Add `benchmarks/bias_conditional_branch_count.cpp` alphabetically:
+
+```cmake
+add_executable(ferret
+  src/main.cpp
+  benchmarks/bias_conditional_branch_count.cpp
+  benchmarks/branch_history_footprint.cpp
+  benchmarks/dependent_chain_throughput.cpp
+  benchmarks/direct_branch_footprint.cpp
+  benchmarks/nested_call_depth.cpp
+)
+```
+
+- [ ] **Step 5: Build and run the registry test**
+
+```bash
+nix develop --command cmake --build build
+nix develop --command ctest --test-dir build -R BiasConditionalBranchCount --output-on-failure
+```
+
+Expected: `BiasConditionalBranchCount.RegistryLookupReturnsBenchmark` passes; no other behavior is wired yet.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add benchmarks/bias_conditional_branch_count.cpp tests/test_bias_conditional_branch_count.cpp tests/CMakeLists.txt CMakeLists.txt
+git commit --no-gpg-sign -m "feat(bias_conditional_branch_count): scaffold benchmark + registry test"
+```
+
+---
+
+### Task 3: Lock in axes, options, sites_per_kernel, iterations
+
+**Files:**
+- Modify: `tests/test_bias_conditional_branch_count.cpp`
+
+- [ ] **Step 1: Append the axes/options test suite**
+
+Append to `tests/test_bias_conditional_branch_count.cpp` (above the existing single test, helpers go in an anonymous namespace at the top):
+
+```cpp
+#include "ferret/params.hpp"
+
+namespace {
+ferret::Params make_params(int64_t branches, int64_t total_outcomes, int64_t bias = 95, int64_t nt = 50,
+                            int64_t spacing = 16) {
+  ferret::Params p;
+  p.set("branches", branches);
+  p.set("total_outcomes", total_outcomes);
+  p.set("bias_pct", bias);
+  p.set("nt_branch_pct", nt);
+  p.set("spacing_bytes", spacing);
+  p.set("seed", 1);
+  return p;
+}
+const ferret::BenchOption* find_option(const ferret::BenchOptions& opts, const std::string& name) {
+  for (const auto& o : opts) {
+    if (o.name == name) return &o;
+  }
+  return nullptr;
+}
+}  // namespace
+
+TEST(BiasConditionalBranchCount, ExposesBranchesAndTotalOutcomesAxes) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  auto axes = b->axes();
+  ASSERT_EQ(axes.size(), 2u);
+  EXPECT_EQ(axes[0].name(), "branches");
+  EXPECT_EQ(axes[1].name(), "total_outcomes");
+}
+
+TEST(BiasConditionalBranchCount, BranchesAxisExpansionMatchesSpec) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  auto vs = b->axes()[0].expand();
+  // 1..8192 with k=1: {1,2,4,8,16,32,64,128,256,512,1024,2048,4096,8192} = 14 points.
+  EXPECT_EQ(vs.size(), 14u);
+  EXPECT_EQ(vs.front(), 1);
+  EXPECT_EQ(vs.back(), 8192);
+}
+
+TEST(BiasConditionalBranchCount, TotalOutcomesAxisExpansionMatchesSpec) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  auto vs = b->axes()[1].expand();
+  // 8192..1048576 with k=1: 8 points {8192, 16384, ..., 1048576}.
+  EXPECT_EQ(vs.size(), 8u);
+  EXPECT_EQ(vs.front(), 8192);
+  EXPECT_EQ(vs.back(), 1048576);
+}
+
+TEST(BiasConditionalBranchCount, DefaultAxisGridIsValidationClean) {
+  // total_outcomes_min must be >= branches_max so pattern_period >= 1 at
+  // every default Cartesian point. spec §5.1.
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  auto axes = b->axes();
+  auto branches = axes[0].expand();
+  auto totals = axes[1].expand();
+  EXPECT_GE(totals.front(), branches.back());
+}
+
+TEST(BiasConditionalBranchCount, ExposesAllThreeOptions) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  auto opts = b->options();
+  ASSERT_EQ(opts.size(), 3u);
+  EXPECT_EQ(find_option(opts, "bias_pct")->default_value, 95);
+  EXPECT_EQ(find_option(opts, "nt_branch_pct")->default_value, 50);
+  EXPECT_EQ(find_option(opts, "spacing_bytes")->default_value, 16);
+}
+
+TEST(BiasConditionalBranchCount, SitesPerKernelEqualsBranches) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->sites_per_kernel(make_params(32, 65536)), 32u);
+  EXPECT_EQ(b->sites_per_kernel(make_params(1, 8192)), 1u);
+}
+
+TEST(BiasConditionalBranchCount, IterationsAmortizesAtTenMillionSites) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->iterations(make_params(1, 8192)), 10'000'000u);
+  EXPECT_EQ(b->iterations(make_params(100, 65536)), 100'000u);
+  EXPECT_EQ(b->iterations(make_params(10'000'001, 65536)), 1u);
+}
+```
+
+- [ ] **Step 2: Run the new tests; they should pass already (the stub already declares the axes/options)**
+
+```bash
+nix develop --command cmake --build build
+nix develop --command ctest --test-dir build -R BiasConditionalBranchCount --output-on-failure
+```
+
+Expected: all `BiasConditionalBranchCount.*` axis/options tests pass. Validation/fill/emit tests are coming in Task 4+.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_bias_conditional_branch_count.cpp
+git commit --no-gpg-sign -m "test(bias_conditional_branch_count): lock in axes, options, sites/iterations"
+```
+
+---
+
+### Task 4: Add internal direction-assignment + outcome-fill routines
+
+Spec §7.1–§7.3. Two independent RNG streams: one for direction assignment (stable across `total_outcomes`), one for outcome fill.
+
+**Files:**
+- Modify: `benchmarks/bias_conditional_branch_count.cpp`
+- Modify: `tests/test_bias_conditional_branch_count.cpp`
+
+- [ ] **Step 1: Write failing tests for the direction-assignment helper**
+
+Add to `tests/test_bias_conditional_branch_count.cpp` (top of file, after existing helpers):
+
+```cpp
+#include <cstdint>
+#include <vector>
+
+namespace ferret::bias_conditional_branch_count_internal {
+std::vector<uint8_t> assign_directions(size_t branches, int64_t nt_branch_pct, uint64_t seed);
+std::vector<uint32_t> generate_pattern_fill(size_t branches, size_t pattern_period, int64_t bias_pct,
+                                             int64_t nt_branch_pct, uint64_t seed);
+}  // namespace ferret::bias_conditional_branch_count_internal
+```
+
+Then add the tests:
+
+```cpp
+TEST(BiasConditionalBranchCount, DirectionAssignmentHonorsNtBranchPct) {
+  auto dirs = ferret::bias_conditional_branch_count_internal::assign_directions(
+      /*branches=*/1024, /*nt_branch_pct=*/50, /*seed=*/1);
+  ASSERT_EQ(dirs.size(), 1024u);
+  size_t nt = 0;
+  for (uint8_t d : dirs) {
+    EXPECT_TRUE(d == 0u || d == 1u);
+    nt += d;
+  }
+  EXPECT_EQ(nt, 512u);  // 1024 * 50 / 100
+}
+
+TEST(BiasConditionalBranchCount, DirectionAssignmentDeterministicForSameSeed) {
+  auto a = ferret::bias_conditional_branch_count_internal::assign_directions(64, 50, 42);
+  auto b = ferret::bias_conditional_branch_count_internal::assign_directions(64, 50, 42);
+  EXPECT_EQ(a, b);
+}
+
+TEST(BiasConditionalBranchCount, DirectionAssignmentDiffersBetweenSeeds) {
+  auto a = ferret::bias_conditional_branch_count_internal::assign_directions(64, 50, 42);
+  auto b = ferret::bias_conditional_branch_count_internal::assign_directions(64, 50, 43);
+  EXPECT_NE(a, b);
+}
+
+TEST(BiasConditionalBranchCount, DirectionAssignmentAllTPreferredWhenZero) {
+  auto dirs = ferret::bias_conditional_branch_count_internal::assign_directions(128, 0, 1);
+  for (uint8_t d : dirs) EXPECT_EQ(d, 0u);
+}
+
+TEST(BiasConditionalBranchCount, DirectionAssignmentAllNtPreferredWhenHundred) {
+  auto dirs = ferret::bias_conditional_branch_count_internal::assign_directions(128, 100, 1);
+  for (uint8_t d : dirs) EXPECT_EQ(d, 1u);
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+nix develop --command cmake --build build 2>&1 | tail -20
+```
+
+Expected: link error (`assign_directions` not defined).
+
+- [ ] **Step 3: Implement `assign_directions`**
+
+Edit `benchmarks/bias_conditional_branch_count.cpp`. Add `#include <algorithm>` and `#include <random>` at the top, then add an internal namespace before the struct:
+
+```cpp
+namespace ferret {
+
+namespace bias_conditional_branch_count_internal {
+
+constexpr uint64_t kDirBranchesMix = 0x9E3779B97F4A7C15ULL;
+constexpr uint64_t kDirNtPctMix    = 0xD6E8FEB86659FD93ULL;
+constexpr uint64_t kFillTotalMix   = 0xBF58476D1CE4E5B9ULL;
+constexpr uint64_t kFillBiasMix    = 0x94D049BB133111EBULL;
+
+std::vector<uint8_t> assign_directions(size_t branches, int64_t nt_branch_pct, uint64_t seed) {
+  std::vector<uint8_t> dirs(branches, 0u);
+  if (branches == 0) return dirs;
+  size_t nt_count = static_cast<size_t>(static_cast<int64_t>(branches) * nt_branch_pct / 100);
+  if (nt_count == 0) return dirs;
+  if (nt_count >= branches) {
+    std::fill(dirs.begin(), dirs.end(), uint8_t{1});
+    return dirs;
+  }
+  // Seeded Fisher–Yates: pick `nt_count` distinct indices to flag NT-preferred.
+  std::vector<size_t> idxs(branches);
+  for (size_t i = 0; i < branches; ++i) idxs[i] = i;
+  uint64_t mixed = seed ^ (static_cast<uint64_t>(branches) * kDirBranchesMix) ^
+                   (static_cast<uint64_t>(nt_branch_pct) * kDirNtPctMix);
+  std::mt19937_64 rng(mixed);
+  for (size_t i = 0; i < nt_count; ++i) {
+    std::uniform_int_distribution<size_t> dist(i, branches - 1);
+    size_t j = dist(rng);
+    std::swap(idxs[i], idxs[j]);
+    dirs[idxs[i]] = 1u;
+  }
+  return dirs;
+}
+
+}  // namespace bias_conditional_branch_count_internal
+```
+
+(Leave the struct + macro registration as-is for now.)
+
+- [ ] **Step 4: Run tests**
+
+```bash
+nix develop --command cmake --build build
+nix develop --command ctest --test-dir build -R BiasConditionalBranchCount.DirectionAssignment --output-on-failure
+```
+
+Expected: all five direction-assignment tests pass.
+
+- [ ] **Step 5: Write failing tests for `generate_pattern_fill`**
+
+Append to `tests/test_bias_conditional_branch_count.cpp`:
+
+```cpp
+TEST(BiasConditionalBranchCount, FillIsZeroOrOnePerCell) {
+  auto v = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(
+      /*branches=*/8, /*pattern_period=*/32, /*bias_pct=*/95, /*nt_branch_pct=*/50, /*seed=*/7);
+  ASSERT_EQ(v.size(), 256u);
+  for (uint32_t x : v) {
+    EXPECT_TRUE(x == 0u || x == 1u) << "out of {0,1}: " << x;
+  }
+}
+
+TEST(BiasConditionalBranchCount, FillDeterministicForSameSeed) {
+  auto a = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(8, 32, 95, 50, 7);
+  auto b = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(8, 32, 95, 50, 7);
+  EXPECT_EQ(a, b);
+}
+
+TEST(BiasConditionalBranchCount, FillDiffersBetweenSeeds) {
+  auto a = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(8, 32, 95, 50, 7);
+  auto b = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(8, 32, 95, 50, 8);
+  EXPECT_NE(a, b);
+}
+
+TEST(BiasConditionalBranchCount, FillDiffersByBiasPct) {
+  auto a = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(8, 256, 95, 50, 1);
+  auto b = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(8, 256, 50, 50, 1);
+  EXPECT_NE(a, b);
+}
+
+TEST(BiasConditionalBranchCount, FillFrequencyTracksBiasOnTPreferred) {
+  // Spec §10.1 statistical-bounds test. T-preferred branch with bias_pct=95
+  // over 1024 outcomes: empirical T-frequency must lie in [0.93, 0.97]
+  // (~3-sigma bounds at p=0.95, n=1024). With nt_branch_pct=0 every branch
+  // is T-preferred, so we can read any column.
+  auto dirs = ferret::bias_conditional_branch_count_internal::assign_directions(64, 0, 11);
+  for (uint8_t d : dirs) ASSERT_EQ(d, 0u);
+  auto v = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(
+      /*branches=*/64, /*pattern_period=*/1024, /*bias_pct=*/95, /*nt_branch_pct=*/0, /*seed=*/11);
+  size_t ones = 0;
+  for (size_t t = 0; t < 1024; ++t) ones += v[t * 64 + 0];
+  double freq = static_cast<double>(ones) / 1024.0;
+  EXPECT_GT(freq, 0.93);
+  EXPECT_LT(freq, 0.97);
+}
+
+TEST(BiasConditionalBranchCount, FillFrequencyMirrorsBiasOnNtPreferred) {
+  // nt_branch_pct=100 → every branch NT-preferred. With bias_pct=95, the
+  // T-frequency should be ~5% (the *minority* direction).
+  auto dirs = ferret::bias_conditional_branch_count_internal::assign_directions(64, 100, 11);
+  for (uint8_t d : dirs) ASSERT_EQ(d, 1u);
+  auto v = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(
+      /*branches=*/64, /*pattern_period=*/1024, /*bias_pct=*/95, /*nt_branch_pct=*/100, /*seed=*/11);
+  size_t ones = 0;
+  for (size_t t = 0; t < 1024; ++t) ones += v[t * 64 + 0];
+  double freq = static_cast<double>(ones) / 1024.0;
+  EXPECT_GT(freq, 0.03);
+  EXPECT_LT(freq, 0.07);
+}
+```
+
+- [ ] **Step 6: Implement `generate_pattern_fill`**
+
+Add inside `namespace bias_conditional_branch_count_internal` in `benchmarks/bias_conditional_branch_count.cpp`:
+
+```cpp
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+std::vector<uint32_t> generate_pattern_fill(size_t branches, size_t pattern_period, int64_t bias_pct,
+                                              int64_t nt_branch_pct, uint64_t seed) {
+  std::vector<uint32_t> flat(branches * pattern_period, 0u);
+  if (branches == 0 || pattern_period == 0) return flat;
+
+  auto dirs = assign_directions(branches, nt_branch_pct, seed);
+
+  // Fill RNG seed mix — depends on full param set but stays distinct from
+  // the direction-assignment seed so direction stays stable when only
+  // total_outcomes / bias_pct change.
+  uint64_t dir_mix = seed ^ (static_cast<uint64_t>(branches) * kDirBranchesMix) ^
+                     (static_cast<uint64_t>(nt_branch_pct) * kDirNtPctMix);
+  uint64_t fill_mix = dir_mix ^ (static_cast<uint64_t>(pattern_period) * kFillTotalMix) ^
+                      (static_cast<uint64_t>(bias_pct) * kFillBiasMix);
+  std::mt19937_64 rng(fill_mix);
+
+  // Fixed-point compare in Q14 (0..16384). r ∈ [0, 16384); branch taken iff
+  // r < prob_taken_q14.
+  auto prob_taken_q14 = [&](bool nt_preferred) -> uint32_t {
+    int64_t pct = nt_preferred ? (100 - bias_pct) : bias_pct;
+    return static_cast<uint32_t>(pct * 16384 / 100);
+  };
+
+  for (size_t t = 0; t < pattern_period; ++t) {
+    for (size_t j = 0; j < branches; ++j) {
+      uint32_t r = static_cast<uint32_t>(rng() & 0x3fffu);
+      flat[t * branches + j] = (r < prob_taken_q14(dirs[j] != 0u)) ? 1u : 0u;
+    }
+  }
+  return flat;
+}
+```
+
+- [ ] **Step 7: Run tests**
+
+```bash
+nix develop --command cmake --build build
+nix develop --command ctest --test-dir build -R BiasConditionalBranchCount.Fill --output-on-failure
+```
+
+Expected: all six fill tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add benchmarks/bias_conditional_branch_count.cpp tests/test_bias_conditional_branch_count.cpp
+git commit --no-gpg-sign -m "feat(bias_conditional_branch_count): direction assignment + outcome fill"
+```
+
+---
+
+### Task 5: Wire `emit_kernel` to the shared chain emitter + validation
+
+**Files:**
+- Modify: `benchmarks/bias_conditional_branch_count.cpp`
+- Modify: `tests/test_bias_conditional_branch_count.cpp`
+
+- [ ] **Step 1: Write the failing emit/layout tests**
+
+Append to `tests/test_bias_conditional_branch_count.cpp`:
+
+```cpp
+extern "C" {
+#include <sljitLir.h>
+}
+
+namespace {
+struct CompilerHandle {
+  sljit_compiler* c = sljit_create_compiler(nullptr);
+  ~CompilerHandle() {
+    if (c) sljit_free_compiler(c);
+  }
+};
+}  // namespace
+
+TEST(BiasConditionalBranchCount, RejectsZeroBranches) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(0, 8192)), std::invalid_argument);
+}
+
+TEST(BiasConditionalBranchCount, RejectsZeroTotalOutcomes) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(1, 0)), std::invalid_argument);
+}
+
+TEST(BiasConditionalBranchCount, RejectsTotalOutcomesBelowBranches) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(64, 32)), std::invalid_argument);
+}
+
+TEST(BiasConditionalBranchCount, RejectsBiasPctOutOfRange) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(1, 8192, /*bias=*/-1)), std::invalid_argument);
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(1, 8192, /*bias=*/101)), std::invalid_argument);
+}
+
+TEST(BiasConditionalBranchCount, RejectsNtBranchPctOutOfRange) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(1, 8192, 95, /*nt=*/-1)), std::invalid_argument);
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(1, 8192, 95, /*nt=*/101)), std::invalid_argument);
+}
+
+TEST(BiasConditionalBranchCount, RejectsSpacingBytesTooSmall) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(1, 8192, 95, 50, /*spacing=*/4)), std::invalid_argument);
+}
+
+TEST(BiasConditionalBranchCount, EmitsValidKernelForSmallParams) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  auto p = make_params(/*branches=*/4, /*total_outcomes=*/16, /*bias=*/95, /*nt=*/50, /*spacing=*/16);
+  ASSERT_NO_THROW(b->emit_kernel(ch.c, p));
+  ASSERT_EQ(sljit_get_compiler_error(ch.c), SLJIT_SUCCESS);
+
+  void* code = sljit_generate_code(ch.c, 0, nullptr);
+  ASSERT_NE(code, nullptr);
+  ASSERT_NO_THROW(b->verify_layout(ch.c));
+  sljit_free_code(code, nullptr);
+}
+
+TEST(BiasConditionalBranchCount, EmitsAcceptsEdgeCaseTotalOutcomesEqualsBranches) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  // total_outcomes == branches → pattern_period == 1. Spec §9: accepted.
+  auto p = make_params(/*branches=*/4, /*total_outcomes=*/4);
+  ASSERT_NO_THROW(b->emit_kernel(ch.c, p));
+  ASSERT_EQ(sljit_get_compiler_error(ch.c), SLJIT_SUCCESS);
+  void* code = sljit_generate_code(ch.c, 0, nullptr);
+  ASSERT_NE(code, nullptr);
+  sljit_free_code(code, nullptr);
+}
+```
+
+- [ ] **Step 2: Replace the stub `emit_kernel` with the real implementation**
+
+Edit `benchmarks/bias_conditional_branch_count.cpp`. Replace the `emit_kernel` body and add a `verify_layout` override. The full replacement for the struct + method definitions:
+
+```cpp
+struct BiasConditionalBranchCount : Benchmark {
+  std::vector<uint32_t> flat_;
+  BranchChainEmitResult last_emit_;
+  size_t last_branches_ = 0;
+  size_t last_spacing_ = 0;
+
+  [[nodiscard]] std::string name() const override { return "bias_conditional_branch_count"; }
+
+  [[nodiscard]] SweepAxes axes() const override {
+    return {
+        Axis::geom_range("branches", 1, 1 << 13, /*samples_per_octave=*/1),
+        Axis::geom_range("total_outcomes", 1 << 13, 1 << 20, /*samples_per_octave=*/1),
+    };
+  }
+
+  [[nodiscard]] BenchOptions options() const override {
+    return {
+        BenchOption{.name = "bias_pct", .default_value = 95},
+        BenchOption{.name = "nt_branch_pct", .default_value = 50},
+        BenchOption{.name = "spacing_bytes", .default_value = 16},
+    };
+  }
+
+  [[nodiscard]] size_t sites_per_kernel(const Params& p) const override { return p.get<size_t>("branches"); }
+
+  [[nodiscard]] size_t iterations(const Params& p) const override {
+    return std::max<size_t>(1, 10'000'000 / p.get<size_t>("branches"));
+  }
+
+  void emit_kernel(sljit_compiler* c, const Params& p) override;
+  void verify_layout(sljit_compiler* c) override;
+};
+
+void BiasConditionalBranchCount::emit_kernel(sljit_compiler* c, const Params& p) {
+  auto branches = p.get<size_t>("branches");
+  auto total_outcomes = p.get<size_t>("total_outcomes");
+  auto bias_pct = p.get<int64_t>("bias_pct");
+  auto nt_branch_pct = p.get<int64_t>("nt_branch_pct");
+  auto spacing = p.get<size_t>("spacing_bytes");
+  auto seed = static_cast<uint64_t>(p.get<int64_t>("seed"));
+
+  if (branches < 1) {
+    throw std::invalid_argument("branches must be >= 1");
+  }
+  if (total_outcomes < 1) {
+    throw std::invalid_argument("total_outcomes must be >= 1");
+  }
+  if (total_outcomes < branches) {
+    throw std::invalid_argument("total_outcomes (" + std::to_string(total_outcomes) +
+                                ") must be >= branches (" + std::to_string(branches) +
+                                ") so pattern_period >= 1");
+  }
+  if (bias_pct < 0 || bias_pct > 100) {
+    throw std::invalid_argument("bias_pct must be in [0, 100]; got " + std::to_string(bias_pct));
+  }
+  if (nt_branch_pct < 0 || nt_branch_pct > 100) {
+    throw std::invalid_argument("nt_branch_pct must be in [0, 100]; got " + std::to_string(nt_branch_pct));
+  }
+  if (spacing < branch_chain_min_site_bytes()) {
+    throw std::invalid_argument("spacing_bytes=" + std::to_string(spacing) +
+                                " is smaller than the minimum site encoding (" +
+                                std::to_string(branch_chain_min_site_bytes()) +
+                                " bytes) on this architecture");
+  }
+
+  size_t pattern_period = total_outcomes / branches;
+  size_t iters = iterations(p);
+
+  flat_ = bias_conditional_branch_count_internal::generate_pattern_fill(
+      branches, pattern_period, bias_pct, nt_branch_pct, seed);
+
+  last_emit_ = emit_branch_chain(c, BranchChainEmitConfig{
+                                        .flat_base = flat_.data(),
+                                        .branches = branches,
+                                        .pattern_period = pattern_period,
+                                        .spacing_bytes = spacing,
+                                        .iterations = iters,
+                                    });
+  last_branches_ = branches;
+  last_spacing_ = spacing;
+}
+
+void BiasConditionalBranchCount::verify_layout(sljit_compiler* /*c*/) {
+  if (last_branches_ == 0 || last_emit_.site_labels.empty()) {
+    return;
+  }
+  verify_branch_chain_layout(last_emit_, last_branches_, last_spacing_);
+}
+```
+
+Also add `#include <algorithm>` and `#include <random>` if not already present, and remove the `(void)c; (void)p; throw` stub.
+
+- [ ] **Step 3: Build and run all `BiasConditionalBranchCount.*` tests**
+
+```bash
+nix develop --command cmake --build build
+nix develop --command ctest --test-dir build -R BiasConditionalBranchCount --output-on-failure
+```
+
+Expected: all 20+ tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add benchmarks/bias_conditional_branch_count.cpp tests/test_bias_conditional_branch_count.cpp
+git commit --no-gpg-sign -m "feat(bias_conditional_branch_count): wire emit_kernel + validation"
+```
+
+---
+
+### Task 6: Integration smoke test
+
+**Files:**
+- Modify: `tests/test_integration.cpp`
+
+- [ ] **Step 1: Append the new integration tests**
+
+The existing integration tests in `tests/test_integration.cpp` use `FERRET_BINARY` + `run(cmd)` + `slurp(path)` (no `make_tmp_csv` / `read_csv_rows` abstractions). Match that style exactly. Append the following block after the existing `Integration.BranchHistoryFootprint*` tests (around line 171):
+
+```cpp
+TEST(Integration, BiasConditionalBranchCountProducesExpectedRowCount) {
+  auto out = std::filesystem::temp_directory_path() / "ferret_bcbc.csv";
+  std::filesystem::remove(out);
+  // branches ∈ {1, 2, 4} × total_outcomes ∈ {8, 16} → 6 data rows.
+  std::string cmd = std::string(FERRET_BINARY) +
+                    " run bias_conditional_branch_count"
+                    " --branches=1..4 --total_outcomes=8..16"
+                    " --bias_pct=95 --nt_branch_pct=50"
+                    " --reps=3 --warmup=1"
+                    " --out=" +
+                    out.string();
+  ASSERT_EQ(0, run(cmd));
+
+  std::string contents = slurp(out.string());
+  size_t newlines = std::count(contents.begin(), contents.end(), '\n');
+  EXPECT_EQ(newlines, 7u);  // header + 6 data rows
+  EXPECT_EQ(contents.find(",,\n"), std::string::npos);
+}
+
+TEST(Integration, BiasConditionalBranchCountHeaderHasExpectedColumns) {
+  auto out = std::filesystem::temp_directory_path() / "ferret_bcbc_hdr.csv";
+  std::filesystem::remove(out);
+  std::string cmd = std::string(FERRET_BINARY) +
+                    " run bias_conditional_branch_count"
+                    " --branches=1 --total_outcomes=8"
+                    " --reps=2 --warmup=1"
+                    " --out=" +
+                    out.string();
+  ASSERT_EQ(0, run(cmd));
+
+  std::string contents = slurp(out.string());
+  EXPECT_NE(contents.find("branches"), std::string::npos);
+  EXPECT_NE(contents.find("total_outcomes"), std::string::npos);
+  EXPECT_NE(contents.find("bias_pct"), std::string::npos);
+  EXPECT_NE(contents.find("nt_branch_pct"), std::string::npos);
+  EXPECT_NE(contents.find("spacing_bytes"), std::string::npos);
+}
+
+TEST(Integration, BiasConditionalBranchCountRejectsTotalOutcomesBelowBranches) {
+  // Spec §9: total_outcomes < branches must fail the sweep cleanly.
+  auto out = std::filesystem::temp_directory_path() / "ferret_bcbc_bad.csv";
+  std::filesystem::remove(out);
+  std::string cmd = std::string(FERRET_BINARY) +
+                    " run bias_conditional_branch_count"
+                    " --branches=64 --total_outcomes=8"
+                    " --reps=1 --warmup=0"
+                    " --out=" +
+                    out.string();
+  // measure_rows returns std::nullopt on invalid_argument; run() reports
+  // non-zero exit.
+  EXPECT_NE(0, run(cmd));
+}
+```
+
+- [ ] **Step 2: Run integration tests**
+
+```bash
+nix develop --command cmake --build build
+nix develop --command ctest --test-dir build -R Integration.BiasConditionalBranchCount --output-on-failure
+```
+
+Expected: all three tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test_integration.cpp
+git commit --no-gpg-sign -m "test(bias_conditional_branch_count): integration smoke + CSV schema"
+```
+
+---
+
+### Task 7: Per-benchmark doc page
+
+**Files:**
+- Create: `docs/benchmarks/bias_conditional_branch_count.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Write the doc page**
+
+Create `docs/benchmarks/bias_conditional_branch_count.md`:
+
+```markdown
+# `bias_conditional_branch_count` — SC bias-table capacity probe
+
+`N` data-dependent conditional branches, half biased toward taken
+(Bernoulli(p)) and half toward not-taken (Bernoulli(1-p)), each driven
+by a long aperiodic outcome stream of total length `total_outcomes`
+shared across all branches. Pattern period per branch =
+`total_outcomes / branches`.
+
+The benchmark is designed to expose the **SC (Statistical Corrector)
+bias-table capacity** in TAGE-SC-L–style direction predictors by
+holding tagged-table pressure roughly constant (set by
+`total_outcomes`) while varying the number of distinct PCs (set by
+`branches`). Mixed-direction biases produce destructive aliasing in
+the SC bias table once `branches` exceeds the bias-table's effective
+entry count.
+
+## Kernel structure
+
+Identical to `branch_history_footprint`: one outer loop, `N` sites
+each loading a `uint32_t` outcome from the per-row buffer, comparing
+against zero, and branching to the immediately-following instruction.
+Architecturally a no-op; only the direction predictor is exercised.
+
+```
+   PC                  site (>= spacing_bytes apart)
+ 0x0000   ┌──────────────────────────────────────┐
+          │  MOV  r2, [row_ptr + 0]              │
+          │  CMP  r2, 0                          │
+          │  JNE  .Lnext_0                       │ ──┐
+          │ .Lnext_0:                            │ ◄─┘
+          │  <NOP pad>                           │
+ base+1×spacing+  ┌─────────────────────────────┐
+          │  MOV  r2, [row_ptr + 4]              │
+          │  CMP  r2, 0                          │
+          │  JNE  .Lnext_1                       │ ──┐
+          │ .Lnext_1:                            │ ◄─┘
+          │  <NOP pad>                           │
+ base+2×spacing+  ┌─────────────────────────────┐
+          │   ...                                │
+          ├──────────────────────────────────────┤
+          │  ADD  hist_idx, hist_idx, 1          │
+          │  CMP  hist_idx, pattern_period       │
+          │  SUBS iters, iters, 1; B.NE loop_top │
+          └──────────────────────────────────────┘
+```
+
+- The pattern buffer is `flat[pattern_period][branches]` (transposed).
+- Each of the `branches` PCs is assigned a *preferred* direction (T or
+  NT). At default `nt_branch_pct=50`, half prefer each.
+- Outcomes are i.i.d. Bernoulli(`bias_pct/100`) toward the branch's
+  preferred direction. Direction assignment is seed-deterministic and
+  stable across `total_outcomes` values for a given `(branches,
+  nt_branch_pct, seed)`.
+
+## Per-benchmark options
+
+| flag                   | meaning                                                  |
+| ---------------------- | -------------------------------------------------------- |
+| `--bias_pct=95`        | Per-branch bias magnitude (0..100). Default 95.          |
+| `--nt_branch_pct=50`   | Percent of branches assigned NT-preferred. Default 50.   |
+| `--spacing_bytes=16`   | Minimum PC stride per site (min 8 AArch64 / 6 x86_64).   |
+
+## CLI surface
+
+| flag                       | meaning                                                   |
+| -------------------------- | --------------------------------------------------------- |
+| `--branches=A..B[@k]`      | Geometric sweep, default `1..8192`.                       |
+| `--total_outcomes=A..B[@k]`| Geometric sweep, default `8192..1048576`.                 |
+| `--bias_pct=N`             | See above. Default 95.                                    |
+| `--nt_branch_pct=N`        | See above. Default 50.                                    |
+| `--spacing_bytes=N`        | Default 16.                                               |
+| `--seed=…`                 | Seeds direction assignment + outcome fill.                |
+
+`total_outcomes` must be `>= branches` for every Cartesian point
+(`pattern_period >= 1`). Widen one and you may need to widen the
+other.
+
+See [`../cli.md`](../cli.md) for global flags.
+
+## Reading the curves
+
+Plot a surface with `branches` on one axis and `total_outcomes` on
+the other:
+
+```sh
+python3 scripts/plot.py surface /tmp/sc.csv --out=/tmp/sc.png
+```
+
+Expected shape: an **L-shaped high-cycles region** in the upper-right
+corner of the plane.
+
+- **Lower-left plateau:** flat at the predictor-saturated floor.
+  Tagged tables memorize the short pattern (low `total_outcomes`) or
+  SC bias has room for every PC (low `branches`).
+- **Cliff along `branches`:** vertical wall — the SC bias-table
+  capacity. Below: SC corrects; above: destructive aliasing in SC
+  slots pulls saturated counters toward zero and mispredict rate
+  climbs.
+- **Cliff along `total_outcomes`:** horizontal wall — the tagged-table
+  effective memorization threshold. Below: tagged tables learn the
+  cyclic pattern; above: they churn perpetually.
+- **Upper-right plateau:** both predictors fail; cycles/site at the
+  high-mispredict ceiling.
+
+The SC fingerprint: the **vertical cliff position is invariant to
+`total_outcomes`** (above the tagged-table threshold). If the cliff
+slides diagonally with `total_outcomes`, the cliff is tagged-table-
+pressure-dominated and the SC reading is confounded on this CPU.
+
+## Caveats
+
+- **Per-row L1d footprint at high `branches`.** With `uint32_t`
+  outcomes, the per-row footprint is `branches * 4` bytes. At
+  `branches = 8192` that's 32 KB — at or just past the L1d ceiling
+  on most current cores. Cycles/site beyond that point may combine
+  the SC-bias cliff with L1d-miss effects.
+- **T0 may produce a small secondary cliff.** TAGE's base bimodal
+  table is also PC-indexed; when `branches` exceeds T0 capacity, T0
+  also aliases. SC bias normally corrects this, so the dominant
+  cliff is SC's.
+- **Other SC sub-components (GHIST/PATH/IMLI)** may partially correct
+  what BIAS cannot. The aperiodic / history-independent design
+  minimizes their contribution.
+- **Outer-loop tax at `branches=1`.** Read the leftmost column as a
+  tax baseline. Same caveat as `branch_history_footprint`.
+- **Apple Silicon pinning.** See project README discipline section.
+
+## Related docs
+
+- Construction rationale: [design spec](../superpowers/specs/2026-05-20-bias-conditional-branch-count-design.md).
+- Sister benchmark: [`branch_history_footprint`](branch_history_footprint.md) — direction-predictor capacity, generic.
+- Project two-step workflow: [project README](../../README.md).
+```
+
+- [ ] **Step 2: Update README benchmark table**
+
+Edit `README.md`. Find the benchmark table (around line 65). Add a row for the new benchmark:
+
+```markdown
+| [`bias_conditional_branch_count`](docs/benchmarks/bias_conditional_branch_count.md) | SC bias-table capacity (TAGE-SC-L) |
+```
+
+The new row goes after the `branch_history_footprint` row in the table.
+
+- [ ] **Step 3: Verify both docs render and links resolve**
+
+```bash
+test -f docs/benchmarks/bias_conditional_branch_count.md && echo "doc OK"
+grep -n "bias_conditional_branch_count" README.md
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/benchmarks/bias_conditional_branch_count.md README.md
+git commit --no-gpg-sign -m "docs(bias_conditional_branch_count): per-benchmark page + readme entry"
+```
+
+---
+
+### Task 8: Full test + smoke run
+
+- [ ] **Step 1: Run the complete test suite**
+
+```bash
+nix develop --command cmake --build build
+nix develop --command ctest --test-dir build --output-on-failure
+```
+
+Expected: all tests pass (existing + new).
+
+- [ ] **Step 2: Sanitizer build (ASan + UBSan)**
+
+```bash
+nix develop --command cmake -S . -B build-san -GNinja -DFERRET_SANITIZER=address+undefined
+nix develop --command cmake --build build-san
+nix develop --command ctest --test-dir build-san --output-on-failure
+```
+
+Expected: all tests pass under ASan + UBSan. Highest-value targets are the direction-assignment Fisher–Yates loop (off-by-one in the NT-set boundary) and the Q14 probability comparison (off-by-one at `bias_pct=0`/`100`).
+
+- [ ] **Step 3: Smoke-run the benchmark from the command line**
+
+```bash
+nix develop --command ./build/ferret list | grep bias_conditional_branch_count
+nix develop --command ./build/ferret run bias_conditional_branch_count \
+    --branches=1..16 --total_outcomes=64..256 \
+    --out=/tmp/sc-smoke.csv
+head -5 /tmp/sc-smoke.csv
+wc -l /tmp/sc-smoke.csv
+```
+
+Expected:
+- `list` contains the new benchmark name.
+- CSV has the expected columns (`branches`, `total_outcomes`, `bias_pct`, `nt_branch_pct`, `spacing_bytes`, ticks/iterations/sites/cycles/ns).
+- 5 × 3 = 15 data rows plus a header (16 total lines).
+
+- [ ] **Step 4: Optional: render the surface to confirm plot tooling works**
+
+```bash
+nix develop --command ./build/ferret run bias_conditional_branch_count \
+    --branches=1..256 --total_outcomes=8192..65536 \
+    --out=/tmp/sc-shape.csv
+python3 scripts/plot.py surface /tmp/sc-shape.csv --out=/tmp/sc-shape.png
+```
+
+Expected: PNG renders without error. The qualitative shape interpretation is documented in §11 of the spec; full validation is the manual-platform-check step from the spec §10.4 and not part of this task.
+
+- [ ] **Step 5: Confirm git status is clean**
+
+```bash
+git status
+git log --oneline -8
+```
+
+Expected: clean tree; recent commits listed in this order (newest first):
+
+```
+docs(bias_conditional_branch_count): per-benchmark page + readme entry
+test(bias_conditional_branch_count): integration smoke + CSV schema
+feat(bias_conditional_branch_count): wire emit_kernel + validation
+feat(bias_conditional_branch_count): direction assignment + outcome fill
+test(bias_conditional_branch_count): lock in axes, options, sites/iterations
+feat(bias_conditional_branch_count): scaffold benchmark + registry test
+refactor(branch_chain_emit): extract shared sljit branch-chain emitter
+docs(bias_conditional_branch_count): brainstorming design spec
+```
+
+If anything is missing or in the wrong order, surface to the user — do not amend silently.

--- a/docs/superpowers/specs/2026-05-20-bias-conditional-branch-count-design.md
+++ b/docs/superpowers/specs/2026-05-20-bias-conditional-branch-count-design.md
@@ -1,0 +1,615 @@
+# `bias_conditional_branch_count` — Microbenchmark Design
+
+Date: 2026-05-20
+Status: brainstorming output, pending user review before plan generation.
+
+## 1. Goal
+
+`bias_conditional_branch_count` is the fifth ferret microbenchmark. It
+probes the **effective capacity of the Statistical Corrector (SC) bias
+table** in TAGE-SC-L–style direction predictors, by constructing a
+workload where TAGE alone is forced into a steady-state above the
+information-theoretic mispredict floor while SC's per-PC bias counters
+remain the only structure that can close the gap. Sweeping `branches`
+orthogonally to the total pattern volume `total_outcomes` lets the user
+test the falsifiable claim that the capacity cliff is **PC-count
+driven** (i.e., SC bias entries) rather than **history-volume driven**
+(i.e., TAGE tagged tables).
+
+The benchmark sits next to `branch_history_footprint` in the
+direction-predictor family: same kernel shape, different experimental
+design and a different microarchitectural structure under test.
+
+### 1.1 Why this is hard, and why this design works
+
+A naive "biased branch with random history pollution" benchmark does
+**not** distinguish SC from TAGE, because TAGE's own base predictor
+(T0, the bimodal table) is itself a per-PC bias counter. For a 95/5
+branch, T0 saturates at strong-T on its own; tagged tables don't
+allocate (no usefulness gain over T0 on i.i.d. data); the steady-state
+mispredict rate sits at ~5% with or without SC.
+
+To create a measurable SC-vs-TAGE gap, the workload must:
+
+1. **Force TAGE's tagged tables to override T0 most of the time** — so
+   that T0's correct bias signal is suppressed by noisy tagged
+   predictions. This is achieved by making the per-branch outcome
+   stream a long aperiodic Bernoulli(p) sequence with GHR that varies
+   enough for tagged tables to allocate but not enough for any tagged
+   entry to saturate. The "rotation of NT positions every round"
+   framing is equivalent to "the pattern period exceeds TAGE's
+   effective history horizon," which we implement with a single long
+   pre-generated random buffer.
+
+2. **Create destructive aliasing in SC's bias table when capacity is
+   exceeded** — so the cliff position has a measurable signature. This
+   requires *opposing* biases: if all branches bias toward the same
+   direction, aliased SC entries still agree on the prediction and the
+   cliff never appears. The design splits branches into two
+   sub-populations: a fraction biased toward T (Bernoulli(p)), the
+   complement biased toward NT (Bernoulli(1-p)). With a default 50/50
+   split, every aliased pair in the SC bias table contains one of each
+   direction, driving the saturated counter back toward zero and
+   producing ~50% mispredict on the aliased PCs.
+
+3. **Isolate SC bias capacity from TAGE tagged-table capacity** — so
+   the cliff can be attributed to SC specifically. SC's bias table is
+   indexed by PC alone; its pressure scales with `branches`. TAGE's
+   tagged tables are indexed by `PC ⊕ hash(history)`; their pressure
+   scales with `branches × pattern_period = total_outcomes`. Sweeping
+   the two axes orthogonally means: if the cliff in `branches` occurs
+   at the same x-position across all `total_outcomes` rows, the cliff
+   is PC-count driven (SC). If the cliff slides with `total_outcomes`,
+   the cliff is history-volume driven (tagged) and the SC-isolation
+   claim is falsified.
+
+The 2D surface plot landed in `2026-05-18-surface-plot-design.md` is
+the natural visualization: cycles/site as height over the
+`(branches, total_outcomes)` plane. A vertical wall (cliff invariant
+to `total_outcomes`) is the SC bias-table fingerprint.
+
+## 2. Scope
+
+### In scope
+
+- Two sweep axes: `branches` and `total_outcomes`.
+- Derived per-point quantity: `pattern_period = total_outcomes /
+  branches` (integer division, floored, with `>= 1` enforced).
+- Static branch chain emitted via the **shared site emitter** factored
+  out from `branch_history_footprint`. Each site is the same
+  load + cmp + branch-to-next shape; the only difference is the
+  pattern fill strategy.
+- Per-branch direction assignment (T-biased vs NT-biased), deterministic
+  given `--seed`.
+- Per-bench options: `bias_pct` (magnitude of per-branch bias),
+  `nt_branch_pct` (percentage of branches assigned NT-preferred),
+  `spacing_bytes` (per-site PC stride).
+- `uint32_t`-per-outcome storage (kernel shared with
+  `branch_history_footprint`), with documented data-cache caveat at
+  the high end of `branches`.
+- x86_64 and AArch64.
+- Unit + integration tests, mirroring the existing direction-predictor
+  benchmark's test layout.
+
+### Out of scope
+
+- Bit-packed or `uint8_t`-per-outcome storage. The compression would
+  push the L1d ceiling on per-row footprint higher (allowing larger
+  `branches`), but it requires changing the per-site instruction
+  sequence (load byte + AND + cmp instead of load word + cmp), which
+  diverges from the shared emitter. Promotable to v2 once the v1 cliff
+  position is empirically known.
+- Sweeping `nt_branch_pct` or `bias_pct` as Cartesian axes. They are
+  per-run options in v1. The diagonal-isolation experiment uses fixed
+  values; sensitivity studies are run as separate invocations and
+  overlaid.
+- Defeating T0 by PC-low-bit aliasing (Route 1 from brainstorming).
+  Different experimental design, separate benchmark. This benchmark
+  uses the "perpetual tagged-table re-allocation" mechanism instead.
+- The Loop predictor, IMLI table, or other SC sub-components beyond
+  the bias table. The bias table is the largest and most
+  capacity-revealing SC component; other components are smaller and
+  specialized.
+- A "TAGE-only" reference curve. We have one CPU; the falsifiable
+  claim is on the *shape* of the surface (cliff invariance to
+  `total_outcomes`), not a side-by-side compare.
+
+## 3. Workflow
+
+Same two-step pattern as the other benchmarks, with the new surface
+renderer:
+
+```sh
+# Step 1: probe core frequency (existing benchmark, unchanged).
+build/ferret run dependent_chain_throughput --core=3 --out=/tmp/freq.csv
+python3 scripts/freq.py /tmp/freq.csv
+# → estimated_freq=4.521GHz
+
+# Step 2: sweep branches × total_outcomes at the default bias.
+build/ferret run bias_conditional_branch_count --core=3 \
+    --branches=1..8192 --total_outcomes=8192..1048576 \
+    --bias_pct=95 --nt_branch_pct=50 \
+    --freq=4.521GHz --out=/tmp/sc.csv
+
+# Step 3: 3D surface plot (the load-bearing visualization).
+python3 scripts/plot.py surface /tmp/sc.csv --out=/tmp/sc.png
+
+# Or a 2D heatmap for quick inspection:
+python3 scripts/plot.py heatmap /tmp/sc.csv --out=/tmp/sc-heat.png
+
+# Or a 1D slice at fixed total_outcomes:
+python3 scripts/plot.py line /tmp/sc.csv --x=branches \
+    --filter=total_outcomes=65536 --out=/tmp/sc-slice.png
+```
+
+The fingerprint to look for: the cliff position along `branches` is
+*invariant* to `total_outcomes`. A vertical wall in the surface.
+
+## 4. Kernel construction
+
+### 4.1 Memory layout
+
+Identical to `branch_history_footprint`: a single flat `uint32_t`
+buffer interpreted as `flat[pattern_period][branches]`, transposed so
+consecutive branch sites in one outer iteration access adjacent words.
+
+Buffer size = `total_outcomes * 4` bytes. At the default-axis max
+(`total_outcomes = 2^20 = 1 048 576`) that's 4 MB — fits L2 on every
+target. Crucially, the buffer size depends only on `total_outcomes`,
+not on the `(branches, pattern_period)` split. The diagonal-constraint
+sweep holds buffer footprint constant while varying `branches`, so any
+cliff observed *cannot* be attributed to data-cache effects on
+buffer-size.
+
+The per-row footprint **does** depend on `branches`: row size =
+`branches * 4` bytes. At `branches = 8192` (default axis max) that's
+32 KB — at the L1d ceiling on most current cores. Caveat documented in
+§11.
+
+### 4.2 Per-arch site bytes
+
+Inherited verbatim from `branch_history_footprint` §4.2. The per-site
+instruction sequence and `kMinSiteBytes` / `kBranchAlign` constraints
+are unchanged.
+
+### 4.3 Kernel skeleton
+
+Conceptually identical to `branch_history_footprint` §4.3. The only
+JIT-immediate that changes between benchmarks is `iters` (a function
+of `branches`, not of `bias_pct` / `nt_branch_pct`). The bias and
+direction-assignment knobs influence only the *contents* of `flat_`,
+not the emitted code.
+
+### 4.4 Branch-to-next-instruction trick
+
+Inherited verbatim from `branch_history_footprint` §4.4.
+
+### 4.5 Row pointer update per iteration
+
+Inherited verbatim from `branch_history_footprint` §4.5, with
+`history_len` substituted by `pattern_period`. The runtime computation
+is `row_ptr = flat_base + hist_idx * branches * 4` recomputed once per
+outer iteration; `hist_idx` wraps at `pattern_period`.
+
+### 4.6 Code sharing strategy
+
+The site-emission logic in `branch_history_footprint.cpp` is extracted
+into a shared helper exposed via a header:
+
+```cpp
+// include/ferret/branch_chain_emit.hpp
+namespace ferret {
+
+struct BranchChainEmitConfig {
+    const uint32_t* flat_base;
+    size_t branches;
+    size_t pattern_period;
+    size_t spacing_bytes;
+    size_t iterations;
+};
+
+struct BranchChainEmitResult {
+    std::vector<sljit_label*> site_labels;  // size == branches + 1
+};
+
+BranchChainEmitResult emit_branch_chain(sljit_compiler*,
+                                         const BranchChainEmitConfig&);
+
+}  // namespace ferret
+```
+
+Both benchmarks call this helper. The differences live in:
+
+- The pattern-fill routine (per-benchmark `generate_pattern_fill`).
+- The set of per-bench options exposed via `options()`.
+- The `axes()` returned by each benchmark.
+- The reading-the-curves doc page.
+
+The refactor preserves `branch_history_footprint`'s existing observable
+behavior (same opcodes, same layout, same CSV columns). A regression
+guard in `tests/test_branch_history_footprint.cpp` re-asserts that the
+post-refactor opcode bytes match the pre-refactor opcode bytes for a
+small `(branches=4, history_len=4)` point.
+
+## 5. Sweep axes and benchmark options
+
+### 5.1 Axes
+
+```cpp
+SweepAxes axes() const override {
+  return {
+      Axis::geom_range("branches",        1,        1 << 13, /*k=*/1),  // 1..8192
+      Axis::geom_range("total_outcomes",  1 << 13,  1 << 20, /*k=*/1),  // 8192..1048576
+  };
+}
+```
+
+Default Cartesian = 14 × 8 = 112 points. Typical run time ≈ 5 min
+with the standard 10-rep schedule.
+
+The `total_outcomes` lower bound is set to `2^13` so it equals the
+`branches` upper bound — every default Cartesian point satisfies
+`total_outcomes >= branches` (i.e., `pattern_period >= 1`). This
+matters because `run_command.cpp::measure_rows` aborts the whole
+sweep with a single `std::nullopt` when any point throws; the design
+must keep the default grid validation-clean. Users widening
+`--branches=...` past `8192` must also widen `--total_outcomes=...`
+correspondingly to avoid invalidation.
+
+The first axis `branches` varies slowest in the CSV (per ferret's
+column-order convention), matching `branch_history_footprint`.
+
+### 5.2 Per-bench options
+
+```cpp
+BenchOptions options() const override {
+  return {
+      BenchOption{.name = "bias_pct",       .default_value = 95},
+      BenchOption{.name = "nt_branch_pct",  .default_value = 50},
+      BenchOption{.name = "spacing_bytes",  .default_value = 16},
+  };
+}
+```
+
+- `--bias_pct=N`: percentage probability that a branch outputs its
+  *preferred* direction on each visit. `bias_pct=50` is unbiased
+  (random); `bias_pct=100` is constant. Default 95.
+- `--nt_branch_pct=N`: percentage of branches assigned NT-preferred.
+  The complement is T-preferred. Default 50 (even split, maximizes
+  destructive aliasing). `nt_branch_pct=0` recovers the single-
+  direction case; `nt_branch_pct=100` is the same scenario mirrored;
+  intermediate values yield asymmetric aliasing.
+- `--spacing_bytes=N`: per-site PC stride. Validated against
+  `kMinSiteBytes` and `kBranchAlign` as in `branch_history_footprint`.
+
+All options are int-typed because ferret's `BenchOption` carries an
+`int64_t` default. Percentage encoding (0..100) avoids float
+plumbing through the CLI / CSV.
+
+### 5.3 `sites_per_kernel` and `iterations`
+
+```cpp
+size_t sites_per_kernel(const Params& p) const override {
+  return p.get<size_t>("branches");
+}
+
+size_t iterations(const Params& p) const override {
+  return std::max<size_t>(1, 10'000'000 / p.get<size_t>("branches"));
+}
+```
+
+Per-site cost = ticks / (iterations × branches). The runner converts
+to cycles when `--freq` is set, nanoseconds otherwise.
+
+## 6. Class shape
+
+```cpp
+struct BiasConditionalBranchCount : Benchmark {
+  std::vector<uint32_t> flat_;
+  std::vector<sljit_label*> last_labels_;
+  size_t last_branches_ = 0;
+  size_t last_spacing_ = 0;
+
+  std::string name() const override { return "bias_conditional_branch_count"; }
+  SweepAxes  axes()    const override;
+  BenchOptions options() const override;
+  size_t sites_per_kernel(const Params&) const override;
+  size_t iterations(const Params&) const override;
+  void emit_kernel(sljit_compiler*, const Params&) override;
+  void verify_layout(sljit_compiler*) override;
+};
+
+FERRET_BENCHMARK("bias_conditional_branch_count", BiasConditionalBranchCount);
+```
+
+`emit_kernel` is responsible for: validating params, deriving
+`pattern_period`, resizing+filling `flat_` for the current
+`(branches, total_outcomes, bias_pct, nt_branch_pct)` point, then
+calling `emit_branch_chain` (§4.6) with the configured immediates.
+
+## 7. Pattern generation
+
+This is the only structural novelty vs. `branch_history_footprint`.
+
+### 7.1 Direction assignment
+
+Each of the `branches` PCs is assigned a *preferred* outcome
+direction (T or NT). The assignment is deterministic given `--seed`
+and the current `(branches, total_outcomes)` point: we shuffle the
+indices `[0, branches)` with a seeded `std::mt19937_64` and take the
+first `branches * nt_branch_pct / 100` indices as NT-preferred. This
+gives a spatially-mixed assignment (avoids stripe patterns like
+"all even indices NT") which keeps GHR contributions from adjacent
+sites balanced.
+
+### 7.2 Outcome fill
+
+For each `(t, j)` in the flat buffer:
+
+```cpp
+bool prefers_nt = nt_set.contains(j);                       // §7.1
+uint32_t prob_taken_q14 = prefers_nt
+    ? (100 - bias_pct) * 16384 / 100
+    : bias_pct           * 16384 / 100;
+uint32_t r = static_cast<uint32_t>(rng() & 0x3fff);         // 14-bit
+flat_[t * branches + j] = (r < prob_taken_q14) ? 1u : 0u;
+```
+
+The 14-bit fixed-point comparison is exact for integer `bias_pct ∈
+[0, 100]`, avoids floats, and keeps the RNG draw cheap. The outcome
+is `1` when the branch *should be taken* and `0` otherwise — matching
+the existing kernel's contract that `cbnz`/`jecxz` branch on nonzero.
+
+### 7.3 Seed mixing
+
+Two independent RNG streams to keep direction-assignment **stable
+across `total_outcomes` at fixed `branches`** (so a vertical slice
+through the surface holds the per-branch direction set fixed):
+
+```cpp
+// Direction assignment — independent of total_outcomes and bias_pct.
+uint64_t dir_seed = static_cast<uint64_t>(seed)
+                  ^ (static_cast<uint64_t>(branches)        * 0x9E3779B97F4A7C15ULL)
+                  ^ (static_cast<uint64_t>(nt_branch_pct)   * 0xD6E8FEB86659FD93ULL);
+std::mt19937_64 rng_dir(dir_seed);
+// ... shuffle [0, branches) and take first nt_count as NT-preferred ...
+
+// Outcome fill — uses full mix.
+uint64_t fill_seed = dir_seed
+                   ^ (static_cast<uint64_t>(total_outcomes)  * 0xBF58476D1CE4E5B9ULL)
+                   ^ (static_cast<uint64_t>(bias_pct)        * 0x94D049BB133111EBULL);
+std::mt19937_64 rng_fill(fill_seed);
+// ... fill flat_ ...
+```
+
+Distinct grid points and distinct option values get distinct fills.
+Three new mix constants (different odd 64-bit primes) are added to
+keep the convention extensible.
+
+## 8. CSV impact
+
+`bias_conditional_branch_count` adds two axis columns (`branches`,
+`total_outcomes`) and three option columns (`bias_pct`,
+`nt_branch_pct`, `spacing_bytes`) to the right of `benchmark`:
+
+```
+benchmark,branches,total_outcomes,bias_pct,nt_branch_pct,spacing_bytes,ticks_min,ticks_median,iterations,sites_per_kernel,cycles_per_site,ns_per_site
+bias_conditional_branch_count,1,4096,95,50,16,...
+bias_conditional_branch_count,1,8192,95,50,16,...
+...
+```
+
+No plot script changes needed. `scripts/plot.py heatmap`, `line`, and
+`surface` already operate on the generic axis-column convention.
+
+## 9. Error handling
+
+Pre-codegen validation in `emit_kernel`, thrown as
+`std::invalid_argument` *before* any sljit calls:
+
+- `branches < 1` → "branches must be >= 1".
+- `total_outcomes < 1` → "total_outcomes must be >= 1".
+- `total_outcomes < branches` → "total_outcomes (X) must be >=
+  branches (Y) so pattern_period >= 1".
+- `bias_pct < 0 || bias_pct > 100` → "bias_pct must be in [0, 100]".
+- `nt_branch_pct < 0 || nt_branch_pct > 100` → "nt_branch_pct must
+  be in [0, 100]".
+- `spacing_bytes < kMinSiteBytes` → same message as
+  `branch_history_footprint`.
+- `spacing_bytes % kBranchAlign != 0` → same message.
+
+Post-codegen verification in `verify_layout`: inherited from the
+shared emitter (§4.6).
+
+Buffer-allocation failure throws `std::bad_alloc`; propagated to the
+runner. At the default-axis max the buffer is 4 MB, well within any
+plausible RAM budget.
+
+## 10. Testing
+
+Mirrors `branch_history_footprint`'s test suite under
+`tests/test_bias_conditional_branch_count.cpp`.
+
+### 10.1 Unit tests
+
+- **Registry**: `bias_conditional_branch_count` resolves via
+  `BenchmarkRegistry::create`.
+- **Axes**: `axes()` returns two `geom_range` axes with names
+  `branches`, `total_outcomes` and the expected `(lo, hi, k)`.
+- **Options**: `options()` returns `bias_pct`, `nt_branch_pct`,
+  `spacing_bytes` with documented defaults.
+- **Validation**: invalid combinations from §9 throw
+  `std::invalid_argument` with the documented message prefixes.
+  Edge case `total_outcomes == branches` is accepted (yields
+  `pattern_period = 1`).
+- **Determinism of fill**: same `--seed` + same
+  `(branches, total_outcomes, bias_pct, nt_branch_pct)` produces
+  identical `flat_` contents.
+- **Direction-assignment stats**: with `nt_branch_pct=50, branches=
+  1024`, the assignment contains exactly 512 NT-preferred indices.
+  Test this with a public accessor on the benchmark instance
+  (`direction_view()` returning a `std::span<const uint8_t>` of
+  0/1 per branch).
+- **Outcome-distribution stats**: with `bias_pct=95, nt_branch_pct=
+  50, branches=64, total_outcomes=65536` (pattern_period=1024), the
+  per-branch outcome frequency on T-preferred branches lies in
+  [0.93, 0.97] and on NT-preferred branches in [0.03, 0.07] (3-sigma
+  bounds with `pattern_period=1024` samples).
+- **Site layout**: emit at `(branches=4, total_outcomes=16,
+  spacing=16)`, generate code, assert `verify_layout` accepts and
+  that site spacing matches.
+
+### 10.2 Integration test
+
+Smoke-run with very small axes (`branches=1..4`,
+`total_outcomes=8..32`) and assert:
+
+- CSV has 3 × 3 = 9 rows with the expected columns.
+- All `ticks_min > 0`.
+- The `bias_pct=50, nt_branch_pct=50` baseline (effectively uniform
+  random) produces cycles/site close to the
+  `branch_history_footprint --pattern=1` value at the same
+  `(branches, history_len)` point — confirming the kernel shape is
+  unchanged.
+
+### 10.3 Sanitizer matrix
+
+ASAN, UBSAN, TSAN clean — same matrix as other benchmarks. Highest-
+value targets: the new direction-assignment shuffle (off-by-one in
+the NT-set boundary), the fixed-point probability comparison
+(off-by-one at `bias_pct=0`/`100`).
+
+### 10.4 Manual platform check
+
+Before merging, run the full default sweep on both supported arches
+and confirm:
+
+- A floor region at small `branches` (cycles/site near the
+  `(1-p)·penalty + base` analytical floor).
+- A cliff at some intermediate `branches` value.
+- The cliff position is **invariant to `total_outcomes`** to within
+  ±1 octave on the geometric axis (i.e., a vertical wall in the
+  surface, not a diagonal ridge).
+
+If the cliff diagonally tracks `total_outcomes`, the diagonal-
+isolation claim is falsified for this CPU and the docs page must
+flag the result as "tagged-table-pressure-dominated, SC bias capacity
+not directly resolvable on this core."
+
+## 11. Reading the curves
+
+The 3D surface (`scripts/plot.py surface`) plots cycles/site as
+height over `(branches, total_outcomes)`. The expected shape is an
+**L-shaped high-cycles region** occupying the upper-right corner of
+the plane, bounded by two cliffs:
+
+1. **Lower-left plateau (low `branches`, low `total_outcomes`)** —
+   cycles/site at the predictor-memorized floor. Either pattern is
+   short enough for tagged tables to memorize (low `total_outcomes`)
+   or the PC set is small enough for SC bias to handle it (low
+   `branches`).
+2. **Cliff along `total_outcomes` at fixed high `branches`** —
+   horizontal wall. Crossing this cliff means the per-PC pattern
+   period exceeds what tagged tables can memorize; tagged tables
+   start churning. Cliff position ≈ tagged-table effective
+   memorization threshold for this `branches` value.
+3. **Cliff along `branches` at fixed high `total_outcomes`** —
+   vertical wall. **This is the SC-bias-table-capacity signature.**
+   Below the cliff, SC bias entries are unaliased; above, opposite-
+   bias PCs collide in SC slots and the saturated counter is pulled
+   toward zero → mispredicts at the aliased subset → cycles climb.
+4. **Upper-right plateau (high `branches`, high `total_outcomes`)** —
+   cycles/site at the high-mispredict ceiling. Neither predictor can
+   help: tagged tables churn, SC bias aliases destructively.
+
+The falsifiable SC-isolation claim is on cliff #3 specifically: its
+position along `branches` should be **invariant to `total_outcomes`**
+within the range above cliff #2 (the regime where TAGE is no longer
+memorizing). If cliff #3 instead slides diagonally with
+`total_outcomes`, the cliff isn't pure SC-capacity — tagged-table
+pressure is contributing, and the SC reading is confounded for this
+CPU.
+
+The cleanest 1D reduction is a `--filter=total_outcomes=N` line slice
+at any `N` well above the tagged-table threshold (e.g., the largest
+sampled `total_outcomes`). Plot cycles/site vs `branches`; read off
+the cliff x-position as the SC bias-table effective entry count.
+
+### 11.1 What changes when `bias_pct` or `nt_branch_pct` change
+
+- `bias_pct` controls the floor height: floor ≈
+  `(1 - bias_pct/100) · penalty + base`. Re-running with
+  `bias_pct ∈ {70, 80, 90, 95, 99}` and overlaying line slices gives
+  a family of curves with the same cliff position but different floor
+  heights.
+- `nt_branch_pct` controls the height of the post-cliff plateau:
+  with `nt_branch_pct=0` (all T-preferred), aliasing is constructive
+  and cliff #3 disappears (T0/SC entries that alias still agree on
+  T). At `nt_branch_pct=50` (default), cliff #3 is maximal.
+  Intermediate values produce intermediate cliffs — a useful
+  sanity-check that the destructive-aliasing mechanism is what's
+  driving the signal.
+
+### 11.1 What changes when `bias_pct` or `nt_branch_pct` change
+
+- `bias_pct` controls the floor height: floor ≈
+  `(1 - bias_pct/100) · penalty + base`. Re-running with
+  `bias_pct ∈ {70, 80, 90, 95, 99}` and overlaying line slices gives
+  a family of curves with the same cliff position but different floor
+  heights.
+- `nt_branch_pct` controls the height of the post-cliff plateau:
+  with `nt_branch_pct=0` (all T-preferred), aliasing is constructive
+  and the cliff disappears. At `nt_branch_pct=50` (default), the
+  cliff is maximal. Intermediate values produce intermediate cliffs
+  — a useful sanity-check that the destructive-aliasing mechanism is
+  what's driving the signal.
+
+## 12. Known limits
+
+- **Per-row L1d footprint at high `branches`.** With `uint32_t`
+  outcomes, the per-row footprint is `branches * 4` bytes. At
+  `branches = 8192` that's 32 KB — at or just past the L1d ceiling
+  on most current cores. Cycles/site beyond that point may reflect
+  *combined* SC-bias-cliff and L1d-miss effects. The cliff position
+  is typically below this threshold on shipping cores (SC bias
+  tables are 1K–16K entries; the cliff usually lands at 1K–8K),
+  but the caveat is documented and v2 may switch to a `uint8_t` or
+  bit-packed encoding to push the limit higher.
+- **T0 capacity may produce a secondary cliff.** TAGE's base
+  bimodal table is also PC-indexed. When `branches` exceeds T0
+  capacity (~4K on many cores), T0 also aliases. SC bias *can*
+  correct T0 alias when T0 fires (only as fallback), so the
+  observable cliff is the SC capacity. If SC bias is smaller than
+  T0, the dominant cliff is SC; if SC bias is larger than T0, there
+  may be a small secondary step at T0 capacity before the main SC
+  cliff. Document and interpret per-CPU.
+- **Other SC sub-components.** SC has GHIST / PATH / IMLI tables
+  beyond BIAS. They may partially correct what BIAS cannot, blurring
+  the cliff. The aperiodic, history-independent design minimizes the
+  contribution of GHIST/PATH; IMLI is loop-iteration-correlated and
+  doesn't engage on this workload.
+- **Predictor noise floor.** The min-of-K rep schedule mitigates
+  but does not eliminate run-to-run variance. Standard caveat.
+- **Outer-loop tax at `branches=1`.** Same as
+  `branch_history_footprint`. The leftmost column is a tax baseline.
+- **Apple Silicon pinning.** Inherits the per-cluster-not-per-core
+  caveat from the project README.
+- **Single-CPU experiment.** No TAGE-only reference. The falsifiable
+  claim is on the *shape* of the surface (cliff invariance to
+  `total_outcomes`), interpreted per-CPU.
+
+## 13. Future work (out of v1)
+
+- `uint8_t` or bit-packed outcome storage to push the per-row L1d
+  ceiling higher and allow `branches` sweeps to 64K+, exposing SC
+  bias tables of any plausible size on shipping cores.
+- Companion benchmark `t0_bias_collision` (Route 1 from
+  brainstorming) — defeat T0 by PC-low-bit collision and read SC's
+  rescue behavior. Different experimental design, separate benchmark.
+- `bias_pct` and `nt_branch_pct` as Cartesian sweep axes for a
+  full 4D study (`branches × total_outcomes × bias × nt_split`).
+  v1 keeps them as per-run options to stay within ferret's
+  established 2D-axis convention.
+- Per-branch bias from a continuous distribution (e.g., Beta(α, β))
+  rather than binary T-or-NT-preferred, to study how the cliff
+  changes when biases are graded rather than bimodal.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,6 +122,17 @@ target_link_libraries(test_branch_history_footprint PRIVATE
 )
 gtest_discover_tests(test_branch_history_footprint)
 
+add_executable(test_bias_conditional_branch_count
+  test_bias_conditional_branch_count.cpp
+  ../benchmarks/bias_conditional_branch_count.cpp
+)
+target_link_libraries(test_bias_conditional_branch_count PRIVATE
+  ferret_core
+  sljit::sljit
+  GTest::gtest GTest::gtest_main
+)
+gtest_discover_tests(test_bias_conditional_branch_count)
+
 add_executable(test_jit test_jit.cpp)
 target_link_libraries(test_jit PRIVATE
   ferret_core

--- a/tests/test_bias_conditional_branch_count.cpp
+++ b/tests/test_bias_conditional_branch_count.cpp
@@ -1,0 +1,295 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "ferret/benchmark.hpp"
+#include "ferret/params.hpp"
+
+extern "C" {
+#include <sljitLir.h>
+}
+
+namespace ferret::bias_conditional_branch_count_internal {
+std::vector<uint8_t> assign_directions(size_t branches, int64_t nt_branch_pct, uint64_t seed);
+std::vector<uint32_t> generate_pattern_fill(size_t branches, size_t pattern_period, int64_t bias_pct,
+                                              int64_t nt_branch_pct, uint64_t seed);
+struct LayoutSnapshot {
+  std::vector<sljit_label*> labels;
+  size_t branches;
+  size_t spacing;
+};
+LayoutSnapshot last_layout_snapshot();
+}  // namespace ferret::bias_conditional_branch_count_internal
+
+namespace {
+ferret::Params make_params(int64_t branches, int64_t total_outcomes, int64_t bias = 95, int64_t nt = 50,
+                            int64_t spacing = 16) {
+  ferret::Params p;
+  p.set("branches", branches);
+  p.set("total_outcomes", total_outcomes);
+  p.set("bias_pct", bias);
+  p.set("nt_branch_pct", nt);
+  p.set("spacing_bytes", spacing);
+  p.set("seed", 1);
+  return p;
+}
+const ferret::BenchOption* find_option(const ferret::BenchOptions& opts, const std::string& name) {
+  for (const auto& o : opts) {
+    if (o.name == name) return &o;
+  }
+  return nullptr;
+}
+struct CompilerHandle {
+  sljit_compiler* c = sljit_create_compiler(nullptr);
+  ~CompilerHandle() {
+    if (c) sljit_free_compiler(c);
+  }
+};
+}  // namespace
+
+TEST(BiasConditionalBranchCount, RegistryLookupReturnsBenchmark) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->name(), "bias_conditional_branch_count");
+}
+
+TEST(BiasConditionalBranchCount, ExposesBranchesAndTotalOutcomesAxes) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  auto axes = b->axes();
+  ASSERT_EQ(axes.size(), 2u);
+  EXPECT_EQ(axes[0].name(), "branches");
+  EXPECT_EQ(axes[1].name(), "total_outcomes");
+}
+
+TEST(BiasConditionalBranchCount, BranchesAxisExpansionMatchesSpec) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  auto vs = b->axes()[0].expand();
+  // 1..8192 with k=1: {1,2,4,…,8192} = 14 points.
+  EXPECT_EQ(vs.size(), 14u);
+  EXPECT_EQ(vs.front(), 1);
+  EXPECT_EQ(vs.back(), 8192);
+}
+
+TEST(BiasConditionalBranchCount, TotalOutcomesAxisExpansionMatchesSpec) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  auto vs = b->axes()[1].expand();
+  // 8192..1048576 with k=1: 8 points.
+  EXPECT_EQ(vs.size(), 8u);
+  EXPECT_EQ(vs.front(), 8192);
+  EXPECT_EQ(vs.back(), 1048576);
+}
+
+TEST(BiasConditionalBranchCount, DefaultAxisGridIsValidationClean) {
+  // total_outcomes_min must be >= branches_max so pattern_period >= 1
+  // at every default Cartesian point. spec §5.1.
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  auto axes = b->axes();
+  auto branches = axes[0].expand();
+  auto totals = axes[1].expand();
+  EXPECT_GE(totals.front(), branches.back());
+}
+
+TEST(BiasConditionalBranchCount, ExposesAllThreeOptions) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  auto opts = b->options();
+  ASSERT_EQ(opts.size(), 3u);
+  EXPECT_EQ(find_option(opts, "bias_pct")->default_value, 95);
+  EXPECT_EQ(find_option(opts, "nt_branch_pct")->default_value, 50);
+  EXPECT_EQ(find_option(opts, "spacing_bytes")->default_value, 16);
+}
+
+TEST(BiasConditionalBranchCount, SitesPerKernelEqualsBranches) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->sites_per_kernel(make_params(32, 65536)), 32u);
+  EXPECT_EQ(b->sites_per_kernel(make_params(1, 8192)), 1u);
+}
+
+TEST(BiasConditionalBranchCount, IterationsAmortizesAtTenMillionSites) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->iterations(make_params(1, 8192)), 10'000'000u);
+  EXPECT_EQ(b->iterations(make_params(100, 65536)), 100'000u);
+  EXPECT_EQ(b->iterations(make_params(10'000'001, 65536)), 1u);
+}
+
+TEST(BiasConditionalBranchCount, DirectionAssignmentHonorsNtBranchPct) {
+  auto dirs = ferret::bias_conditional_branch_count_internal::assign_directions(/*branches=*/1024,
+                                                                                  /*nt_branch_pct=*/50, /*seed=*/1);
+  ASSERT_EQ(dirs.size(), 1024u);
+  size_t nt = 0;
+  for (uint8_t d : dirs) {
+    EXPECT_TRUE(d == 0u || d == 1u);
+    nt += d;
+  }
+  EXPECT_EQ(nt, 512u);
+}
+
+TEST(BiasConditionalBranchCount, DirectionAssignmentDeterministicForSameSeed) {
+  auto a = ferret::bias_conditional_branch_count_internal::assign_directions(64, 50, 42);
+  auto b = ferret::bias_conditional_branch_count_internal::assign_directions(64, 50, 42);
+  EXPECT_EQ(a, b);
+}
+
+TEST(BiasConditionalBranchCount, DirectionAssignmentDiffersBetweenSeeds) {
+  auto a = ferret::bias_conditional_branch_count_internal::assign_directions(64, 50, 42);
+  auto b = ferret::bias_conditional_branch_count_internal::assign_directions(64, 50, 43);
+  EXPECT_NE(a, b);
+}
+
+TEST(BiasConditionalBranchCount, DirectionAssignmentAllTPreferredWhenZero) {
+  auto dirs = ferret::bias_conditional_branch_count_internal::assign_directions(128, 0, 1);
+  for (uint8_t d : dirs) EXPECT_EQ(d, 0u);
+}
+
+TEST(BiasConditionalBranchCount, DirectionAssignmentAllNtPreferredWhenHundred) {
+  auto dirs = ferret::bias_conditional_branch_count_internal::assign_directions(128, 100, 1);
+  for (uint8_t d : dirs) EXPECT_EQ(d, 1u);
+}
+
+TEST(BiasConditionalBranchCount, FillIsZeroOrOnePerCell) {
+  auto v = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(
+      /*branches=*/8, /*pattern_period=*/32, /*bias_pct=*/95, /*nt_branch_pct=*/50, /*seed=*/7);
+  ASSERT_EQ(v.size(), 256u);
+  for (uint32_t x : v) {
+    EXPECT_TRUE(x == 0u || x == 1u);
+  }
+}
+
+TEST(BiasConditionalBranchCount, FillDeterministicForSameSeed) {
+  auto a = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(8, 32, 95, 50, 7);
+  auto b = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(8, 32, 95, 50, 7);
+  EXPECT_EQ(a, b);
+}
+
+TEST(BiasConditionalBranchCount, FillDiffersBetweenSeeds) {
+  auto a = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(8, 32, 95, 50, 7);
+  auto b = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(8, 32, 95, 50, 8);
+  EXPECT_NE(a, b);
+}
+
+TEST(BiasConditionalBranchCount, FillDiffersByBiasPct) {
+  auto a = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(8, 256, 95, 50, 1);
+  auto b = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(8, 256, 50, 50, 1);
+  EXPECT_NE(a, b);
+}
+
+TEST(BiasConditionalBranchCount, FillFrequencyTracksBiasOnTPreferred) {
+  // Spec §10.1: 3-sigma bounds at p=0.95, n=1024.
+  auto v = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(
+      /*branches=*/64, /*pattern_period=*/1024, /*bias_pct=*/95, /*nt_branch_pct=*/0, /*seed=*/11);
+  size_t ones = 0;
+  for (size_t t = 0; t < 1024; ++t) ones += v[t * 64 + 0];
+  double freq = static_cast<double>(ones) / 1024.0;
+  EXPECT_GT(freq, 0.93);
+  EXPECT_LT(freq, 0.97);
+}
+
+TEST(BiasConditionalBranchCount, FillFrequencyMirrorsBiasOnNtPreferred) {
+  auto v = ferret::bias_conditional_branch_count_internal::generate_pattern_fill(
+      /*branches=*/64, /*pattern_period=*/1024, /*bias_pct=*/95, /*nt_branch_pct=*/100, /*seed=*/11);
+  size_t ones = 0;
+  for (size_t t = 0; t < 1024; ++t) ones += v[t * 64 + 0];
+  double freq = static_cast<double>(ones) / 1024.0;
+  EXPECT_GT(freq, 0.03);
+  EXPECT_LT(freq, 0.07);
+}
+
+TEST(BiasConditionalBranchCount, RejectsZeroBranches) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(0, 8192)), std::invalid_argument);
+}
+
+TEST(BiasConditionalBranchCount, RejectsZeroTotalOutcomes) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(1, 0)), std::invalid_argument);
+}
+
+TEST(BiasConditionalBranchCount, RejectsTotalOutcomesBelowBranches) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(64, 32)), std::invalid_argument);
+}
+
+TEST(BiasConditionalBranchCount, RejectsBiasPctOutOfRange) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(1, 8192, /*bias=*/-1)), std::invalid_argument);
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(1, 8192, /*bias=*/101)), std::invalid_argument);
+}
+
+TEST(BiasConditionalBranchCount, RejectsNtBranchPctOutOfRange) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(1, 8192, 95, /*nt=*/-1)), std::invalid_argument);
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(1, 8192, 95, /*nt=*/101)), std::invalid_argument);
+}
+
+TEST(BiasConditionalBranchCount, RejectsSpacingBytesTooSmall) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(1, 8192, 95, 50, /*spacing=*/4)), std::invalid_argument);
+}
+
+TEST(BiasConditionalBranchCount, EmitsValidKernelForSmallParams) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  auto p = make_params(/*branches=*/4, /*total_outcomes=*/16, /*bias=*/95, /*nt=*/50, /*spacing=*/16);
+  ASSERT_NO_THROW(b->emit_kernel(ch.c, p));
+  ASSERT_EQ(sljit_get_compiler_error(ch.c), SLJIT_SUCCESS);
+
+  void* code = sljit_generate_code(ch.c, 0, nullptr);
+  ASSERT_NE(code, nullptr);
+  ASSERT_NO_THROW(b->verify_layout(ch.c));
+  sljit_free_code(code, nullptr);
+}
+
+TEST(BiasConditionalBranchCount, EmitsAcceptsEdgeCaseTotalOutcomesEqualsBranches) {
+  // total_outcomes == branches → pattern_period == 1.
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  auto p = make_params(/*branches=*/4, /*total_outcomes=*/4);
+  ASSERT_NO_THROW(b->emit_kernel(ch.c, p));
+  ASSERT_EQ(sljit_get_compiler_error(ch.c), SLJIT_SUCCESS);
+  void* code = sljit_generate_code(ch.c, 0, nullptr);
+  ASSERT_NE(code, nullptr);
+  sljit_free_code(code, nullptr);
+}
+
+TEST(BiasConditionalBranchCount, LayoutSnapshotMeetsMinimumSpacing) {
+  auto b = ferret::BenchmarkRegistry::create("bias_conditional_branch_count");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  b->emit_kernel(ch.c, make_params(/*branches=*/4, /*total_outcomes=*/16, /*bias=*/95, /*nt=*/50, /*spacing=*/16));
+  void* code = sljit_generate_code(ch.c, 0, nullptr);
+  ASSERT_NE(code, nullptr);
+  b->verify_layout(ch.c);
+
+  auto snap = ferret::bias_conditional_branch_count_internal::last_layout_snapshot();
+  ASSERT_EQ(snap.branches, 4u);
+  ASSERT_EQ(snap.spacing, 16u);
+  ASSERT_EQ(snap.labels.size(), 5u);
+  sljit_uw base = sljit_get_label_addr(snap.labels[0]);
+  for (size_t i = 1; i <= snap.branches; ++i) {
+    sljit_uw addr = sljit_get_label_addr(snap.labels[i]);
+    EXPECT_GE(addr - base, i * snap.spacing) << "site " << i << " closer than min spacing";
+  }
+  sljit_free_code(code, nullptr);
+}

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -651,3 +651,53 @@ TEST(Integration, NestedCallDepthLongSweepRowCount) {
   EXPECT_EQ(newlines, 65u) << "expected 1 header + 64 data rows";
   EXPECT_EQ(contents.find(",,"), std::string::npos);
 }
+
+TEST(Integration, BiasConditionalBranchCountProducesExpectedRowCount) {
+  auto out = std::filesystem::temp_directory_path() / "ferret_bcbc.csv";
+  std::filesystem::remove(out);
+  // branches ∈ {1, 2, 4} × total_outcomes ∈ {8, 16} → 6 data rows.
+  std::string cmd = std::string(FERRET_BINARY) +
+                    " run bias_conditional_branch_count"
+                    " --branches=1..4 --total_outcomes=8..16"
+                    " --bias_pct=95 --nt_branch_pct=50"
+                    " --reps=3 --warmup=1"
+                    " --out=" +
+                    out.string();
+  ASSERT_EQ(0, run(cmd));
+
+  std::string contents = slurp(out.string());
+  size_t newlines = std::count(contents.begin(), contents.end(), '\n');
+  EXPECT_EQ(newlines, 7u);  // header + 6 data rows
+  EXPECT_EQ(contents.find(",,\n"), std::string::npos);
+}
+
+TEST(Integration, BiasConditionalBranchCountHeaderHasExpectedColumns) {
+  auto out = std::filesystem::temp_directory_path() / "ferret_bcbc_hdr.csv";
+  std::filesystem::remove(out);
+  std::string cmd = std::string(FERRET_BINARY) +
+                    " run bias_conditional_branch_count"
+                    " --branches=1 --total_outcomes=8"
+                    " --reps=2 --warmup=1"
+                    " --out=" +
+                    out.string();
+  ASSERT_EQ(0, run(cmd));
+
+  std::string contents = slurp(out.string());
+  EXPECT_NE(contents.find("branches"), std::string::npos);
+  EXPECT_NE(contents.find("total_outcomes"), std::string::npos);
+  EXPECT_NE(contents.find("bias_pct"), std::string::npos);
+  EXPECT_NE(contents.find("nt_branch_pct"), std::string::npos);
+  EXPECT_NE(contents.find("spacing_bytes"), std::string::npos);
+}
+
+TEST(Integration, BiasConditionalBranchCountRejectsTotalOutcomesBelowBranches) {
+  auto out = std::filesystem::temp_directory_path() / "ferret_bcbc_bad.csv";
+  std::filesystem::remove(out);
+  std::string cmd = std::string(FERRET_BINARY) +
+                    " run bias_conditional_branch_count"
+                    " --branches=64 --total_outcomes=8"
+                    " --reps=1 --warmup=0"
+                    " --out=" +
+                    out.string();
+  EXPECT_NE(0, run(cmd));
+}


### PR DESCRIPTION
## Summary

Adds ferret's fifth benchmark, `bias_conditional_branch_count`, which probes the **SC (Statistical Corrector) bias-table capacity** in TAGE-SC-L–style direction predictors.

Mixed-direction biased conditional branches (default 50/50 split between T-preferred and NT-preferred PCs, each emitting Bernoulli(`bias_pct`/100) outcomes toward its preferred direction) driven by a long pre-generated aperiodic pattern. Sweeps `branches × total_outcomes`; holding `total_outcomes` constant while varying `branches` isolates the SC bias-table PC-count pressure from TAGE tagged-table volume pressure, so the cliff position along `branches` reads as the effective SC bias-table capacity.

- `benchmarks/bias_conditional_branch_count.cpp` — kernel using upstream's `bench_helpers` primitives (`emit_outer_loop`, `compute_iterations`, `verify_uniform_spacing`, `mix_seed`), mirroring `branch_history_footprint`'s shape.
- Default axes: `branches=1..8192`, `total_outcomes=8192..1048576` (14 × 8 = 112 Cartesian points, every point satisfies `total_outcomes >= branches`).
- Per-bench options: `bias_pct` (default 95), `nt_branch_pct` (default 50, max destructive aliasing), `spacing_bytes` (default 16).
- Two independent RNG streams (direction assignment + outcome fill) keep direction assignment **stable across `total_outcomes` at fixed (`branches`, `nt_branch_pct`, `seed`)** — load-bearing for the experimental design (spec §7.3).
- Spec + plan in `docs/superpowers/{specs,plans}/`; per-benchmark doc page with reading-the-curves guide; README table entry.

## Why this design distinguishes SC from TAGE

A naive "biased branch with random history pollution" benchmark does **not** distinguish SC from TAGE, because TAGE's base predictor T0 is itself a per-PC bias counter and saturates on i.i.d. biased data. The two design choices that make the cliff visible:

1. **Long aperiodic patterns** force perpetual tagged-table re-allocation: TAGE allocates entries on mispredict (initialized weakly toward the triggering — minority — direction), the pattern never repeats during measurement, tagged entries never reach saturation, and noisy tagged predictions override T0's correct bias signal. SC's bias table is updated on every visit independent of allocation and stays saturated.
2. **Mixed-direction biases** create destructive aliasing in the SC bias table once `branches` exceeds capacity: opposite-bias PCs that hash to the same SC slot pull the saturated counter toward zero, and the cliff appears. Single-direction would not produce a cliff because aliased entries still agree.

The falsifiable claim is that the cliff position along `branches` is **invariant to `total_outcomes`** — if it slides diagonally, the reading is tagged-table-dominated and the SC isolation is confounded on this CPU.

## Test plan

- [x] \`ctest\` — 228/228 passing on the rebased base (197 baseline + 28 new unit tests + 3 new integration tests).
- [x] \`ferret list\` — \`bias_conditional_branch_count\` registered.
- [x] Smoke run (\`--branches=1..16 --total_outcomes=64..256\`) — CSV schema correct, all rows have positive ticks.
- [ ] Manual platform check: full default sweep on an x86_64 Linux box + Apple M-series, confirm the surface shape matches the L-shape predicted in the spec (vertical cliff along \`branches\` invariant to \`total_outcomes\`). Documented in spec §10.4 as a manual verification step.

## Notable design caveat

At \`branches=8192\` the per-row L1d footprint with \`uint32_t\` outcomes is 32 KB — at or just past the L1d ceiling on most x86 cores. The benchmark's doc page calls this out; if real-CPU runs show a confounding cliff at that branch count, the spec's future-work section notes a \`uint8_t\`/bit-packed encoding as the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)