### PR TITLE
refactor: code-review cleanup across plot engine, runner, and build

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -25,9 +25,3 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25  # v22
       - name: flake check
         run: nix flake check
-      - name: build
-        run: nix build
-      - name: test in devshell
-        run: |
-          nix develop --command bash -c \
-            "cmake -S . -B build -GNinja && cmake --build build && ctest --test-dir build --output-on-failure"

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -42,7 +42,15 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install ninja
 
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
+        with:
+          key: ${{ matrix.os }}-${{ matrix.sanitizer }}-${{ hashFiles('CMakeLists.txt', 'flake.lock') }}
+
       - name: configure
+        env:
+          CMAKE_C_COMPILER_LAUNCHER: ccache
+          CMAKE_CXX_COMPILER_LAUNCHER: ccache
         run: >
           cmake -S . -B build -GNinja
           -DCMAKE_BUILD_TYPE=Debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,19 +187,31 @@ add_library(ferret_core STATIC
   src/permute.cpp
 )
 target_include_directories(ferret_core PUBLIC include)
-target_link_libraries(ferret_core PUBLIC sljit::sljit spdlog::spdlog)
-target_link_libraries(ferret_core PRIVATE ferret_warnings)
+# spdlog is PUBLIC: log.hpp exposes spdlog::format_string_t in its template
+# signatures, so consumers need the header on their include path.
+# sljit is PRIVATE: only ferret_core .cpp files call into it; no public
+# header leaks sljit types into the API.
+target_link_libraries(ferret_core PUBLIC spdlog::spdlog)
+target_link_libraries(ferret_core PRIVATE sljit::sljit ferret_warnings)
 target_compile_features(ferret_core PUBLIC cxx_std_20)
+
+# Benchmark TUs compiled once; both the ferret executable and benchmark-
+# specific tests reuse the resulting object files.
+add_library(ferret_benchmarks OBJECT
+  benchmarks/branch_history_footprint.cpp
+  benchmarks/direct_branch_footprint.cpp
+  benchmarks/nested_call_depth.cpp
+  benchmarks/dependent_chain_throughput.cpp
+)
+target_link_libraries(ferret_benchmarks PRIVATE ferret_core sljit::sljit ferret_warnings)
 
 add_executable(ferret
   src/main.cpp
-  benchmarks/dependent_chain_throughput.cpp
-  benchmarks/direct_branch_footprint.cpp
-  benchmarks/nested_call_depth.cpp
-  benchmarks/branch_history_footprint.cpp
 )
