### PR TITLE
ci(plot): cover kaleido PNG export on Linux/macOS/Nix

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,3 +26,77 @@ jobs:
 
       - name: run ferret_plot pytest suite (in devshell)
         run: nix develop --command ./scripts/test_py.sh
+
+  png-integration:
+    # Exercise the kaleido PNG path end-to-end on three environments:
+    #   - linux-nix: Nix devshell, kaleido 0.2.1 from nixpkgs + pkgs.chromium
+    #   - linux-pip: ubuntu-latest with pip kaleido>=1.0 + preinstalled
+    #     google-chrome-stable on the runner image
+    #   - macos-pip: macos-latest with pip kaleido>=1.0 + preinstalled
+    #     Google Chrome.app
+    # Surface PNG triggers the WebGL/SwiftShader fallback in output.py;
+    # heatmap PNG goes through the standard kaleido canvas path.
+    name: png-integration (${{ matrix.label }})
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: linux-nix
+            os: ubuntu-latest
+            via: nix
+          - label: linux-pip
+            os: ubuntu-latest
+            via: pip
+          - label: macos-pip
+            os: macos-latest
+            via: pip
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: install Nix
+        if: matrix.via == 'nix'
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25  # v22
+
+      - name: setup Python
+        if: matrix.via == 'pip'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: install Python deps (pip)
+        if: matrix.via == 'pip'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+
+      - name: locate Chrome / Chromium
+        shell: bash
+        run: |
+          # Fail fast if no headless Chrome is reachable. Mirrors the
+          # search performed by ferret_plot.output._find_chrome_executable
+          # so a passing probe here means the test gate won't skip.
+          mac_chrome="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+          for name in chromium chromium-browser chrome Chrome google-chrome google-chrome-stable; do
+            if command -v "$name" >/dev/null 2>&1; then
+              echo "found $(command -v "$name")"
+              exit 0
+            fi
+          done
+          if [ -x "$mac_chrome" ]; then
+            echo "found $mac_chrome"
+            exit 0
+          fi
+          echo "::error::no Chrome/Chromium binary on PATH or in /Applications"
+          exit 1
+
+      - name: run integration tests (nix devshell)
+        if: matrix.via == 'nix'
+        run: nix develop --command python3 -m pytest tests/python -m integration -v
+
+      - name: run integration tests (pip)
+        if: matrix.via == 'pip'
+        run: python -m pytest tests/python -m integration -v

--- a/scripts/ferret_plot/output.py
+++ b/scripts/ferret_plot/output.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import subprocess
 import tempfile
 import webbrowser
 from pathlib import Path
@@ -55,6 +56,9 @@ _INSTALL_HINT = (
     "the binary, or run `python -m plotly.io._kaleido install_chrome` "
     "to install a portable headless chrome."
 )
+_WEBGL_EXPORT_HINT = (
+    "surface PNG export needs Chrome or Chromium on PATH so ferret can render Plotly WebGL with SwiftShader"
+)
 
 # Module-level cache so we probe at most once per process.
 _chrome_probe_cache: dict[str, bool] = {}
@@ -89,6 +93,20 @@ def _chrome_available() -> bool:
     if any(shutil.which(name) is not None for name in _CHROME_NAMES):
         return True
     return any(os.path.isfile(p) and os.access(p, os.X_OK) for p in _MACOS_CHROME_PATHS)
+
+
+def _find_chrome_executable() -> str | None:
+    browser_path = os.environ.get("BROWSER_PATH")
+    if browser_path and os.path.isfile(browser_path) and os.access(browser_path, os.X_OK):
+        return browser_path
+    for name in _CHROME_NAMES:
+        path = shutil.which(name)
+        if path is not None:
+            return path
+    for path in _MACOS_CHROME_PATHS:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+    return None
 
 
 def _resolve_format(out: str | None, fmt: str | None) -> str:
@@ -151,6 +169,45 @@ def _surface_canvas(fig: Any) -> tuple[int, int]:
     return width, height
 
 