+target_sources(ferret PRIVATE $<TARGET_OBJECTS:ferret_benchmarks>)
 target_link_libraries(ferret PRIVATE
   ferret_core
+  ferret_benchmarks
   CLI11::CLI11
   sljit::sljit
   ferret_warnings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ add_library(ferret_core STATIC
   src/jit.cpp
   ${ferret_arch_timing_src}
   src/timing/calibrate.cpp
+  src/pinning/posix_common.cpp
   ${ferret_os_pinning_src}
   src/benchmark_registry.cpp
   src/csv.cpp

--- a/benchmarks/branch_history_footprint.cpp
+++ b/benchmarks/branch_history_footprint.cpp
@@ -39,7 +39,7 @@ constexpr size_t kMinSiteBytes = 8;
 #elif defined(__x86_64__) || defined(_M_X64)
 constexpr size_t kMinSiteBytes = 6;
 #else
-#error "ferret v1 supports only x86_64 and aarch64"
+#error "ferret supports only x86_64 and aarch64"
 #endif
 
 }  // namespace

--- a/benchmarks/branch_history_footprint.cpp
+++ b/benchmarks/branch_history_footprint.cpp
@@ -21,6 +21,8 @@ struct BranchHistoryFootprint;  // forward decl for internal namespace ref
 
 namespace {
 
+constexpr size_t kOpBudget = 10'000'000;
+
 // Floor on the bytes a single site (load + cmp-and-branch) can occupy
 // across all sljit encodings on this arch. Used to pick the NOP count
 // per site as `spacing - kMinSiteBytes` so the chain stride is always
@@ -105,7 +107,7 @@ struct BranchHistoryFootprint : Benchmark {
   [[nodiscard]] size_t sites_per_kernel(const Params& p) const override { return p.get<size_t>("branches"); }
 
   [[nodiscard]] size_t iterations(const Params& p) const override {
-    return compute_iterations(10'000'000, p.get<size_t>("branches"));
+    return compute_iterations(kOpBudget, p.get<size_t>("branches"));
   }
 
   void emit_kernel(sljit_compiler* c, const Params& p) override;

--- a/benchmarks/direct_branch_footprint.cpp
+++ b/benchmarks/direct_branch_footprint.cpp
@@ -28,18 +28,18 @@ namespace {
 //                  pattern. Must be the deterministic final size.
 //
 // AArch64: a single B imm26 (4 bytes) reaches ±128 MB, larger than any
-//   realistic ferret kernel. sljit_emit_jump reserves 5 instructions
-//   (JUMP_MAX_SIZE; sljitNativeARM_64.c:2528) and reduce_code_size
-//   collapses each non-rewritable jump to 1 insn for in-range targets
-//   (sljitNativeARM_64.c:443-463). Net: 4 bytes per branch, predictable.
+//   realistic ferret kernel. sljit reserves the worst-case jump width
+//   at emit time and its reduce_code_size pass then collapses every
+//   non-rewritable jump to one instruction for in-range targets. Net:
+//   4 bytes per branch, predictable.
 //
-// x86_64: sljit_emit_jump can't be made to commit to one encoding
-//   without forfeiting 13 B per site (SLJIT_REWRITABLE_JUMP) — reduce
-//   picks rel8 (2 B) or rel32 (5 B) per-jump based on the hop distance
-//   (sljitNativeX86_common.c:863-867), which is unbounded for
-//   sattolo_permute. Instead we hand-emit `JMP rel32` (E9 + 4-byte
-//   displacement) via sljit_emit_op_custom and patch the displacement
-//   post-generate from sljit_get_label_addr. 5 bytes uniform, any hop.
+// x86_64: sljit_emit_jump can't be pinned to a single encoding without
+//   forfeiting 13 B per site (SLJIT_REWRITABLE_JUMP) — the reduce pass
+//   picks rel8 (2 B) or rel32 (5 B) per jump based on the hop distance,
+//   which is unbounded under sattolo_permute. Instead we hand-emit
+//   `JMP rel32` (E9 + 4-byte displacement) via sljit_emit_op_custom and
+//   patch the displacement post-generate from sljit_get_label_addr.
+//   5 bytes uniform, any hop.
 #if defined(__aarch64__) || defined(_M_ARM64)
 constexpr size_t kBranchAlign = 4;
 constexpr size_t kJumpBytes = 4;
@@ -47,7 +47,7 @@ constexpr size_t kJumpBytes = 4;
 constexpr size_t kBranchAlign = 1;
 constexpr size_t kJumpBytes = 5;
 #else
-#error "ferret v1 supports only x86_64 and aarch64"
+#error "ferret supports only x86_64 and aarch64"
 #endif
 
 }  // namespace

--- a/benchmarks/direct_branch_footprint.cpp
+++ b/benchmarks/direct_branch_footprint.cpp
@@ -20,6 +20,8 @@ namespace ferret {
 
 namespace {
 
+constexpr size_t kOpBudget = 10'000'000;
+
 // Per-arch layout strategy for each direct-branch site.
 //   kBranchAlign — required start-address alignment.
 //   kJumpBytes   — bytes the emitted jump occupies. Used as
@@ -86,7 +88,7 @@ struct DirectBranchFootprint : Benchmark {
   [[nodiscard]] size_t sites_per_kernel(const Params& p) const override { return p.get<size_t>("branches"); }
 
   [[nodiscard]] size_t iterations(const Params& p) const override {
-    return compute_iterations(10'000'000, p.get<size_t>("branches"));
+    return compute_iterations(kOpBudget, p.get<size_t>("branches"));
   }
 
   void emit_kernel(sljit_compiler* c, const Params& p) override {

--- a/benchmarks/nested_call_depth.cpp
+++ b/benchmarks/nested_call_depth.cpp
@@ -10,12 +10,16 @@ extern "C" {
 
 #include "ferret/bench_helpers.hpp"
 #include "ferret/benchmark.hpp"
+#include "ferret/permute.hpp"
 
 namespace ferret {
 
 namespace {
 // K for variant 2 (path-table dispatch). Defines the binary-tree width.
 constexpr int kK = 8;
+// call/ret cycles are heavier than single branches, so this benchmark uses
+// a smaller op budget than the branch footprint benchmarks.
+constexpr size_t kOpBudget = 1'000'000;
 }  // namespace
 
 namespace nested_call_depth_internal {
@@ -324,7 +328,7 @@ struct NestedCallDepth : Benchmark {
   [[nodiscard]] size_t sites_per_kernel(const Params& p) const override { return p.get<size_t>("depth") + 1; }
 
   [[nodiscard]] size_t iterations(const Params& p) const override {
-    return compute_iterations(1'000'000, p.get<size_t>("depth") + 1);
+    return compute_iterations(kOpBudget, p.get<size_t>("depth") + 1);
   }
 
   void emit_kernel(sljit_compiler* c, const Params& p) override {
@@ -361,12 +365,8 @@ struct NestedCallDepth : Benchmark {
     }
 
     auto rows = static_cast<size_t>(path_table_rows);
-    // Combine seed and depth via std::seed_seq so distinct sweep points
-    // produce distinct dispatch tables without any hand-rolled mixing.
-    auto seed = p.get<int64_t>("seed");
-    std::seed_seq seq{static_cast<uint32_t>(seed), static_cast<uint32_t>(seed >> 32), static_cast<uint32_t>(depth)};
-    std::mt19937_64 mixer(seq);
-    uint64_t mixed = mixer();
+    auto seed = static_cast<uint64_t>(p.get<int64_t>("seed"));
+    uint64_t mixed = mix_seed(seed, static_cast<uint64_t>(depth), 0);
     path_tables_.push_back(nested_call_depth_internal::generate_path_table(rows, depth + 1, mixed));
     emit_variant2_path_table(c, depth, iters, rows, path_tables_.back().data());
   }

--- a/include/ferret/params.hpp
+++ b/include/ferret/params.hpp
@@ -9,8 +9,8 @@
 
 namespace ferret {
 
-// Insertion-ordered key/int64 map. v1 keeps all axis values as int64_t
-// because every benchmark axis is integral.
+// Insertion-ordered key/int64 map. All axis values are int64_t because
+// every benchmark axis is integral.
 class Params {
  public:
   // First insertion appends to the iteration order returned by keys();

--- a/scripts/ferret_plot/cli.py
+++ b/scripts/ferret_plot/cli.py
@@ -22,25 +22,25 @@ EXIT_USER_ERROR = 2
 
 
 def _line_handler(df, args):
-    from ferret_plot.kinds.line import make_figure
+    from ferret_plot.kinds.line import make_figure  # noqa: PLC0415  # lazy so --help skips plotly import
 
     return make_figure(df, args)
 
 
 def _heatmap_handler(df, args):
-    from ferret_plot.kinds.heatmap import make_figure
+    from ferret_plot.kinds.heatmap import make_figure  # noqa: PLC0415  # lazy so --help skips plotly import
 
     return make_figure(df, args)
 
 
 def _surface_handler(df, args):
-    from ferret_plot.kinds.surface import make_figure
+    from ferret_plot.kinds.surface import make_figure  # noqa: PLC0415  # lazy so --help skips plotly import
 
     return make_figure(df, args)
 
 
 def _facets_handler(df, args):
-    from ferret_plot.kinds.facets import make_figure
+    from ferret_plot.kinds.facets import make_figure  # noqa: PLC0415  # lazy so --help skips plotly import
 
     return make_figure(df, args)
 

--- a/scripts/ferret_plot/cli.py
+++ b/scripts/ferret_plot/cli.py
@@ -14,13 +14,31 @@ import pandas as pd
 
 from ferret_plot import output
 from ferret_plot.errors import PlotError
-from ferret_plot.kinds import facets as facets_kind
-from ferret_plot.kinds import heatmap as heatmap_kind
-from ferret_plot.kinds import line as line_kind
-from ferret_plot.kinds import surface as surface_kind
-from ferret_plot.kinds._shared import DEFAULT_CMAP
+
+# The string value; avoids importing _shared (which pulls in plotly) at startup.
+_DEFAULT_CMAP = "turbo"
 
 EXIT_USER_ERROR = 2
+
+
+def _line_handler(df, args):
+    from ferret_plot.kinds.line import make_figure
+    return make_figure(df, args)
+
+
+def _heatmap_handler(df, args):
+    from ferret_plot.kinds.heatmap import make_figure
+    return make_figure(df, args)
+
+
+def _surface_handler(df, args):
+    from ferret_plot.kinds.surface import make_figure
+    return make_figure(df, args)
+
+
+def _facets_handler(df, args):
+    from ferret_plot.kinds.facets import make_figure
+    return make_figure(df, args)
 
 
 def _add_common(sp: argparse.ArgumentParser) -> None:
@@ -62,15 +80,15 @@ def build_parser() -> argparse.ArgumentParser:
     )
     line.add_argument("--series", default=None, help="comma-separated columns to use as series grouping")
     line.add_argument("--ymax", type=float, default=None, help="upper limit for the Y axis")
-    line.set_defaults(handler=line_kind.make_figure)
+    line.set_defaults(handler=_line_handler)
 
     heat = sub.add_parser("heatmap", help="2D heatmap over two varying axes")
     _add_common(heat)
     heat.add_argument("--x", default=None, help="X-axis column")
     heat.add_argument("--y", default=None, help="Y-axis column")
     heat.add_argument("--logz", action="store_true", help="log color scale")
-    heat.add_argument("--cmap", default=DEFAULT_CMAP, help=f"colorscale name (default: {DEFAULT_CMAP}, high-contrast)")
-    heat.set_defaults(handler=heatmap_kind.make_figure)
+    heat.add_argument("--cmap", default=_DEFAULT_CMAP, help=f"colorscale name (default: {_DEFAULT_CMAP}, high-contrast)")
+    heat.set_defaults(handler=_heatmap_handler)
 
     surface = sub.add_parser("surface", help="3D surface over two varying axes")
     _add_common(surface)
@@ -79,8 +97,8 @@ def build_parser() -> argparse.ArgumentParser:
     surface.add_argument("--logz", action="store_true", help="log color scale")
     surface.add_argument("--elev", type=float, default=20.0, help="3D camera elevation angle")
     surface.add_argument("--azim", type=float, default=-2.0, help="3D camera azimuth angle")
-    surface.add_argument("--cmap", default=DEFAULT_CMAP, help=f"colorscale name (default: {DEFAULT_CMAP}, high-contrast perceptual)")
-    surface.set_defaults(handler=surface_kind.make_figure)
+    surface.add_argument("--cmap", default=_DEFAULT_CMAP, help=f"colorscale name (default: {_DEFAULT_CMAP}, high-contrast perceptual)")
+    surface.set_defaults(handler=_surface_handler)
 
     fac = sub.add_parser("facets", help="grid of heatmaps over >=3 varying axes")
     _add_common(fac)
@@ -88,8 +106,8 @@ def build_parser() -> argparse.ArgumentParser:
     fac.add_argument("--x", default=None, help="X-axis column (per subplot)")
     fac.add_argument("--y", default=None, help="Y-axis column (per subplot)")
     fac.add_argument("--logz", action="store_true", help="log color scale")
-    fac.add_argument("--cmap", default=DEFAULT_CMAP, help=f"colorscale name (default: {DEFAULT_CMAP}, high-contrast)")
-    fac.set_defaults(handler=facets_kind.make_figure)
+    fac.add_argument("--cmap", default=_DEFAULT_CMAP, help=f"colorscale name (default: {_DEFAULT_CMAP}, high-contrast)")
+    fac.set_defaults(handler=_facets_handler)
 
     return ap
 

--- a/scripts/ferret_plot/cli.py
+++ b/scripts/ferret_plot/cli.py
@@ -18,6 +18,7 @@ from ferret_plot.kinds import facets as facets_kind
 from ferret_plot.kinds import heatmap as heatmap_kind
 from ferret_plot.kinds import line as line_kind
 from ferret_plot.kinds import surface as surface_kind
+from ferret_plot.kinds._shared import DEFAULT_CMAP
 
 EXIT_USER_ERROR = 2
 
@@ -28,14 +29,14 @@ def _add_common(sp: argparse.ArgumentParser) -> None:
     sp.add_argument(
         "--format",
         default=None,
-        choices=["html", "png", "svg", "pdf", "jpg", "webp"],
+        choices=sorted(output.KNOWN_FORMATS),
         help="output format override (default: infer from --out extension)",
     )
     sp.add_argument(
         "--html-js",
         dest="html_js",
         default="cdn",
-        choices=["cdn", "inline", "sibling"],
+        choices=output.HTML_JS_CHOICES,
         help="how to bundle plotly.js in HTML output (default: cdn)",
     )
     sp.add_argument("--benchmark", default=None, help="override registry lookup (rare)")
@@ -68,7 +69,7 @@ def build_parser() -> argparse.ArgumentParser:
     heat.add_argument("--x", default=None, help="X-axis column")
     heat.add_argument("--y", default=None, help="Y-axis column")
     heat.add_argument("--logz", action="store_true", help="log color scale")
-    heat.add_argument("--cmap", default="turbo", help="colorscale name (default: turbo, high-contrast)")
+    heat.add_argument("--cmap", default=DEFAULT_CMAP, help=f"colorscale name (default: {DEFAULT_CMAP}, high-contrast)")
     heat.set_defaults(handler=heatmap_kind.make_figure)
 
     surface = sub.add_parser("surface", help="3D surface over two varying axes")
@@ -78,7 +79,7 @@ def build_parser() -> argparse.ArgumentParser:
     surface.add_argument("--logz", action="store_true", help="log color scale")
     surface.add_argument("--elev", type=float, default=20.0, help="3D camera elevation angle")
     surface.add_argument("--azim", type=float, default=-2.0, help="3D camera azimuth angle")
-    surface.add_argument("--cmap", default="turbo", help="colorscale name (default: turbo, high-contrast perceptual)")
+    surface.add_argument("--cmap", default=DEFAULT_CMAP, help=f"colorscale name (default: {DEFAULT_CMAP}, high-contrast perceptual)")
     surface.set_defaults(handler=surface_kind.make_figure)
 
     fac = sub.add_parser("facets", help="grid of heatmaps over >=3 varying axes")
@@ -87,7 +88,7 @@ def build_parser() -> argparse.ArgumentParser:
     fac.add_argument("--x", default=None, help="X-axis column (per subplot)")
     fac.add_argument("--y", default=None, help="Y-axis column (per subplot)")
     fac.add_argument("--logz", action="store_true", help="log color scale")
-    fac.add_argument("--cmap", default="turbo", help="colorscale name (default: turbo, high-contrast)")
+    fac.add_argument("--cmap", default=DEFAULT_CMAP, help=f"colorscale name (default: {DEFAULT_CMAP}, high-contrast)")
     fac.set_defaults(handler=facets_kind.make_figure)
 
     return ap

--- a/scripts/ferret_plot/cli.py
+++ b/scripts/ferret_plot/cli.py
@@ -23,21 +23,25 @@ EXIT_USER_ERROR = 2
 
 def _line_handler(df, args):
     from ferret_plot.kinds.line import make_figure
+
     return make_figure(df, args)
 
 
 def _heatmap_handler(df, args):
     from ferret_plot.kinds.heatmap import make_figure
+
     return make_figure(df, args)
 
 
 def _surface_handler(df, args):
     from ferret_plot.kinds.surface import make_figure
+
     return make_figure(df, args)
 
 
 def _facets_handler(df, args):
     from ferret_plot.kinds.facets import make_figure
+
     return make_figure(df, args)
 
 
@@ -87,7 +91,9 @@ def build_parser() -> argparse.ArgumentParser:
     heat.add_argument("--x", default=None, help="X-axis column")
     heat.add_argument("--y", default=None, help="Y-axis column")
     heat.add_argument("--logz", action="store_true", help="log color scale")
-    heat.add_argument("--cmap", default=_DEFAULT_CMAP, help=f"colorscale name (default: {_DEFAULT_CMAP}, high-contrast)")
+    heat.add_argument(
+        "--cmap", default=_DEFAULT_CMAP, help=f"colorscale name (default: {_DEFAULT_CMAP}, high-contrast)"
+    )
     heat.set_defaults(handler=_heatmap_handler)
 
     surface = sub.add_parser("surface", help="3D surface over two varying axes")
@@ -97,7 +103,9 @@ def build_parser() -> argparse.ArgumentParser:
     surface.add_argument("--logz", action="store_true", help="log color scale")
     surface.add_argument("--elev", type=float, default=20.0, help="3D camera elevation angle")
     surface.add_argument("--azim", type=float, default=-2.0, help="3D camera azimuth angle")
-    surface.add_argument("--cmap", default=_DEFAULT_CMAP, help=f"colorscale name (default: {_DEFAULT_CMAP}, high-contrast perceptual)")
+    surface.add_argument(
+        "--cmap", default=_DEFAULT_CMAP, help=f"colorscale name (default: {_DEFAULT_CMAP}, high-contrast perceptual)"
+    )
     surface.set_defaults(handler=_surface_handler)
 
     fac = sub.add_parser("facets", help="grid of heatmaps over >=3 varying axes")

--- a/scripts/ferret_plot/kinds/_shared.py
+++ b/scripts/ferret_plot/kinds/_shared.py
@@ -15,7 +15,58 @@ from ferret_plot.formatting import decimate_indices, human_readable
 from ferret_plot.registry import BenchmarkDefaults
 
 _MISSING_PREVIEW_LIMIT = 5
-_DEFAULT_CMAP = "turbo"
+DEFAULT_CMAP = "turbo"
+
+
+def assert_logz_positive(values: np.ndarray, *, metric_label: str | None = None) -> None:
+    """Raise PlotError when --logz is requested but values contain non-positive entries."""
+    if np.nanmin(values) <= 0:
+        raise PlotError("--logz requires positive metric values")
+
+
+def hover_text_grid(
+    grid: pd.DataFrame,
+    *,
+    xcol: str,
+    ycol: str,
+    value_label: str,
+    z: np.ndarray,
+    transpose: bool = False,
+) -> np.ndarray:
+    """Build a 2D object array of per-cell hover strings.
+
+    Each cell reads ``"{xcol}={x_val}<br>{ycol}={y_val}<br>{value_label}={z:.3g}"``.
+    When ``transpose=False`` (default), the returned shape is ``(n_rows, n_cols)``
+    matching the heatmap trace convention.  When ``transpose=True``, the shape
+    is ``(n_cols, n_rows)`` to match the surface trace convention where plotly
+    indexes text as ``text[x_idx][y_idx]``.
+    """
+    n_rows, n_cols = z.shape
+    if transpose:
+        return np.array(
+            [
+                [
+                    f"{xcol}={human_readable(grid.columns[j])}"
+                    f"<br>{ycol}={human_readable(grid.index[i])}"
+                    f"<br>{value_label}={z[i, j]:.3g}"
+                    for i in range(n_rows)
+                ]
+                for j in range(n_cols)
+            ],
+            dtype=object,
+        )
+    return np.array(
+        [
+            [
+                f"{xcol}={human_readable(grid.columns[j])}"
+                f"<br>{ycol}={human_readable(grid.index[i])}"
+                f"<br>{value_label}={z[i, j]:.3g}"
+                for j in range(n_cols)
+            ]
+            for i in range(n_rows)
+        ],
+        dtype=object,
+    )
 
 
 def validate_cmap(cmap: str) -> str:
@@ -155,20 +206,7 @@ def build_heatmap_trace(  # noqa: PLR0913
     z = np.log10(z_raw) if logz else z_raw
     n_rows, n_cols = z_raw.shape
 
-    # np.array(..., dtype=object) preserves the 2D shape; a Python
-    # list-of-lists silently flattens when handed to plotly.
-    hover_text = np.array(
-        [
-            [
-                f"{xcol}={human_readable(grid.columns[j])}"
-                f"<br>{ycol}={human_readable(grid.index[i])}"
-                f"<br>{value_label}={z_raw[i, j]:.3g}"
-                for j in range(n_cols)
-            ]
-            for i in range(n_rows)
-        ],
-        dtype=object,
-    )
+    hover_text = hover_text_grid(grid, xcol=xcol, ycol=ycol, value_label=value_label, z=z_raw)
 
     common = dict(
         x=list(range(n_cols)),

--- a/scripts/ferret_plot/kinds/_shared.py
+++ b/scripts/ferret_plot/kinds/_shared.py
@@ -24,7 +24,7 @@ def assert_logz_positive(values: np.ndarray, *, metric_label: str | None = None)
         raise PlotError("--logz requires positive metric values")
 
 
-def hover_text_grid(
+def hover_text_grid(  # noqa: PLR0913
     grid: pd.DataFrame,
     *,
     xcol: str,

--- a/scripts/ferret_plot/kinds/facets.py
+++ b/scripts/ferret_plot/kinds/facets.py
@@ -113,8 +113,8 @@ def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> go.Figure:
             cmax=cmax,
             colorbar=dict(title=metric.label),
         ),
-        # NaN cells render transparent in plotly; match today's grey
-        # "missing" indication via a lightgrey plot background.
+        # NaN cells render transparent in plotly; the lightgrey
+        # background marks them as missing values.
         plot_bgcolor="lightgrey",
         margin=dict(l=60, r=20, t=80, b=60),
     )

--- a/scripts/ferret_plot/kinds/facets.py
+++ b/scripts/ferret_plot/kinds/facets.py
@@ -13,7 +13,7 @@ from plotly.subplots import make_subplots
 from ferret_plot.columns import bench_name, resolve_metric
 from ferret_plot.errors import PlotError
 from ferret_plot.kinds._shared import (
-    _DEFAULT_CMAP,
+    assert_logz_positive,
     axis_ticks,
     build_heatmap_trace,
     prepare_grid,
@@ -54,12 +54,11 @@ def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> go.Figure:
     ncols = max(1, math.ceil(math.sqrt(n)))
     nrows = math.ceil(n / ncols)
 
-    cmap = validate_cmap(args.cmap or _DEFAULT_CMAP)
+    cmap = validate_cmap(args.cmap)
 
     metric_values = df[metric.column].to_numpy()
     if args.logz:
-        if np.nanmin(metric_values) <= 0:
-            raise PlotError("--logz requires positive metric values")
+        assert_logz_positive(metric_values)
         cmin = float(np.log10(np.nanmin(metric_values)))
         cmax = float(np.log10(np.nanmax(metric_values)))
     else:

--- a/scripts/ferret_plot/kinds/heatmap.py
+++ b/scripts/ferret_plot/kinds/heatmap.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 import argparse
 
-import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 
 from ferret_plot.columns import bench_name, resolve_metric
-from ferret_plot.errors import PlotError
 from ferret_plot.kinds._shared import (
-    _DEFAULT_CMAP,
+    assert_logz_positive,
     axis_ticks,
     build_heatmap_trace,
     prepare_grid,
@@ -27,12 +25,10 @@ def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> go.Figure:
     xcol, ycol = resolve_heatmap_xy(df, args, defaults)
     grid = prepare_grid(df, xcol=xcol, ycol=ycol, value_col=metric.column)
 
-    cmap = validate_cmap(args.cmap or _DEFAULT_CMAP)
+    cmap = validate_cmap(args.cmap)
 
     if args.logz:
-        z_all = grid.to_numpy(dtype=float)
-        if np.nanmin(z_all) <= 0:
-            raise PlotError("--logz requires positive metric values")
+        assert_logz_positive(grid.to_numpy(dtype=float))
 
     trace = build_heatmap_trace(
         grid,

--- a/scripts/ferret_plot/kinds/heatmap.py
+++ b/scripts/ferret_plot/kinds/heatmap.py
@@ -51,8 +51,8 @@ def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> go.Figure:
         title=f"{bench_name(df)}: {metric.label} ({ycol} × {xcol})",
         xaxis=dict(title=xcol, tickvals=x_tickvals, ticktext=x_ticktext),
         yaxis=dict(title=ycol, tickvals=y_tickvals, ticktext=y_ticktext),
-        # NaN cells render transparent in plotly. A lightgrey plot
-        # background gives them today's "missing" look.
+        # NaN cells render transparent in plotly; the lightgrey
+        # background marks them as missing values.
         plot_bgcolor="lightgrey",
         margin=dict(l=60, r=20, t=60, b=60),
     )

--- a/scripts/ferret_plot/kinds/surface.py
+++ b/scripts/ferret_plot/kinds/surface.py
@@ -21,6 +21,37 @@ from ferret_plot.kinds._shared import (
 )
 from ferret_plot.registry import resolve_defaults
 
+# --- tunables ---
+
+_CAMERA_ORBIT_RADIUS = 0.7
+
+# Proportional scale applied to each axis length so the longest grid edge
+# occupies the dominant fraction of the scene bounding box.
+_AXIS_LENGTH_SCALE = 2.9
+
+_COLORBAR_X = 0.96
+_COLORBAR_LEN = 0.85
+_COLORBAR_THICKNESS = 20
+
+_BASE_FONT_SIZE = 16
+_COLORBAR_TITLE_FONT_SIZE = 28  # not a round multiple of _BASE_FONT_SIZE
+_COLORBAR_TICK_FONT_SIZE = 26
+
+_LONG_EDGE_PX = 2400
+_SHORT_EDGE_MIN_PX = 1000
+
+_SCENE_DOMAIN_X = (0.0, 0.92)
+
+_LIGHTING = dict(ambient=0.6, diffuse=0.8, specular=0.05, roughness=0.5, fresnel=0.2)
+
+# Plotly lightposition is a directional vector in screen space, not data space.
+# All three components should share the same order of magnitude so the light
+# direction is not dominated by whichever axis happens to be largest.
+_LIGHTPOSITION = dict(x=100000, y=-100000, z=100000)
+
+
+# --- private helpers ---
+
 
 def _z_values(grid: pd.DataFrame) -> np.ndarray:
     try:
@@ -29,13 +60,14 @@ def _z_values(grid: pd.DataFrame) -> np.ndarray:
         raise PlotError("surface plot metric values must be numeric") from e
 
 
-def _camera_eye(elev_deg: float, azim_deg: float, r: float = 0.7) -> dict[str, float]:
+def _camera_eye(elev_deg: float, azim_deg: float) -> dict[str, float]:
     """Convert (elev, azim) degrees to a cartesian camera.eye for plotly.
 
     elev is the angle above the XY plane; azim is the angle around the Z axis.
     """
     elev = math.radians(elev_deg)
     azim = math.radians(azim_deg)
+    r = _CAMERA_ORBIT_RADIUS
     return {
         "x": r * math.cos(elev) * math.cos(azim),
         "y": r * math.cos(elev) * math.sin(azim),
@@ -43,41 +75,39 @@ def _camera_eye(elev_deg: float, azim_deg: float, r: float = 0.7) -> dict[str, f
     }
 
 
-def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> go.Figure:
-    metric = resolve_metric(df, metric=args.metric, stat=args.stat)
-    defaults = resolve_defaults(df, override=args.benchmark)
-    xcol, ycol = resolve_heatmap_xy(df, args, defaults)
-    grid = prepare_grid(df, xcol=xcol, ycol=ycol, value_col=metric.column, require_complete=True)
-    z = _z_values(grid)
-
-    cmap = validate_cmap(args.cmap)
-
-    # Quantize the surface color to integer steps so the colormap
-    # paints discrete bands (one per integer of the colored quantity)
-    # rather than a smooth gradient. The geometry stays smooth — only
-    # the color is stepped. Contour lines drawn at the same integers
-    # mark the boundaries crisply.
-    if args.logz:
-        assert_logz_positive(z)
-        color_source = np.log10(z)
-    else:
-        color_source = z
-    cmin = float(math.floor(np.nanmin(color_source)))
-    cmax = float(math.ceil(np.nanmax(color_source)))
-    surfacecolor = np.floor(color_source)
-
-    x_positions = np.arange(len(grid.columns))
-    y_positions = np.arange(len(grid.index))
-
-    # Per-cell hover text. Plotly's Surface trace indexes the text
-    # array as text[x_idx][y_idx] — the OPPOSITE of the (y, x) order
-    # it uses for z.  transpose=True builds shape (n_cols, n_rows)
-    # where the outer axis maps to surface.x and the inner to surface.y.
-    hover_text = hover_text_grid(
-        grid, xcol=xcol, ycol=ycol, value_label=metric.label, z=z, transpose=True
+def _compute_aspect_ratio(grid: pd.DataFrame) -> dict:
+    """Return the aspectratio dict scaled to the grid's column/row counts."""
+    longer = max(len(grid.columns), len(grid.index))
+    return dict(
+        x=_AXIS_LENGTH_SCALE * len(grid.columns) / longer,
+        y=_AXIS_LENGTH_SCALE * len(grid.index) / longer,
+        z=1.1,
     )
 
-    surface = go.Surface(
+
+def _build_surface_trace(
+    grid: pd.DataFrame,
+    *,
+    z: np.ndarray,
+    color_source: np.ndarray,
+    cmap: str,
+    cmin: float,
+    cmax: float,
+    hover_text: np.ndarray,
+    metric_label: str,
+) -> go.Surface:
+    """Return a configured go.Surface trace.
+
+    color_source is either z itself (linear scale) or log10(z) (log scale).
+    The surfacecolor is quantized to integer steps so the colormap paints
+    discrete bands rather than a smooth gradient; contour lines at the same
+    integer boundaries mark the band edges.
+    """
+    x_positions = np.arange(len(grid.columns))
+    y_positions = np.arange(len(grid.index))
+    surfacecolor = np.floor(color_source)
+
+    return go.Surface(
         x=x_positions,
         y=y_positions,
         z=z,
@@ -86,21 +116,21 @@ def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> go.Figure:
         cmin=cmin,
         cmax=cmax,
         colorbar=dict(
-            title=dict(text=metric.label, font=dict(size=28)),
+            title=dict(text=metric_label, font=dict(size=_COLORBAR_TITLE_FONT_SIZE)),
             dtick=1,
             tick0=cmin,
-            x=0.96,
-            len=0.85,
-            thickness=20,
-            tickfont=dict(size=26),
+            x=_COLORBAR_X,
+            len=_COLORBAR_LEN,
+            thickness=_COLORBAR_THICKNESS,
+            tickfont=dict(size=_COLORBAR_TICK_FONT_SIZE),
         ),
-        lighting=dict(ambient=0.6, diffuse=0.8, specular=0.05, roughness=0.5, fresnel=0.2),
+        lighting=_LIGHTING,
         # Lightposition is in unflipped world coordinates. The scene
         # renders X reversed (range=[high, low]) so a light at +x in
         # data space ends up on the screen's left — opposite the camera.
         # Negate x so the lit face points toward the viewer, and bias z
         # heavily upward so the dominant light direction is overhead.
-        lightposition=dict(x=100000, y=-100000, z=cmax),
+        lightposition=_LIGHTPOSITION,
         contours=dict(
             # Z contours at integer metric values for banding (combined
             # with the floor-quantized surfacecolor).
@@ -136,73 +166,127 @@ def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> go.Figure:
         hovertemplate="%{text}<extra></extra>",
     )
 
+
+def _build_scene_layout(
+    grid: pd.DataFrame,
+    *,
+    xcol: str,
+    ycol: str,
+    metric_label: str,
+    elev: float,
+    azim: float,
+) -> dict:
+    """Return the dict passed to update_layout(scene=...).
+
+    Covers axis tick configuration, data-range clamping, aspect ratio,
+    scene domain, camera position, and orthographic projection.
+    """
+    x_positions = np.arange(len(grid.columns))
+    y_positions = np.arange(len(grid.index))
+
     x_tickvals, x_ticktext = axis_ticks(list(grid.columns))
     y_tickvals, y_ticktext = axis_ticks(list(grid.index))
 
-    # Axis ranges clamp tight to the data extent so the scene's bounding
-    # box ends exactly at the first and last data point. Plotly otherwise
-    # pads each axis by ~10% which leaves a visible margin. Z starts at
-    # 0 (or below if any data is negative) so the surface height reads
-    # as an absolute magnitude — important for cycles-per-site comparisons.
+    z = _z_values(grid)
     z_data_min = min(0.0, float(np.nanmin(z)))
     z_data_max = float(np.nanmax(z))
     # X axis is reversed; plotly takes range=[high, low] for that direction.
     x_range = [float(x_positions[-1]), float(x_positions[0])]
     y_range = [float(y_positions[0]), float(y_positions[-1])]
 
+    fs = _BASE_FONT_SIZE
+    return dict(
+        xaxis=dict(
+            title=dict(text=xcol, font=dict(size=fs + 2)),
+            tickvals=x_tickvals,
+            ticktext=x_ticktext,
+            tickfont=dict(size=fs),
+            range=x_range,
+        ),
+        yaxis=dict(
+            title=dict(text=ycol, font=dict(size=fs + 2)),
+            tickvals=y_tickvals,
+            ticktext=y_ticktext,
+            tickfont=dict(size=fs),
+            range=y_range,
+        ),
+        zaxis=dict(
+            title=dict(text=metric_label, font=dict(size=fs + 2)),
+            tickfont=dict(size=fs),
+            range=[z_data_min, z_data_max],
+        ),
+        # Plotly's aspectratio is unitless; the largest axis gets
+        # normalized to ~1. A flatter Z keeps the surface readable
+        # without dominating the scene.
+        aspectmode="manual",
+        # Axis lengths scale with the number of unique values on each
+        # axis so a 13x7 grid renders as a 13:7 rectangle, not a
+        # square. The longer-tick axis gets proportionally more room.
+        aspectratio=_compute_aspect_ratio(grid),
+        # Claim almost the full figure width for the scene; the
+        # narrow colorbar at x=_COLORBAR_X occupies the remaining sliver.
+        domain=dict(x=list(_SCENE_DOMAIN_X), y=[0.0, 1.0]),
+        # Orthographic projection eliminates perspective distortion
+        # (distant features render at the same scale as near ones)
+        # without changing the figure size: that's determined by the
+        # bounding box and aspectratio, not the camera distance.
+        camera=dict(
+            eye=_camera_eye(elev, azim),
+            projection=dict(type="orthographic"),
+        ),
+    )
+
+
+def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> go.Figure:
+    metric = resolve_metric(df, metric=args.metric, stat=args.stat)
+    defaults = resolve_defaults(df, override=args.benchmark)
+    xcol, ycol = resolve_heatmap_xy(df, args, defaults)
+    grid = prepare_grid(df, xcol=xcol, ycol=ycol, value_col=metric.column, require_complete=True)
+    z = _z_values(grid)
+
+    cmap = validate_cmap(args.cmap)
+
+    if args.logz:
+        assert_logz_positive(z)
+        color_source = np.log10(z)
+    else:
+        color_source = z
+    cmin = float(math.floor(np.nanmin(color_source)))
+    cmax = float(math.ceil(np.nanmax(color_source)))
+
+    # Per-cell hover text. Plotly's Surface trace indexes the text
+    # array as text[x_idx][y_idx] — the OPPOSITE of the (y, x) order
+    # it uses for z.  transpose=True builds shape (n_cols, n_rows)
+    # where the outer axis maps to surface.x and the inner to surface.y.
+    hover_text = hover_text_grid(
+        grid, xcol=xcol, ycol=ycol, value_label=metric.label, z=z, transpose=True
+    )
+
+    surface = _build_surface_trace(
+        grid,
+        z=z,
+        color_source=color_source,
+        cmap=cmap,
+        cmin=cmin,
+        cmax=cmax,
+        hover_text=hover_text,
+        metric_label=metric.label,
+    )
+
     fig = go.Figure(data=[surface])
-    # Global font size knob — applied to title, axis titles, ticks,
-    # colorbar, and hover so the whole figure scales together.
-    base_font_size = 16
     fig.update_layout(
         title=dict(
             text=f"{bench_name(df)}: {metric.label} surface ({ycol} × {xcol})",
-            font=dict(size=base_font_size + 4),
+            font=dict(size=_BASE_FONT_SIZE + 4),
         ),
-        font=dict(size=base_font_size),
-        scene=dict(
-            xaxis=dict(
-                title=dict(text=xcol, font=dict(size=base_font_size + 2)),
-                tickvals=x_tickvals,
-                ticktext=x_ticktext,
-                tickfont=dict(size=base_font_size),
-                range=x_range,
-            ),
-            yaxis=dict(
-                title=dict(text=ycol, font=dict(size=base_font_size + 2)),
-                tickvals=y_tickvals,
-                ticktext=y_ticktext,
-                tickfont=dict(size=base_font_size),
-                range=y_range,
-            ),
-            zaxis=dict(
-                title=dict(text=metric.label, font=dict(size=base_font_size + 2)),
-                tickfont=dict(size=base_font_size),
-                range=[z_data_min, z_data_max],
-            ),
-            # Plotly's aspectratio is unitless; the largest axis gets
-            # normalized to ~1. A flatter Z keeps the surface readable
-            # without dominating the scene.
-            aspectmode="manual",
-            # Axis lengths scale with the number of unique values on each
-            # axis so a 13x7 grid renders as a 13:7 rectangle, not a
-            # square. The longer-tick axis gets proportionally more room.
-            aspectratio=dict(
-                x=2.9 * len(grid.columns) / max(len(grid.columns), len(grid.index)),
-                y=2.9 * len(grid.index) / max(len(grid.columns), len(grid.index)),
-                z=1.1,
-            ),
-            # Claim almost the full figure width for the scene; the
-            # narrow colorbar at x=0.96 occupies the remaining sliver.
-            domain=dict(x=[0.0, 0.92], y=[0.0, 1.0]),
-            # Orthographic projection eliminates perspective distortion
-            # (distant features render at the same scale as near ones)
-            # without changing the figure size: that's determined by the
-            # bounding box and aspectratio, not the camera distance.
-            camera=dict(
-                eye=_camera_eye(args.elev, args.azim),
-                projection=dict(type="orthographic"),
-            ),
+        font=dict(size=_BASE_FONT_SIZE),
+        scene=_build_scene_layout(
+            grid,
+            xcol=xcol,
+            ycol=ycol,
+            metric_label=metric.label,
+            elev=args.elev,
+            azim=args.azim,
         ),
         margin=dict(l=10, r=10, t=60, b=10),
     )

--- a/scripts/ferret_plot/kinds/surface.py
+++ b/scripts/ferret_plot/kinds/surface.py
@@ -85,7 +85,7 @@ def _compute_aspect_ratio(grid: pd.DataFrame) -> dict:
     )
 
 
-def _build_surface_trace(
+def _build_surface_trace(  # noqa: PLR0913
     grid: pd.DataFrame,
     *,
     z: np.ndarray,
@@ -167,7 +167,7 @@ def _build_surface_trace(
     )
 
 
-def _build_scene_layout(
+def _build_scene_layout(  # noqa: PLR0913
     grid: pd.DataFrame,
     *,
     xcol: str,

--- a/scripts/ferret_plot/kinds/surface.py
+++ b/scripts/ferret_plot/kinds/surface.py
@@ -11,10 +11,10 @@ import plotly.graph_objects as go
 
 from ferret_plot.columns import bench_name, resolve_metric
 from ferret_plot.errors import PlotError
-from ferret_plot.formatting import human_readable
 from ferret_plot.kinds._shared import (
-    _DEFAULT_CMAP,
+    assert_logz_positive,
     axis_ticks,
+    hover_text_grid,
     prepare_grid,
     resolve_heatmap_xy,
     validate_cmap,
@@ -50,7 +50,7 @@ def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> go.Figure:
     grid = prepare_grid(df, xcol=xcol, ycol=ycol, value_col=metric.column, require_complete=True)
     z = _z_values(grid)
 
-    cmap = validate_cmap(args.cmap or _DEFAULT_CMAP)
+    cmap = validate_cmap(args.cmap)
 
     # Quantize the surface color to integer steps so the colormap
     # paints discrete bands (one per integer of the colored quantity)
@@ -58,8 +58,7 @@ def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> go.Figure:
     # the color is stepped. Contour lines drawn at the same integers
     # mark the boundaries crisply.
     if args.logz:
-        if np.nanmin(z) <= 0:
-            raise PlotError("--logz requires positive metric values")
+        assert_logz_positive(z)
         color_source = np.log10(z)
     else:
         color_source = z
@@ -70,26 +69,12 @@ def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> go.Figure:
     x_positions = np.arange(len(grid.columns))
     y_positions = np.arange(len(grid.index))
 
-    n_rows = len(grid.index)
-    n_cols = len(grid.columns)
     # Per-cell hover text. Plotly's Surface trace indexes the text
-    # array as text[x_idx][y_idx] at the hovered point — the OPPOSITE
-    # of the (y, x) order it uses for z. So we build text shape
-    # (n_cols, n_rows) where the OUTER axis maps to surface.x (grid
-    # columns / xcol values) and INNER axis maps to surface.y (grid
-    # index / ycol values). np.array(..., dtype=object) preserves the
-    # 2D shape — a plain list-of-lists would silently flatten.
-    hover_text = np.array(
-        [
-            [
-                f"{xcol}={human_readable(grid.columns[j])}"
-                f"<br>{ycol}={human_readable(grid.index[i])}"
-                f"<br>{metric.label}={z[i, j]:.3g}"
-                for i in range(n_rows)
-            ]
-            for j in range(n_cols)
-        ],
-        dtype=object,
+    # array as text[x_idx][y_idx] — the OPPOSITE of the (y, x) order
+    # it uses for z.  transpose=True builds shape (n_cols, n_rows)
+    # where the outer axis maps to surface.x and the inner to surface.y.
+    hover_text = hover_text_grid(
+        grid, xcol=xcol, ycol=ycol, value_label=metric.label, z=z, transpose=True
     )
 
     surface = go.Surface(

--- a/scripts/ferret_plot/kinds/surface.py
+++ b/scripts/ferret_plot/kinds/surface.py
@@ -258,9 +258,7 @@ def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> go.Figure:
     # array as text[x_idx][y_idx] — the OPPOSITE of the (y, x) order
     # it uses for z.  transpose=True builds shape (n_cols, n_rows)
     # where the outer axis maps to surface.x and the inner to surface.y.
-    hover_text = hover_text_grid(
-        grid, xcol=xcol, ycol=ycol, value_label=metric.label, z=z, transpose=True
-    )
+    hover_text = hover_text_grid(grid, xcol=xcol, ycol=ycol, value_label=metric.label, z=z, transpose=True)
 
     surface = _build_surface_trace(
         grid,

--- a/scripts/ferret_plot/output.py
+++ b/scripts/ferret_plot/output.py
@@ -25,10 +25,14 @@ from typing import Any
 
 from ferret_plot.errors import PlotError
 
-_IMAGE_FORMATS = frozenset({"png", "svg", "pdf", "jpg", "jpeg", "webp"})
+_IMAGE_FORMATS = frozenset({"png", "svg", "pdf", "jpg", "webp"})
 _HTML_FORMATS = frozenset({"html"})
 _KNOWN_FORMATS = _IMAGE_FORMATS | _HTML_FORMATS
 _HTML_JS_MAP = {"cdn": "cdn", "inline": True, "sibling": "directory"}
+
+# Public names consumed by cli.py to keep choices in sync with this module.
+KNOWN_FORMATS = _KNOWN_FORMATS
+HTML_JS_CHOICES = list(_HTML_JS_MAP)
 
 # Names kaleido v1 checks on PATH for Chrome/Chromium.
 _CHROME_NAMES = (

--- a/scripts/ferret_plot/output.py
+++ b/scripts/ferret_plot/output.py
@@ -16,6 +16,7 @@ so users don't see kaleido's internal traceback. Result is cached.
 from __future__ import annotations
 
 import atexit
+import contextlib
 import os
 import shutil
 import subprocess
@@ -232,10 +233,8 @@ def emit(fig: Any, *, out: str | None, fmt: str | None, html_js: str) -> None:
                 out_path = tmp.name
 
             def _unlink_temp(path: str) -> None:
-                try:
+                with contextlib.suppress(OSError):
                     os.unlink(path)
-                except OSError:
-                    pass
 
             atexit.register(_unlink_temp, out_path)
         else:

--- a/scripts/ferret_plot/output.py
+++ b/scripts/ferret_plot/output.py
@@ -15,9 +15,11 @@ so users don't see kaleido's internal traceback. Result is cached.
 
 from __future__ import annotations
 
+import atexit
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import webbrowser
 from pathlib import Path
@@ -228,6 +230,14 @@ def emit(fig: Any, *, out: str | None, fmt: str | None, html_js: str) -> None:
         if out is None:
             with tempfile.NamedTemporaryFile(suffix=".html", delete=False) as tmp:
                 out_path = tmp.name
+
+            def _unlink_temp(path: str) -> None:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+
+            atexit.register(_unlink_temp, out_path)
         else:
             out_path = out
         fig.write_html(
@@ -236,7 +246,9 @@ def emit(fig: Any, *, out: str | None, fmt: str | None, html_js: str) -> None:
             full_html=True,
         )
         if out is None:
-            webbrowser.open(f"file://{out_path}")
+            opened = webbrowser.open(f"file://{out_path}")
+            if not opened:
+                print(f"plot.py: no browser available; HTML written to {out_path}", file=sys.stderr)
         return
 
     # Image format => kaleido path. Probe Chrome first.

--- a/src/cli_axis.cpp
+++ b/src/cli_axis.cpp
@@ -58,8 +58,8 @@ std::vector<int64_t> parse_cli_axis_value(const std::string& cli_value, const Ax
     try {
       return axis.expand_range(lo, hi, at_k);
     } catch (const std::invalid_argument& e) {
-      // Re-throw with the cli_value context that the old expand_range_token
-      // attached via its `context` parameter.
+      // Append the cli_value context so the diagnostic names the
+      // offending input token.
       throw std::invalid_argument(std::string(e.what()) + " (in: " + cli_value + ")");
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,8 +28,8 @@ int main(int argc, char** argv) {
     auto* list_cmd = app.add_subcommand("list", "List registered benchmarks");
 
     auto* run_cmd = app.add_subcommand("run", "Run a benchmark");
-    std::string name;
-    run_cmd->add_option("name", name, "benchmark name")->required();
+    ferret::RunOptions opts{};
+    run_cmd->add_option("name", opts.name, "benchmark name")->required();
 
     // --log-level is attached to run_cmd, not app, because run_cmd uses
     // allow_extras() and would otherwise swallow it as an --<axis>= override.
@@ -38,23 +38,18 @@ int main(int argc, char** argv) {
         ->add_option("--log-level", log_level_str, "log level: trace|debug|info|warn|error|critical|off (default warn)")
         ->check(CLI::IsMember({"trace", "debug", "info", "warn", "warning", "error", "critical", "off"}));
 
-    std::string out_path;
-    run_cmd->add_option("--out", out_path, "CSV output path (default stdout)");
+    run_cmd->add_option("--out", opts.out_path, "CSV output path (default stdout)");
 
-    int core = -1;
-    run_cmd->add_option("--core", core, "core to pin to (default: no pin)");
+    run_cmd->add_option("--core", opts.core, "core to pin to (default: no pin)");
 
     std::string freq_str;
     run_cmd->add_option("--freq", freq_str, "core frequency, e.g. 4.521GHz; enables cycles_per_site columns");
 
-    int reps = 7;
-    run_cmd->add_option("--reps", reps, "number of timed repetitions per param point (default 7)");
+    run_cmd->add_option("--reps", opts.reps, "number of timed repetitions per param point (default 7)");
 
-    int warmup = 1;
-    run_cmd->add_option("--warmup", warmup, "warmup calls before each measurement (default 1)");
+    run_cmd->add_option("--warmup", opts.warmup, "warmup calls before each measurement (default 1)");
 
-    int64_t seed = 1;
-    run_cmd->add_option("--seed", seed, "RNG seed for benchmarks that randomize (default 1)");
+    run_cmd->add_option("--seed", opts.seed, "RNG seed for benchmarks that randomize (default 1)");
 
     run_cmd->allow_extras();
 
@@ -67,16 +62,15 @@ int main(int argc, char** argv) {
     }
 
     if (*run_cmd) {
-      if (reps < 1) {
-        flog::error("--reps must be >= 1 (got {})", reps);
+      if (opts.reps < 1) {
+        flog::error("--reps must be >= 1 (got {})", opts.reps);
         return 2;
       }
-      if (warmup < 0) {
-        flog::error("--warmup must be >= 0 (got {})", warmup);
+      if (opts.warmup < 0) {
+        flog::error("--warmup must be >= 0 (got {})", opts.warmup);
         return 2;
       }
 
-      ferret::RunOptions opts;
       try {
         opts.overrides = ferret::parse_extras(run_cmd->remaining());
       } catch (const std::exception& e) {
@@ -92,12 +86,6 @@ int main(int argc, char** argv) {
           return 2;
         }
       }
-      opts.name = name;
-      opts.out_path = out_path;
-      opts.core = core;
-      opts.reps = reps;
-      opts.warmup = warmup;
-      opts.seed = seed;
       return ferret::run(opts);
     }
 

--- a/src/pinning/linux.cpp
+++ b/src/pinning/linux.cpp
@@ -2,8 +2,6 @@
 
 #include <pthread.h>
 #include <sched.h>
-#include <sys/mman.h>
-#include <sys/resource.h>
 
 namespace ferret::pinning {
 
@@ -13,9 +11,5 @@ bool pin_to_core(int cpu) {
   CPU_SET(cpu, &set);
   return pthread_setaffinity_np(pthread_self(), sizeof(set), &set) == 0;
 }
-
-bool boost_priority() { return setpriority(PRIO_PROCESS, 0, -10) == 0; }
-
-bool lock_memory() { return mlockall(MCL_CURRENT | MCL_FUTURE) == 0; }
 
 }  // namespace ferret::pinning

--- a/src/pinning/macos.cpp
+++ b/src/pinning/macos.cpp
@@ -4,9 +4,7 @@
 #include <mach/thread_act.h>
 #include <mach/thread_policy.h>
 #include <pthread.h>
-#include <sys/mman.h>
 #include <sys/qos.h>
-#include <sys/resource.h>
 
 #include "ferret/log.hpp"
 
@@ -43,9 +41,5 @@ bool pin_to_core(int cpu) {
       kr, cpu);
   return true;
 }
-
-bool boost_priority() { return setpriority(PRIO_PROCESS, 0, -10) == 0; }
-
-bool lock_memory() { return mlockall(MCL_CURRENT | MCL_FUTURE) == 0; }
 
 }  // namespace ferret::pinning

--- a/src/pinning/posix_common.cpp
+++ b/src/pinning/posix_common.cpp
@@ -1,0 +1,12 @@
+#include "ferret/pinning.hpp"
+
+#include <sys/mman.h>
+#include <sys/resource.h>
+
+namespace ferret::pinning {
+
+bool boost_priority() { return setpriority(PRIO_PROCESS, 0, -10) == 0; }
+
+bool lock_memory() { return mlockall(MCL_CURRENT | MCL_FUTURE) == 0; }
+
+}  // namespace ferret::pinning

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,6 +82,7 @@ gtest_discover_tests(test_runner)
 add_executable(test_padding test_padding.cpp)
 target_link_libraries(test_padding PRIVATE
   ferret_core
+  sljit::sljit
   GTest::gtest GTest::gtest_main
   ferret_warnings
 )
@@ -106,10 +107,11 @@ gtest_discover_tests(test_bench_helpers)
 
 add_executable(test_nested_call_depth
   test_nested_call_depth.cpp
-  ../benchmarks/nested_call_depth.cpp
 )
+target_sources(test_nested_call_depth PRIVATE $<TARGET_OBJECTS:ferret_benchmarks>)
 target_link_libraries(test_nested_call_depth PRIVATE
   ferret_core
+  ferret_benchmarks
   sljit::sljit
   GTest::gtest GTest::gtest_main
 )
@@ -117,10 +119,11 @@ gtest_discover_tests(test_nested_call_depth)
 
 add_executable(test_branch_history_footprint
   test_branch_history_footprint.cpp
-  ../benchmarks/branch_history_footprint.cpp
 )
+target_sources(test_branch_history_footprint PRIVATE $<TARGET_OBJECTS:ferret_benchmarks>)
 target_link_libraries(test_branch_history_footprint PRIVATE
   ferret_core
+  ferret_benchmarks
   sljit::sljit
   GTest::gtest GTest::gtest_main
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_executable(test_smoke test_smoke.cpp)
-target_link_libraries(test_smoke PRIVATE GTest::gtest GTest::gtest_main)
+target_link_libraries(test_smoke PRIVATE
+  ferret_core
+  GTest::gtest GTest::gtest_main
+  ferret_warnings
+)
 gtest_discover_tests(test_smoke)
 
 add_executable(test_deps_link test_deps_link.cpp)
@@ -146,6 +150,14 @@ target_link_libraries(test_parse PRIVATE
   ferret_warnings
 )
 gtest_discover_tests(test_parse)
+
+add_executable(test_run_options test_run_options.cpp)
+target_link_libraries(test_run_options PRIVATE
+  ferret_core
+  GTest::gtest GTest::gtest_main
+  ferret_warnings
+)
+gtest_discover_tests(test_run_options)
 
 add_executable(test_integration test_integration.cpp)
 target_compile_definitions(test_integration PRIVATE

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -8,12 +8,17 @@ import argparse
 import sys
 from pathlib import Path
 
+import pytest
+
 _SCRIPTS = Path(__file__).resolve().parent.parent.parent / "scripts"
 sys.path.insert(0, str(_SCRIPTS))
 
+from ferret_plot import cli as _cli
+from ferret_plot import output
 
-# Per-kind default attribute sets — match the argparse namespaces built by
-# ferret_plot.cli.build_parser. Update both sides when adding a flag.
+
+# Destinations shared by every subparser — worth declaring explicitly so
+# tests can override them without knowing a subcommand's specific flags.
 _COMMON_DEFAULTS = {
     "csv": "",
     "out": None,
@@ -23,12 +28,36 @@ _COMMON_DEFAULTS = {
     "metric": "auto",
     "stat": "min",
 }
-_KIND_DEFAULTS = {
-    "line": {"x": None, "xscale": None, "series": None, "ymax": None},
-    "heatmap": {"x": None, "y": None, "logz": False, "cmap": None},
-    "facets": {"facet": None, "x": None, "y": None, "logz": False, "cmap": None},
-    "surface": {"x": None, "y": None, "logz": False, "elev": 20.0, "azim": -2.0, "cmap": None},
-}
+
+
+def _introspect_kind_defaults() -> dict[str, dict[str, object]]:
+    """Derive per-subcommand default dicts from the live parser.
+
+    Walks every subparser and collects the `default` of each _StoreAction,
+    skipping the destinations already covered by _COMMON_DEFAULTS and the
+    internal `handler` default injected by set_defaults.
+    """
+    import argparse as _ap
+
+    skip = set(_COMMON_DEFAULTS) | {"handler", "kind"}
+    result: dict[str, dict[str, object]] = {}
+    parser = _cli.build_parser()
+    for action in parser._actions:
+        if not isinstance(action, _ap._SubParsersAction):
+            continue
+        for name, subparser in action.choices.items():
+            defaults: dict[str, object] = {}
+            for sub_action in subparser._actions:
+                if sub_action.dest in skip:
+                    continue
+                if sub_action.dest == argparse.SUPPRESS:
+                    continue
+                defaults[sub_action.dest] = sub_action.default
+            result[name] = defaults
+    return result
+
+
+_KIND_DEFAULTS = _introspect_kind_defaults()
 
 
 def make_args(kind: str = "line", **overrides) -> argparse.Namespace:
@@ -36,3 +65,32 @@ def make_args(kind: str = "line", **overrides) -> argparse.Namespace:
     base = {**_COMMON_DEFAULTS, **_KIND_DEFAULTS[kind]}
     base.update(overrides)
     return argparse.Namespace(**base)
+
+
+@pytest.fixture(autouse=True)
+def _clear_chrome_cache():
+    output._chrome_probe_cache.clear()
+    yield
+    output._chrome_probe_cache.clear()
+
+
+@pytest.fixture
+def fake_png_export(monkeypatch):
+    """Stub out PNG export so tests do not require a real Chrome/Kaleido binary.
+
+    Patches _chrome_available to return True, clears the probe cache, and
+    replaces Figure.write_image with a stub that writes a minimal valid PNG
+    header and records the last call in the returned `captured` dict.
+    """
+    captured: dict = {}
+
+    def _fake_write_image(self, path, **kwargs):
+        captured["path"] = path
+        captured["kwargs"] = kwargs
+        with open(path, "wb") as f:
+            f.write(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+
+    monkeypatch.setattr(output, "_chrome_available", lambda: True)
+    output._chrome_probe_cache.clear()
+    monkeypatch.setattr("plotly.graph_objects.Figure.write_image", _fake_write_image)
+    yield captured

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -13,9 +13,8 @@ import pytest
 _SCRIPTS = Path(__file__).resolve().parent.parent.parent / "scripts"
 sys.path.insert(0, str(_SCRIPTS))
 
-from ferret_plot import cli as _cli
-from ferret_plot import output
-
+from ferret_plot import cli as _cli  # noqa: E402  # sys.path setup must precede
+from ferret_plot import output  # noqa: E402  # sys.path setup must precede
 
 # Destinations shared by every subparser — worth declaring explicitly so
 # tests can override them without knowing a subcommand's specific flags.
@@ -37,13 +36,11 @@ def _introspect_kind_defaults() -> dict[str, dict[str, object]]:
     skipping the destinations already covered by _COMMON_DEFAULTS and the
     internal `handler` default injected by set_defaults.
     """
-    import argparse as _ap
-
     skip = set(_COMMON_DEFAULTS) | {"handler", "kind"}
     result: dict[str, dict[str, object]] = {}
     parser = _cli.build_parser()
     for action in parser._actions:
-        if not isinstance(action, _ap._SubParsersAction):
+        if not isinstance(action, argparse._SubParsersAction):
             continue
         for name, subparser in action.choices.items():
             defaults: dict[str, object] = {}

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -23,14 +23,11 @@ _COMMON_DEFAULTS = {
     "metric": "auto",
     "stat": "min",
 }
-# `cmap` is registered per-kind by the migrating tasks (Tasks 5-7).
-# Listed here ahead of time so make_args(...) won't AttributeError
-# when those tasks land.
 _KIND_DEFAULTS = {
     "line": {"x": None, "xscale": None, "series": None, "ymax": None},
     "heatmap": {"x": None, "y": None, "logz": False, "cmap": None},
     "facets": {"facet": None, "x": None, "y": None, "logz": False, "cmap": None},
-    "surface": {"x": None, "y": None, "logz": False, "elev": 20.0, "azim": -13.0, "cmap": None},
+    "surface": {"x": None, "y": None, "logz": False, "elev": 20.0, "azim": -2.0, "cmap": None},
 }
 
 

--- a/tests/python/fixtures.py
+++ b/tests/python/fixtures.py
@@ -1,7 +1,7 @@
 """Synthetic DataFrames mirroring ferret CSV output.
 
 One builder per registered benchmark. Column names and order match
-what CsvWriter (src/output/csv.cpp) emits.
+what the CSV writer emits.
 """
 
 from __future__ import annotations
@@ -80,8 +80,8 @@ def three_axis_df(
 ) -> pd.DataFrame:
     """Synthetic 3-axis frame: branches × spacing × variant.
 
-    'variant' stands in for a future option-as-axis case (e.g. a TAGE
-    predictor configuration). Not a real ferret column today.
+    'variant' stands in for an option-as-axis case (e.g. a TAGE
+    predictor configuration). Not a real ferret column.
     """
     rows = []
     for b in branches:

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pandas as pd
 import pytest
-from ferret_plot import cli, output
+from ferret_plot import cli
 from ferret_plot.cli import EXIT_USER_ERROR
 from fixtures import dbf_df, dct_df, tage_capacity_df, three_axis_df
 
@@ -21,35 +21,17 @@ def _write_csv(df, tmp_path: Path, name: str) -> str:
 
 
 class TestLineSubcommand:
-    def test_line_produces_png(self, tmp_path, monkeypatch):
+    def test_line_produces_png(self, tmp_path, fake_png_export):
         csv_path = _write_csv(dbf_df(), tmp_path, "btb.csv")
         out_path = tmp_path / "out.png"
-
-        def fake_write_image(self, path, **kwargs):
-            with open(path, "wb") as f:
-                f.write(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
-
-        monkeypatch.setattr(output, "_chrome_available", lambda: True)
-        output._chrome_probe_cache.clear()
-        monkeypatch.setattr("plotly.graph_objects.Figure.write_image", fake_write_image)
-
         rc = cli.main(["line", csv_path, "--out", str(out_path)])
         assert rc == 0
         assert out_path.exists()
         assert out_path.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
 
-    def test_line_with_spacing_bytes_x(self, tmp_path, monkeypatch):
+    def test_line_with_spacing_bytes_x(self, tmp_path, fake_png_export):
         csv_path = _write_csv(dbf_df(), tmp_path, "btb.csv")
         out_path = tmp_path / "out.png"
-
-        def fake_write_image(self, path, **kwargs):
-            with open(path, "wb") as f:
-                f.write(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
-
-        monkeypatch.setattr(output, "_chrome_available", lambda: True)
-        output._chrome_probe_cache.clear()
-        monkeypatch.setattr("plotly.graph_objects.Figure.write_image", fake_write_image)
-
         rc = cli.main(["line", csv_path, "--x", "spacing_bytes", "--out", str(out_path)])
         assert rc == 0
         assert out_path.exists()
@@ -65,35 +47,17 @@ class TestLineSubcommand:
 
 
 class TestHeatmapSubcommand:
-    def test_heatmap_produces_png(self, tmp_path, monkeypatch):
+    def test_heatmap_produces_png(self, tmp_path, fake_png_export):
         csv_path = _write_csv(dbf_df(), tmp_path, "btb.csv")
         out_path = tmp_path / "heat.png"
-
-        def fake_write_image(self, path, **kwargs):
-            with open(path, "wb") as f:
-                f.write(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
-
-        monkeypatch.setattr(output, "_chrome_available", lambda: True)
-        output._chrome_probe_cache.clear()
-        monkeypatch.setattr("plotly.graph_objects.Figure.write_image", fake_write_image)
-
         rc = cli.main(["heatmap", csv_path, "--out", str(out_path)])
         assert rc == 0
         assert out_path.exists()
         assert out_path.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
 
-    def test_heatmap_with_explicit_xy(self, tmp_path, monkeypatch):
+    def test_heatmap_with_explicit_xy(self, tmp_path, fake_png_export):
         csv_path = _write_csv(dbf_df(), tmp_path, "btb.csv")
         out_path = tmp_path / "heat-xy.png"
-
-        def fake_write_image(self, path, **kwargs):
-            with open(path, "wb") as f:
-                f.write(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
-
-        monkeypatch.setattr(output, "_chrome_available", lambda: True)
-        output._chrome_probe_cache.clear()
-        monkeypatch.setattr("plotly.graph_objects.Figure.write_image", fake_write_image)
-
         rc = cli.main(["heatmap", csv_path, "--x", "spacing_bytes", "--y", "branches", "--out", str(out_path)])
         assert rc == 0
         assert out_path.exists()
@@ -109,22 +73,9 @@ class TestSurfaceSubcommand:
         assert args.elev == _SURFACE_ELEV_DEFAULT
         assert args.azim == _SURFACE_AZIM_DEFAULT
 
-    def test_surface_produces_png(self, tmp_path, monkeypatch):
+    def test_surface_produces_png(self, tmp_path, fake_png_export):
         csv_path = _write_csv(tage_capacity_df(), tmp_path, "tage.csv")
         out_path = tmp_path / "surface.png"
-
-        captured = {}
-
-        def fake_write_image(self, path, **kwargs):
-            captured["path"] = path
-            captured["kwargs"] = kwargs
-            with open(path, "wb") as f:
-                f.write(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
-
-        monkeypatch.setattr(output, "_chrome_available", lambda: True)
-        output._chrome_probe_cache.clear()
-        monkeypatch.setattr("plotly.graph_objects.Figure.write_image", fake_write_image)
-
         rc = cli.main(
             [
                 "surface",
@@ -140,7 +91,7 @@ class TestSurfaceSubcommand:
         assert rc == 0
         assert out_path.exists()
         assert out_path.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
-        assert captured["kwargs"]["format"] == "png"
+        assert fake_png_export["kwargs"]["format"] == "png"
 
     def test_surface_invalid_axis_exits_2(self, tmp_path, capsys):
         csv_path = _write_csv(tage_capacity_df(), tmp_path, "tage.csv")
@@ -161,18 +112,9 @@ class TestSurfaceSubcommand:
 
 
 class TestFacetsSubcommand:
-    def test_facets_produces_png(self, tmp_path, monkeypatch):
+    def test_facets_produces_png(self, tmp_path, fake_png_export):
         csv_path = _write_csv(three_axis_df(variants=("a", "b", "c")), tmp_path, "3ax.csv")
         out_path = tmp_path / "facets.png"
-
-        def fake_write_image(self, path, **kwargs):
-            with open(path, "wb") as f:
-                f.write(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
-
-        monkeypatch.setattr(output, "_chrome_available", lambda: True)
-        output._chrome_probe_cache.clear()
-        monkeypatch.setattr("plotly.graph_objects.Figure.write_image", fake_write_image)
-
         rc = cli.main(["facets", csv_path, "--facet", "variant", "--out", str(out_path)])
         assert rc == 0
         assert out_path.exists()

--- a/tests/python/test_columns.py
+++ b/tests/python/test_columns.py
@@ -120,7 +120,7 @@ class TestHumanReadable:
         assert human_readable(-5) == "-5"
 
     def test_kilobyte_suffix(self):
-        assert human_readable(2048) == "2K"  # noqa: PLR2004
+        assert human_readable(2048) == "2K"
 
     def test_megabyte_suffix(self):
         assert human_readable(3 * (1 << 20)) == "3M"

--- a/tests/python/test_line.py
+++ b/tests/python/test_line.py
@@ -58,13 +58,6 @@ class TestLineMakeFigure:
             line_kind.make_figure(df, _args(x="not_a_column"))
 
     def test_scattergl_used_for_large_point_count(self):
-        # Synthesize > 5000 total points across one series.
         df = dct_df(chain_lengths=tuple(range(_LARGE_POINTS + 100)))
         fig = line_kind.make_figure(df, _args())
-        # plotly's Scattergl trace has type "scattergl"; some versions
-        # promote to "scatter" — accept either as long as it's a gl variant.
-        assert isinstance(fig.data[0], (go.Scattergl, go.Scatter))
-        if isinstance(fig.data[0], go.Scatter) and fig.data[0].type != "scattergl":
-            # If it's just go.Scatter, the trace constructor must have been go.Scattergl
-            # at build time. Skip the type assertion in that edge case.
-            pass
+        assert fig.data[0].type == "scattergl"

--- a/tests/python/test_output.py
+++ b/tests/python/test_output.py
@@ -17,14 +17,6 @@ def _fig() -> go.Figure:
     return go.Figure(data=[go.Scatter(x=[0, 1], y=[0, 1])])
 
 
-@pytest.fixture(autouse=True)
-def _clear_chrome_cache():
-    """Bust the cached chrome probe so tests don't leak state across order."""
-    output._chrome_probe_cache.clear()
-    yield
-    output._chrome_probe_cache.clear()
-
-
 class TestEmitFormatResolution:
     def test_html_extension_routes_to_write_html(self, tmp_path, monkeypatch):
         fig = _fig()

--- a/tests/python/test_registry.py
+++ b/tests/python/test_registry.py
@@ -74,7 +74,7 @@ class TestResolveDefaults:
 
 
 class TestBenchmarkDefaults:
-    """Verify the dataclass shape so future task changes don't silently drop fields."""
+    """Verify the dataclass exposes every expected default field."""
 
     def test_empty_defaults_have_all_none_fields(self):
         d = reg.BenchmarkDefaults()

--- a/tests/sljit_test_helpers.hpp
+++ b/tests/sljit_test_helpers.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <string>
+
+extern "C" {
+#include <sljitLir.h>
+}
+
+#include "ferret/benchmark.hpp"
+
+namespace ferret::testing {
+
+inline const BenchOption* find_option(const BenchOptions& opts, const std::string& name) {
+  for (const auto& o : opts) {
+    if (o.name == name) return &o;
+  }
+  return nullptr;
+}
+
+struct CompilerHandle {
+  sljit_compiler* c = sljit_create_compiler(nullptr);
+  CompilerHandle() = default;
+  ~CompilerHandle() {
+    if (c) sljit_free_compiler(c);
+  }
+  CompilerHandle(const CompilerHandle&) = delete;
+  CompilerHandle& operator=(const CompilerHandle&) = delete;
+};
+
+}  // namespace ferret::testing

--- a/tests/test_bench_helpers.cpp
+++ b/tests/test_bench_helpers.cpp
@@ -5,25 +5,28 @@ extern "C" {
 #include <gtest/gtest.h>
 
 #include "ferret/bench_helpers.hpp"
+#include "sljit_test_helpers.hpp"
+
+using ferret::testing::CompilerHandle;
 
 namespace {
 
 // Minimal kernel: outer loop that decrements a counter; body increments R0.
 // After `iters` iterations, R0 should equal `iters`.
 TEST(BenchHelpers, EmitOuterLoopRunsIterTimes) {
-  sljit_compiler* c = sljit_create_compiler(nullptr);
-  ASSERT_NE(c, nullptr);
+  CompilerHandle ch;
+  ASSERT_NE(ch.c, nullptr);
 
   // Return R0 via SLJIT_RETURN.
-  sljit_emit_enter(c, 0, SLJIT_ARGS0(W), /*scratches=*/2, /*saved=*/0, /*local_size=*/0);
-  sljit_emit_op1(c, SLJIT_MOV, SLJIT_R0, 0, SLJIT_IMM, 0);
+  sljit_emit_enter(ch.c, 0, SLJIT_ARGS0(W), /*scratches=*/2, /*saved=*/0, /*local_size=*/0);
+  sljit_emit_op1(ch.c, SLJIT_MOV, SLJIT_R0, 0, SLJIT_IMM, 0);
 
-  ferret::emit_outer_loop(c, SLJIT_R1, /*iters=*/7,
-                          [&] { sljit_emit_op2(c, SLJIT_ADD, SLJIT_R0, 0, SLJIT_R0, 0, SLJIT_IMM, 1); });
+  ferret::emit_outer_loop(ch.c, SLJIT_R1, /*iters=*/7,
+                          [&] { sljit_emit_op2(ch.c, SLJIT_ADD, SLJIT_R0, 0, SLJIT_R0, 0, SLJIT_IMM, 1); });
 
-  sljit_emit_return(c, SLJIT_MOV, SLJIT_R0, 0);
+  sljit_emit_return(ch.c, SLJIT_MOV, SLJIT_R0, 0);
 
-  void* code = sljit_generate_code(c, 0, nullptr);
+  void* code = sljit_generate_code(ch.c, 0, nullptr);
   ASSERT_NE(code, nullptr);
 
   using fn_t = sljit_sw (*)();
@@ -31,40 +34,37 @@ TEST(BenchHelpers, EmitOuterLoopRunsIterTimes) {
   EXPECT_EQ(fn(), 7);
 
   sljit_free_code(code, nullptr);
-  sljit_free_compiler(c);
 }
 
 TEST(BenchHelpers, EmitOuterLoopOneIterationStillRunsBody) {
-  sljit_compiler* c = sljit_create_compiler(nullptr);
-  ASSERT_NE(c, nullptr);
+  CompilerHandle ch;
+  ASSERT_NE(ch.c, nullptr);
 
-  sljit_emit_enter(c, 0, SLJIT_ARGS0(W), 2, 0, 0);
-  sljit_emit_op1(c, SLJIT_MOV, SLJIT_R0, 0, SLJIT_IMM, 0);
+  sljit_emit_enter(ch.c, 0, SLJIT_ARGS0(W), 2, 0, 0);
+  sljit_emit_op1(ch.c, SLJIT_MOV, SLJIT_R0, 0, SLJIT_IMM, 0);
 
-  ferret::emit_outer_loop(c, SLJIT_R1, /*iters=*/1,
-                          [&] { sljit_emit_op2(c, SLJIT_ADD, SLJIT_R0, 0, SLJIT_R0, 0, SLJIT_IMM, 1); });
+  ferret::emit_outer_loop(ch.c, SLJIT_R1, /*iters=*/1,
+                          [&] { sljit_emit_op2(ch.c, SLJIT_ADD, SLJIT_R0, 0, SLJIT_R0, 0, SLJIT_IMM, 1); });
 
-  sljit_emit_return(c, SLJIT_MOV, SLJIT_R0, 0);
+  sljit_emit_return(ch.c, SLJIT_MOV, SLJIT_R0, 0);
 
-  void* code = sljit_generate_code(c, 0, nullptr);
+  void* code = sljit_generate_code(ch.c, 0, nullptr);
   ASSERT_NE(code, nullptr);
   auto fn = reinterpret_cast<sljit_sw (*)()>(code);
   EXPECT_EQ(fn(), 1);
 
   sljit_free_code(code, nullptr);
-  sljit_free_compiler(c);
 }
 
 TEST(BenchHelpers, EmitOuterLoopZeroItersAsserts) {
-  sljit_compiler* c = sljit_create_compiler(nullptr);
-  ASSERT_NE(c, nullptr);
-  sljit_emit_enter(c, 0, SLJIT_ARGS0(W), 2, 0, 0);
+  CompilerHandle ch;
+  ASSERT_NE(ch.c, nullptr);
+  sljit_emit_enter(ch.c, 0, SLJIT_ARGS0(W), 2, 0, 0);
   // EXPECT_DEBUG_DEATH (not EXPECT_DEATH): the assert is compiled out in
   // Release builds (NDEBUG defined). DEBUG_DEATH executes the expression
   // once in Release without expecting a crash, and asserts a death match
   // only in Debug builds — the correct test for an assert-based guard.
-  EXPECT_DEBUG_DEATH(ferret::emit_outer_loop(c, SLJIT_R1, /*iters=*/0, [] {}), "iters > 0");
-  sljit_free_compiler(c);
+  EXPECT_DEBUG_DEATH(ferret::emit_outer_loop(ch.c, SLJIT_R1, /*iters=*/0, [] {}), "iters > 0");
 }
 
 TEST(BenchHelpers, ComputeIterationsScalesByBudget) {
@@ -75,18 +75,18 @@ TEST(BenchHelpers, ComputeIterationsScalesByBudget) {
 }
 
 TEST(BenchHelpers, VerifyUniformSpacingPassesOnExactSpacing) {
-  sljit_compiler* c = sljit_create_compiler(nullptr);
-  ASSERT_NE(c, nullptr);
-  sljit_emit_enter(c, 0, SLJIT_ARGS0V(), 1, 0, 0);
+  CompilerHandle ch;
+  ASSERT_NE(ch.c, nullptr);
+  sljit_emit_enter(ch.c, 0, SLJIT_ARGS0V(), 1, 0, 0);
 
   std::vector<sljit_label*> labels;
-  labels.push_back(sljit_emit_label(c));
+  labels.push_back(sljit_emit_label(ch.c));
   for (int i = 0; i < 4; ++i) {
-    ferret::emit_outer_loop(c, SLJIT_R0, 1, [] {});  // placeholder body
-    labels.push_back(sljit_emit_label(c));
+    ferret::emit_outer_loop(ch.c, SLJIT_R0, 1, [] {});  // placeholder body
+    labels.push_back(sljit_emit_label(ch.c));
   }
-  sljit_emit_return_void(c);
-  ASSERT_NE(sljit_generate_code(c, 0, nullptr), nullptr);
+  sljit_emit_return_void(ch.c);
+  ASSERT_NE(sljit_generate_code(ch.c, 0, nullptr), nullptr);
 
   // After generate_code, every label has a real address. We cannot assert
   // the exact spacing because emit_outer_loop's size is non-zero and
@@ -95,8 +95,6 @@ TEST(BenchHelpers, VerifyUniformSpacingPassesOnExactSpacing) {
   size_t base = sljit_get_label_addr(labels[0]);
   size_t step = sljit_get_label_addr(labels[1]) - base;
   EXPECT_NO_THROW(ferret::verify_uniform_spacing(labels, step, /*strict=*/true));
-
-  sljit_free_compiler(c);
 }
 
 TEST(BenchHelpers, VerifyUniformSpacingNoOpsOnEmpty) {

--- a/tests/test_branch_history_footprint.cpp
+++ b/tests/test_branch_history_footprint.cpp
@@ -2,10 +2,10 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <string>
 #include <vector>
 
 #include "ferret/benchmark.hpp"
+#include "sljit_test_helpers.hpp"
 
 extern "C" {
 #include <sljitLir.h>
@@ -38,19 +38,10 @@ ferret::Params make_params(int64_t branches, int64_t history_len, int64_t patter
   p.set("seed", 1);
   return p;
 }
-const ferret::BenchOption* find_option(const ferret::BenchOptions& opts, const std::string& name) {
-  for (const auto& o : opts) {
-    if (o.name == name) return &o;
-  }
-  return nullptr;
-}
-struct CompilerHandle {
-  sljit_compiler* c = sljit_create_compiler(nullptr);
-  ~CompilerHandle() {
-    if (c) sljit_free_compiler(c);
-  }
-};
 }  // namespace
+
+using ferret::testing::CompilerHandle;
+using ferret::testing::find_option;
 
 TEST(BranchHistoryFootprint, ExposesBranchesAndHistoryLenAxes) {
   auto b = ferret::BenchmarkRegistry::create("branch_history_footprint");

--- a/tests/test_cli_axis.cpp
+++ b/tests/test_cli_axis.cpp
@@ -146,8 +146,9 @@ TEST(CliAxis, GeomRangeListSyntaxStillWorks) {
 }
 
 TEST(CliAxis, EmptyHiWithAtSuffixGivesMalformedRangeOnLog2) {
-  // Was: "@k only valid for geom_range" (misleading — the real issue
-  // is empty hi). After the fix, the tokenization failure wins.
+  // Empty hi (`1..@4`) reports the tokenization failure ("malformed
+  // range"), not "@k only valid for geom_range" — the missing hi is
+  // the real fault and its diagnostic must win.
   Axis branches = Axis::log2_range("branches", 1, 1 << 15);
   try {
     (void)parse_cli_axis_value("1..@4", branches);

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -72,11 +72,10 @@ TEST(Integration, DirectBranchFootprintGeomRangeNonPow2Sweep) {
   std::filesystem::remove(out);
   // Branch range kept small. Larger ranges (e.g., 1024..4096@4) blow up
   // sljit on x86_64 because emit_nops emits one op_custom per byte of
-  // padding (src/padding.cpp:11-15) — at spacing=64 that is 59 ops per
-  // site, and the per-kernel op count grows past what sljit's metadata
-  // tracking handles. Fixing emit_nops to batch the NOPs is a separate
-  // issue. The values picked here exercise non-pow2 expansion and the
-  // CLI @k path end-to-end without tripping the underlying limit.
+  // padding — at spacing=64 that is 59 ops per site, and the per-kernel
+  // op count grows past what sljit's metadata tracking handles. The
+  // values picked here exercise non-pow2 expansion and the CLI @k path
+  // end-to-end without tripping the underlying limit.
   std::string cmd = std::string(FERRET_BINARY) +
                     " run direct_branch_footprint"
                     " --branches=64..256@2 --spacing_bytes=64"
@@ -255,8 +254,8 @@ TEST(Integration, NegativeBranchesExitsTwoNoCrash) {
 TEST(Integration, HugeBranchesExitsTwoNoCrash) {
   // Extreme positive value: log2 axis accepts it (positive), but the
   // benchmark allocator throws std::length_error / std::bad_alloc.
-  // do_run must catch and translate to exit 2 AND must not have leaked
-  // a CSV header to stdout (spec §7 class-1: no partial output).
+  // ferret::run must catch and translate to exit 2, and must not leak
+  // a CSV header to stdout (no partial output on user-error paths).
   auto out = std::filesystem::temp_directory_path() / "ferret_branchesHuge_out.txt";
   auto err = std::filesystem::temp_directory_path() / "ferret_branchesHuge_err.txt";
   std::filesystem::remove(out);
@@ -343,9 +342,9 @@ TEST(Integration, FreqNanExitsTwoNoCrash) {
 }
 
 TEST(Integration, NegativeChainLengthExitsTwoNoCrash) {
-  // chain_length=-1 was previously cast through size_t to a huge value,
-  // making the kernel loop run effectively forever. Params::get<size_t>
-  // now rejects negatives; do_run translates the throw into exit 2.
+  // chain_length=-1 must exit 2: Params::get<size_t> rejects negatives
+  // (otherwise the size_t conversion would yield a huge loop count)
+  // and ferret::run translates the throw into exit 2.
   // CTest enforces a per-test wall-clock timeout (set in
   // tests/CMakeLists.txt via gtest_discover_tests TIMEOUT property) so
   // a regression manifests as a CTest timeout rather than a hang —
@@ -410,9 +409,9 @@ void expect_spacing_rejected(const std::string& spacing_arg) {
 
 TEST(Integration, NestedCallDepthKEightStaticStillRunsCleanly) {
   // Same shape as the depth-1 smoke, but uses larger depths and asserts
-  // no empty cells. After Task 6 each body emits 8 call sites; this test
-  // protects against a regression where some of those sites fall through
-  // or are not properly wired.
+  // no empty cells. Each body emits 8 call sites; this test guards
+  // against a regression where some sites fall through or are not
+  // properly wired.
   auto out = std::filesystem::temp_directory_path() / "ferret_ncd_k8.csv";
   std::filesystem::remove(out);
   std::string cmd = std::string(FERRET_BINARY) +
@@ -489,7 +488,7 @@ TEST(Integration, NegativeSpacingBytesExitsTwoNoCrash) {
 
 TEST(Integration, ZeroChainLengthExitsTwoNoCrash) {
   // chain_length=0 yields sites_per_kernel=0, which would divide by
-  // zero in CSV normalization. do_run must reject the param point
+  // zero in CSV normalization. ferret::run must reject the param point
   // pre-flight with exit 2 and leave the output file empty.
   auto out = std::filesystem::temp_directory_path() / "ferret_chain0.csv";
   auto err = std::filesystem::temp_directory_path() / "ferret_chain0_err.txt";

--- a/tests/test_nested_call_depth.cpp
+++ b/tests/test_nested_call_depth.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <memory>
 #include <vector>
 
 extern "C" {
@@ -10,20 +9,17 @@ extern "C" {
 }
 
 #include "ferret/benchmark.hpp"
+#include "sljit_test_helpers.hpp"
 
 namespace ferret::nested_call_depth_internal {
 // Exposed for unit testing; defined in benchmarks/nested_call_depth.cpp.
 std::vector<uint8_t> generate_path_table(size_t rows, size_t row_stride, uint64_t seed);
 }  // namespace ferret::nested_call_depth_internal
 
-namespace {
+using ferret::testing::CompilerHandle;
+using ferret::testing::find_option;
 
-const ferret::BenchOption* find_option(const ferret::BenchOptions& opts, const std::string& name) {
-  for (const auto& o : opts) {
-    if (o.name == name) return &o;
-  }
-  return nullptr;
-}
+namespace {
 
 ferret::Params make_params(int64_t depth, int64_t variant, int64_t path_table_rows) {
   ferret::Params p;
@@ -33,13 +29,6 @@ ferret::Params make_params(int64_t depth, int64_t variant, int64_t path_table_ro
   p.set("seed", 1);
   return p;
 }
-
-struct CompilerHandle {
-  sljit_compiler* c = sljit_create_compiler(nullptr);
-  ~CompilerHandle() {
-    if (c) sljit_free_compiler(c);
-  }
-};
 
 // ---- Registry / shape ----
 

--- a/tests/test_pinning.cpp
+++ b/tests/test_pinning.cpp
@@ -6,9 +6,7 @@
 
 using namespace ferret;
 
-TEST(Pinning, PinToExistingCoreSucceeds) {
-  EXPECT_TRUE(pinning::pin_to_core(0));
-}
+TEST(Pinning, PinToExistingCoreSucceeds) { EXPECT_TRUE(pinning::pin_to_core(0)); }
 
 TEST(Pinning, BoostPriorityRequiresPrivilege) {
   if (geteuid() != 0) {

--- a/tests/test_pinning.cpp
+++ b/tests/test_pinning.cpp
@@ -1,29 +1,27 @@
 #include <gtest/gtest.h>
 
+#include <unistd.h>
+
 #include "ferret/pinning.hpp"
 
 using namespace ferret;
 
-// All operations are best-effort. The contract is: returns bool, never
-// throws or aborts. We don't assert success because CI runners may
-// forbid setpriority/mlockall/affinity.
-
-TEST(Pinning, PinToCoreReturnsBool) {
-  bool ok = pinning::pin_to_core(0);
-  (void)ok;
-  SUCCEED();
+TEST(Pinning, PinToExistingCoreSucceeds) {
+  EXPECT_TRUE(pinning::pin_to_core(0));
 }
 
-TEST(Pinning, BoostPriorityReturnsBool) {
-  bool ok = pinning::boost_priority();
-  (void)ok;
-  SUCCEED();
+TEST(Pinning, BoostPriorityRequiresPrivilege) {
+  if (geteuid() != 0) {
+    GTEST_SKIP() << "setpriority(-10) requires root; skipping in unprivileged CI";
+  }
+  EXPECT_TRUE(pinning::boost_priority());
 }
 
-TEST(Pinning, LockMemoryReturnsBool) {
-  bool ok = pinning::lock_memory();
-  (void)ok;
-  SUCCEED();
+TEST(Pinning, LockMemoryRequiresPrivilege) {
+  if (geteuid() != 0) {
+    GTEST_SKIP() << "mlockall requires CAP_IPC_LOCK; skipping in unprivileged CI";
+  }
+  EXPECT_TRUE(pinning::lock_memory());
 }
 
 TEST(Pinning, PinToImpossiblyHighCoreReturnsFalse) {

--- a/tests/test_run_options.cpp
+++ b/tests/test_run_options.cpp
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+
+#include "ferret/run_command.hpp"
+
+TEST(RunOptions, DefaultsDocumented) {
+  ferret::RunOptions o{};
+  EXPECT_EQ(o.reps, 7);
+  EXPECT_EQ(o.warmup, 1);
+  EXPECT_EQ(o.seed, 1);
+}

--- a/tests/test_smoke.cpp
+++ b/tests/test_smoke.cpp
@@ -1,3 +1,11 @@
 #include <gtest/gtest.h>
 
-TEST(Smoke, ArithmeticWorks) { EXPECT_EQ(2, 1 + 1); }
+#include "ferret/params.hpp"
+
+using namespace ferret;
+
+TEST(Smoke, ParamsRoundTrip) {
+  Params p;
+  p.set("branches", 1024);
+  EXPECT_EQ(p.get<int64_t>("branches"), 1024);
+}


### PR DESCRIPTION
## Summary

Aggregates the actionable findings from a max-effort whole-codebase
code review: reuse extractions, comment-rule violations, build hygiene,
test quality, and Python CLI startup latency. Twelve focused commits,
each independently revertable.

## What changed

- **Comments**: removed task-number references, change-history narration,
  file-path+line locators, and stale `do_run` / `src/output/csv.cpp`
  references; rewrote as present-tense invariants.
- **Plot kinds**: extracted `assert_logz_positive` and `hover_text_grid`
  into the shared kinds helper; surface, heatmap, and facets now reuse
  one implementation. CLI choices for `--format` / `--html-js` / `--cmap`
  derive from the authoritative output / shared modules so they cannot
  drift; `jpeg` alias dropped in favor of `jpg`.
- **Surface renderer**: split the 180-line `make_figure` into trace,
  scene, and aspect-ratio helpers; surfaced every magic number as a
  named module constant. Fixed `lightposition.z` so overhead lighting
  no longer collapses for data with `cmax << 1e5`.
- **CLI startup**: each subparser handler imports its kind module on
  first call; `plot.py --help` is ~230 ms faster.
- **Temp HTML**: registered `atexit` cleanup for the interactive
  browser staging file; surfaces the path on stderr when
  `webbrowser.open` fails.
- **C++ runner**: `RunOptions{}` is the single source of defaults;
  `main.cpp` reads from the struct instead of redeclaring literals;
  guard test added.
- **C++ tests**: extracted `find_option` and `CompilerHandle` into
  `tests/sljit_test_helpers.hpp`; the two duplicated copies removed
  and `test_bench_helpers` gained exception-safe cleanup via RAII.
- **Pinning**: hoisted `boost_priority` and `lock_memory` to
  `src/pinning/posix_common.cpp` so the Linux and macOS files share
  one implementation.
- **Build**: flipped `sljit::sljit` to PRIVATE on `ferret_core`;
  introduced a `ferret_benchmarks` OBJECT library so the four
  benchmark TUs compile once instead of once per test target.
- **CI**: dropped redundant `nix flake check` / `nix build` /
  devshell-cmake triple; added ccache to the sanitizer matrix.
- **Misc**: nested_call_depth now uses the shared `mix_seed` instead
  of an ad-hoc `std::seed_seq`; per-benchmark op-budget literal
  promoted to a named `kOpBudget` constant.
- **Tests**: Python `fake_png_export` and `_clear_chrome_cache` live in
  conftest; `_KIND_DEFAULTS` introspects the real parser so the fixture
  cannot drift from CLI defaults (drift was already present in the
  `--azim` default and is now fixed). Placeholder `test_pinning` and
  `test_smoke` tests replaced with real assertions; one new
  `test_run_options` guard.

## Test plan

- [x] Python: `nix develop --command bash scripts/test_py.sh` — 111 passed.
- [x] C++: `cmake -B build && cmake --build build && ctest` — 197 passed,
      3 platform/privilege-skipped (expected: aarch64 padding test on
      x86_64, two pinning tests requiring root).
- [x] `ferret list` confirms all four benchmarks register after the
      OBJECT-library change.
- [x] `ferret run dependent_chain_throughput --chain_length=8` smoke
      run still produces a valid CSV.
- [x] `python3 scripts/plot.py --help` ~230 ms faster than main.
- [ ] Visual review of a surface plot to confirm the `lightposition.z`
      fix renders as expected (changes lighting for all surface plots
      with `cmax << 1e5`, i.e. most ferret data).
- [ ] CI green on `sanitizers.yml`, `nix.yml`, `python.yml`.

## Out of scope

Adding `lfence` / `isb` fences around the timing reads, and moving
`arch_now_ticks` to an inline header function, is left for a follow-up
PR. That work needs before/after benchmarks on a stable host so any
shift in measured floors can be quantified and explained, which isn't
appropriate for unattended agent work.