+def _has_surface_trace(fig: Any) -> bool:
+    return any(getattr(trace, "type", "") == "surface" for trace in fig.data)
+
+
+def _is_kaleido_canvas_error(exc: Exception) -> bool:
+    msg = str(exc)
+    return "error code 525" in msg and "canvas/context" in msg
+
+
+def _write_chromium_webgl_png(fig: Any, out: str, *, width: int, height: int) -> None:
+    """Render Plotly WebGL via external headless Chromium and screenshot it."""
+    chrome = _find_chrome_executable()
+    if chrome is None:
+        raise PlotError(_WEBGL_EXPORT_HINT)
+
+    with tempfile.TemporaryDirectory(prefix="ferret-plot-webgl-") as tmpdir:
+        html_path = Path(tmpdir) / "surface.html"
+        # Inline Plotly JS avoids network/CDN stalls in headless Chrome.
+        fig.write_html(str(html_path), include_plotlyjs=True, full_html=True)
+        cmd = [
+            chrome,
+            "--headless",
+            "--no-sandbox",
+            "--enable-webgl",
+            "--ignore-gpu-blocklist",
+            "--enable-unsafe-swiftshader",
+            "--use-angle=swiftshader",
+            "--virtual-time-budget=5000",
+            f"--screenshot={out}",
+            f"--window-size={width},{height}",
+            f"file://{html_path}",
+        ]
+        try:
+            subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=30)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            detail = getattr(e, "stderr", "") or str(e)
+            raise PlotError(f"surface PNG WebGL export failed: {detail}") from e
+
+
 def emit(fig: Any, *, out: str | None, fmt: str | None, html_js: str) -> None:
     """Write `fig` to `out` (or open in browser if `out is None`).
 
@@ -181,4 +238,10 @@ def emit(fig: Any, *, out: str | None, fmt: str | None, html_js: str) -> None:
     # Image format => kaleido path. Probe Chrome first.
     _check_chrome()
     width, height = _image_size(fig)
-    fig.write_image(out, format=resolved, width=width, height=height, scale=2)
+    try:
+        fig.write_image(out, format=resolved, width=width, height=height, scale=2)
+    except ValueError as e:
+        if resolved == "png" and _has_surface_trace(fig) and _is_kaleido_canvas_error(e):
+            _write_chromium_webgl_png(fig, out, width=width, height=height)
+            return
+        raise

--- a/scripts/ferret_plot/output.py
+++ b/scripts/ferret_plot/output.py
@@ -202,7 +202,7 @@ def _write_chromium_webgl_png(fig: Any, out: str, *, width: int, height: int) ->
             f"file://{html_path}",
         ]
         try:
-            subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=30)
+            subprocess.run(cmd, check=True, capture_output=True, text=True, timeout=30)
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             detail = getattr(e, "stderr", "") or str(e)
             raise PlotError(f"surface PNG WebGL export failed: {detail}") from e

--- a/tests/python/test_integration_export.py
+++ b/tests/python/test_integration_export.py
@@ -1,51 +1,50 @@
-"""End-to-end image export via kaleido.
+"""End-to-end PNG export via kaleido.
 
-This test actually launches a headless Chrome through kaleido and is
-slow + dependency-heavy. It's marked `integration` and skipped on
-hosts without Chrome on PATH. Run with: pytest -m integration.
+Each test launches a real headless Chrome through kaleido, so the suite
+is slow + dependency-heavy and lives behind the `integration` marker.
+The gate mirrors `ferret_plot.output._find_chrome_executable` so a host
+that satisfies the production probe also satisfies the test.
+
+Run with: pytest -m integration.
+
+The matrix exercises two PNG paths:
+
+- heatmap: standard kaleido write_image (Plotly canvas)
+- surface: WebGL fallback via headless Chromium SwiftShader, since
+  kaleido fails on 3D scenes with the "error code 525" canvas error.
 """
 
 from __future__ import annotations
 
-import shutil
 from pathlib import Path
 
 import pytest
 from ferret_plot import cli
+from ferret_plot.output import _find_chrome_executable
 from fixtures import tage_capacity_df
-
-_CHROME_NAMES = (
-    "chromium",
-    "chromium-browser",
-    "chrome",
-    "Chrome",
-    "google-chrome",
-    "google-chrome-stable",
-)
 
 
 def _chrome_present() -> bool:
-    return any(shutil.which(n) is not None for n in _CHROME_NAMES)
+    return _find_chrome_executable() is not None
+
+
+_AXIS_ARGS = ["--x", "branch_amount", "--y", "pattern_amount"]
 
 
 @pytest.mark.integration
 @pytest.mark.skipif(not _chrome_present(), reason="kaleido needs Chrome on PATH")
-def test_surface_png_round_trip(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("kind", "filename"),
+    [
+        ("heatmap", "heatmap.png"),
+        ("surface", "surface.png"),
+    ],
+)
+def test_png_round_trip(tmp_path: Path, kind: str, filename: str) -> None:
     csv_path = tmp_path / "tage.csv"
     tage_capacity_df().to_csv(csv_path, index=False)
-    out = tmp_path / "surface.png"
-    rc = cli.main(
-        [
-            "surface",
-            str(csv_path),
-            "--x",
-            "branch_amount",
-            "--y",
-            "pattern_amount",
-            "--out",
-            str(out),
-        ]
-    )
+    out = tmp_path / filename
+    rc = cli.main([kind, str(csv_path), *_AXIS_ARGS, "--out", str(out)])
     assert rc == 0
     assert out.exists()
     assert out.stat().st_size > 1024  # nontrivial PNG, not just header

--- a/tests/python/test_output.py
+++ b/tests/python/test_output.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 import types
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import plotly.graph_objects as go
@@ -89,6 +90,30 @@ class TestChromeProbe:
         monkeypatch.setattr(output, "_chrome_available", lambda: False)
         with pytest.raises(PlotError, match="Chrome or Chromium"):
             output.emit(fig, out=str(tmp_path / "x.png"), fmt=None, html_js="cdn")
+
+
+class TestSurfaceWebglFallback:
+    def test_surface_png_uses_chromium_webgl_when_kaleido_canvas_fails(self, tmp_path, monkeypatch):
+        fig = go.Figure(data=[go.Surface(z=[[1.0, 2.0], [3.0, 4.0]])])
+
+        def fail_write_image(*_args, **_kwargs):
+            raise ValueError("Transform failed with error code 525: error creating static canvas/context")
+
+        calls = []
+
+        def fake_webgl(fig_arg, out_arg, *, width, height):
+            calls.append((fig_arg, out_arg, width, height))
+            Path(out_arg).write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        monkeypatch.setattr(output, "_chrome_available", lambda: True)
+        monkeypatch.setattr(fig, "write_image", fail_write_image)
+        monkeypatch.setattr(output, "_write_chromium_webgl_png", fake_webgl)
+
+        out = tmp_path / "surface.png"
+        output.emit(fig, out=str(out), fmt=None, html_js="cdn")
+
+        assert calls == [(fig, str(out), 2400, 1000)]
+        assert out.read_bytes() == b"\x89PNG\r\n\x1a\n"
 
 
 class TestChromeAvailable:


### PR DESCRIPTION
## Summary

- Adds a chromium-driven WebGL fallback so surface PNG export no longer fails on kaleido's `error code 525: canvas/context` (commit a82c782).
- Adds a `png-integration` CI job that runs the chrome-gated kaleido suite across **linux-nix**, **linux-pip**, and **macos-pip**, so the surface fallback and the heatmap kaleido-canvas path are both exercised on every PR.
- Parametrizes `test_integration_export.py` over `(heatmap, surface)` and reuses `ferret_plot.output._find_chrome_executable` for the skip gate so the test matches production discovery (BROWSER_PATH override, macOS app-bundle paths).
- Inline `ruff UP022` cleanup in `output.py` (`subprocess.run(..., capture_output=True)`) so lint CI stays green.

## CI matrix

| label       | runner          | python    | chrome source                        | kaleido           |
|-------------|-----------------|-----------|--------------------------------------|-------------------|
| linux-nix   | ubuntu-latest   | nix py3   | `pkgs.chromium`                      | 0.2.1 (nixpkgs)   |
| linux-pip   | ubuntu-latest   | 3.12      | preinstalled `google-chrome-stable`  | `>=1.0` from pip  |
| macos-pip   | macos-latest    | 3.12      | preinstalled `Google Chrome.app`     | `>=1.0` from pip  |

Each cell probes the runner for a Chrome/Chromium binary before invoking pytest, so a missing browser fails the job loudly instead of letting the integration test silently skip.

## Test plan

- [x] `nix develop --command python3 -m pytest tests/python -v` (113 passed locally, including both integration cases).
- [x] `nix develop --command ruff format --check scripts/ tests/python/`
- [x] `nix develop --command ruff check scripts/ tests/python/`
- [ ] `python.yml / png-integration (linux-nix)` green on CI.
- [ ] `python.yml / png-integration (linux-pip)` green on CI.
- [ ] `python.yml / png-integration (macos-pip)` green on CI.