### PR TITLE
docs: refresh accuracy and add AGENTS.md operational guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,167 @@
+# AGENTS.md
+
+Operational guide for both human contributors and agentic workers
+(LLM coding assistants). The discursive docs live in
+[`docs/`](docs/); this file is the short, command-oriented checklist
+of what to run, in what order, before opening a PR.
+
+## What ferret is
+
+A JIT-driven microbenchmark framework for probing CPU frontend
+microarchitectural structures (BTB, RAS, BPU, decoded-uop cache,
+ITLB). C++20 core under `src/`, benchmarks under `benchmarks/`, a
+Python plotting CLI under `scripts/`. See [`README.md`](README.md)
+and [`docs/architecture.md`](docs/architecture.md) for the full
+mental model.
+
+## TL;DR pre-PR sequence
+
+Inside `nix develop` (or with the equivalent tools on `PATH`):
+
+```sh
+# 1. Format C++ + Python in place.
+./scripts/format.sh
+
+# 2. Configure with compile_commands.json (lint.sh needs it).
+cmake -S . -B build -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+# 3. Build.
+cmake --build build
+
+# 4. Run C++ tests.
+ctest --test-dir build --output-on-failure
+
+# 5. Run Python tests (skips the `integration` marker).
+./scripts/test_py.sh
+
+# 6. Verify everything CI verifies. This is the gate.
+./scripts/lint.sh
+```
+
+All six must exit zero before opening a PR. There are **no
+pre-commit hooks** — `lint.sh` is enforced only in CI, so running
+it locally is the only way to catch a CI failure before pushing.
+
+## Build directory rule
+
+**Always use `build/`.** Several `build-*/` directories may exist
+locally from past experiments (`build-codereview/`, `build-lint/`,
+`build-x86-linux-asanubsan/`, …); they are not canonical and not
+tracked by git. `scripts/lint.sh` reads `build/compile_commands.json`.
+If you must keep a side-build (e.g., a sanitizer tree), use a
+distinct directory and leave `build/` as the lint-friendly tree.
+
+## C++ workflow specifics
+
+- **Warnings are errors.** `FERRET_WERROR=ON` is the CMake default
+  and applies to ferret's own targets (not vendored deps). Do not
+  commit a build that required `-DFERRET_WERROR=OFF`.
+- **clang-tidy is hard.** `.clang-tidy` has `WarningsAsErrors: '*'`,
+  so any diagnostic from the configured `bugprone-*`, `performance-*`,
+  `readability-*`, `modernize-*` checks fails CI. `lint.sh` skips
+  files under `tests/` and under `_deps/`; everything else under
+  `src/`, `include/`, `benchmarks/` is linted at the compile-commands
+  level.
+- **Sanitizer trees are separate.** ASan and TSan need independent
+  instrumented builds — configure them into distinct directories
+  (`build-asan/`, `build-tsan/`). See
+  [`docs/build.md`](docs/build.md) for the env-var recipe that
+  matches CI.
+- **Per-platform sources.** `CMakeLists.txt` picks
+  `src/timing/{x86_64,aarch64}.cpp`, `src/pinning/{linux,macos}.cpp`,
+  and `src/padding/{x86_64,aarch64}.cpp` at configure time. If you
+  touch one arch/OS path, build the matching one too — CI runs both.
+
+## Python workflow specifics
+
+- `ruff>=0.14` is required (`pyproject.toml` pins `required-version`);
+  older ruff hard-errors on startup. The Nix dev shell provides a
+  pinned version.
+- `tests/python/` is the suite; `conftest.py` puts `scripts/` on
+  `sys.path` so `import ferret_plot` works without an install.
+- The `integration` marker gates tests that spawn Chrome via kaleido
+  (`tests/python/test_integration_export.py`). `scripts/test_py.sh`
+  excludes them with `-m "not integration"`; CI runs the integration
+  suite separately on Linux + macOS with Chrome on `PATH`.
+
+## Running a single test
+
+```sh
+ctest --test-dir build -R test_timing --output-on-failure
+./build/tests/test_timing --gtest_filter='Timing.TicksPerNsIsPositive'
+
+python3 -m pytest tests/python/test_surface.py
+python3 -m pytest tests/python/test_surface.py::test_some_case -v
+python3 -m pytest tests/python -m integration -v   # requires Chrome
+```
+
+`ctest` only knows about C++ targets — Python tests are not
+registered with it.
+
+## Commit messages
+
+`type(scope): subject` (Conventional-Commits-ish). Scope is
+optional; subject is lowercase, imperative, no trailing period.
+
+Types in use: `feat`, `fix`, `refactor`, `style`, `perf`, `build`,
+`ci`, `test`, `docs`, `lint`. Examples from `git log`:
+
+```
+refactor(surface): decompose make_figure and name tunables
+perf(plot): lazy-import kinds and clean up browser staging files
+build: tighten sljit visibility and share benchmark objects
+fix(plot): export surface png via chromium webgl fallback
+lint: silence ruff on intentional lazy imports and wide signatures
+```
+
+Forbidden in commit messages, PR titles, PR bodies, and code
+comments:
+
+- AI tool names (Codex, Claude, Grok, Gemini, …) — including
+  `Co-Authored-By:` footers.
+- Process narration ("FIXED", "Step 3", "Week 2", "Phase 1",
+  "AC-x"). Write what the change *is*, not how the work
+  progressed.
+
+## Branches and PRs
+
+Local branches follow `type/short-description`, matching the commit
+type vocabulary: `feat/branch-history-footprint`,
+`fix/surface-png-webgl-export`, `refactor/code-review-cleanup`,
+`ci/workflow-hardening`.
+
+PRs target `main`. CI must be green:
+
+| Workflow             | What it gates                                                                |
+|----------------------|------------------------------------------------------------------------------|
+| `lint.yml`           | `cmake -S . -B build … && ./scripts/lint.sh` (clang-format, ruff, clang-tidy) |
+| `build.yml`          | Build + ctest across gcc-13/14, clang-17/18 on linux-x86_64; gcc-14/clang-18 on linux-arm64; Apple Clang on macos-arm64 |
+| `python.yml`         | `scripts/test_py.sh` + integration tests on linux-nix, linux-pip, macos-pip   |
+| `sanitizers.yml`     | `address+undefined` (all OS) + `thread` (Linux only) on Debug builds         |
+| `nix.yml`            | `nix flake check`                                                            |
+| `codeql.yml`         | CodeQL c-cpp + python; weekly cron                                           |
+| `zizmor.yml`         | Workflow YAML security audit; weekly cron                                    |
+
+## Footguns
+
+- **`lint.sh` exits 1 with no useful output if `build/compile_commands.json` is missing.** Step 2 of the TL;DR is not optional.
+- **clang-tidy from non-Nix toolchains may diverge** from the version CI pins. If `./scripts/lint.sh` passes locally but the `lint.yml` job fails, suspect version skew — re-run under `nix develop`.
+- **kaleido version split.** The Nix dev shell currently ships kaleido 0.2.1 (nixpkgs-25.11); the pip path uses `>=1.0`. The two have different internal export paths. `test_integration_export.py` exercises both in CI; expect different code paths on each.
+- **`pinning` privileged operations skip silently.** `pin_to_core`, `boost_priority` (via `setpriority(-10)`), and `lock_memory` (`mlockall`) need elevated privileges. The corresponding tests skip themselves when `geteuid() != 0`. Benchmark *correctness* is unaffected, but *timing reproducibility* requires running as root or with the right capabilities.
+- **`detect_leaks` on macOS aborts startup.** Do not name it in `ASAN_OPTIONS` when running sanitizer tests on macOS — see [`docs/build.md`](docs/build.md).
+- **Apple Silicon has no per-core affinity.** `--core=N` is informational on macOS arm64; probe and benchmark land on *some* P-core, not necessarily the same one. See the README's discipline section.
+- **`benchmark-results/` is not gitignored** while `*.csv`, `*.html`, and `*.png` are. Take care not to commit large CSV/PNG outputs into other paths.
+
+## Where to find things
+
+| If you need…                              | Read this                                           |
+|-------------------------------------------|-----------------------------------------------------|
+| Module map of `src/` and `include/ferret/` | [`docs/architecture.md`](docs/architecture.md)      |
+| How to add a benchmark                    | [`docs/writing-a-benchmark.md`](docs/writing-a-benchmark.md) |
+| Global `ferret run` flags and axis syntax | [`docs/cli.md`](docs/cli.md)                        |
+| Full build options + sanitizer matrix     | [`docs/build.md`](docs/build.md)                    |
+| Per-benchmark kernel structure            | [`docs/benchmarks/`](docs/benchmarks/)              |
+| The two-step cycle workflow + caveats     | [`README.md`](README.md)                            |
+
+`superpowers/specs/` and `superpowers/plans/` are point-in-time
+artifacts. If they disagree with current code, the code is right.

--- a/README.md
+++ b/README.md
@@ -121,9 +121,10 @@ responsibility:
 
 ## Documentation
 
+- [`AGENTS.md`](AGENTS.md) — operational checklist for contributors and agentic workers (pre-PR commands, conventions, CI gates, footguns).
 - [`docs/architecture.md`](docs/architecture.md) — codebase overview and module map.
-- [`docs/build.md`](docs/build.md) — full build, sanitizer matrix.
+- [`docs/build.md`](docs/build.md) — full build, sanitizer matrix, single-test recipes.
 - [`docs/cli.md`](docs/cli.md) — global CLI flags and axis syntax.
 - [`docs/benchmarks/`](docs/benchmarks/) — per-benchmark kernel structure and options.
 - [`docs/writing-a-benchmark.md`](docs/writing-a-benchmark.md) — guide for adding a new benchmark.
-- [`docs/contributing.md`](docs/contributing.md) — formatting and linting.
+- [`docs/contributing.md`](docs/contributing.md) — formatting and linting (points to AGENTS.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,11 +4,12 @@
 
 These docs reflect current behavior. Edit them when behavior changes.
 
+- [`../AGENTS.md`](../AGENTS.md) — operational checklist for contributors and agentic workers (pre-PR commands, conventions, CI gates, footguns).
 - [`architecture.md`](architecture.md) — codebase overview and module map.
-- [`build.md`](build.md) — dependency requirements, Nix/CMake recipes, sanitizer matrix.
+- [`build.md`](build.md) — dependency requirements, Nix/CMake recipes, sanitizer matrix, single-test recipes.
 - [`cli.md`](cli.md) — global `ferret run` flags and axis syntax.
 - [`writing-a-benchmark.md`](writing-a-benchmark.md) — guide for adding a new benchmark.
-- [`contributing.md`](contributing.md) — formatting and linting.
+- [`contributing.md`](contributing.md) — formatters and linters (points to AGENTS.md).
 - [`../README.md`](../README.md) — user-facing pitch, quickstart, two-step cycle workflow, discipline.
 
 ### Benchmarks
@@ -18,6 +19,7 @@ One page per benchmark, with kernel-structure ASCII, CLI surface, and reading-th
 - [`benchmarks/dependent_chain_throughput.md`](benchmarks/dependent_chain_throughput.md) — frequency-probe baseline.
 - [`benchmarks/direct_branch_footprint.md`](benchmarks/direct_branch_footprint.md) — direct-jump BTB capacity.
 - [`benchmarks/nested_call_depth.md`](benchmarks/nested_call_depth.md) — RAS depth.
+- [`benchmarks/branch_history_footprint.md`](benchmarks/branch_history_footprint.md) — conditional-branch direction-predictor capacity.
 
 ## Historical artifacts
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,9 @@ alphabetical; each line is one sentence on responsibility.
 
 - `axis.hpp` — declarative parameter axis (Range / Log2Range /
   GeomRange / Values) used by benchmarks to describe what to sweep.
+- `bench_helpers.hpp` — JIT-time helpers for benchmark TUs:
+  `emit_outer_loop`, `compute_iterations`, `verify_uniform_spacing`.
+  Pulls in `sljitLir.h`; not for use from non-JIT public headers.
 - `benchmark.hpp` — base class benchmark authors subclass, plus the
   registry and registration macro.
 - `cli_axis.hpp` — parses CLI values like `1..32768`, `16,32,64`, or
@@ -36,12 +39,15 @@ alphabetical; each line is one sentence on responsibility.
   ostream.
 - `freq.hpp` — parses `--freq=4.521GHz` and similar suffixed numbers
   into hertz.
-- `jit.hpp` — RAII handle for an sljit-compiled kernel.
+- `jit.hpp` — RAII handle for an sljit-compiled kernel; calls
+  `verify_layout` post-codegen.
 - `log.hpp` — spdlog-backed logger aliased as `flog::` at every use
   site (avoids the `::log(double)` collision from `<math.h>`).
 - `padding.hpp` — emits architecture-correct NOPs to pad branch sites.
 - `params.hpp` — insertion-ordered key/int64 map carrying one parameter
   point through the runner and into the CSV.
+- `parse.hpp` — `parse_int()`: shared low-level integer parser used by
+  `cli_axis.cpp` and other consumers.
 - `permute.hpp` — Sattolo's algorithm, a single Hamiltonian cycle over
   `{0..n-1}`, used by benchmarks that want to defeat sequential
   prefetch.
@@ -55,9 +61,31 @@ alphabetical; each line is one sentence on responsibility.
 - `timing.hpp` — per-arch `arch_now_ticks()` (rdtscp on x86_64,
   cntvct_el0 on aarch64) and a lazily-calibrated `ticks_per_ns()`.
 
+## Source layout
+
+`src/` is mostly a flat mirror of `include/ferret/` (one `.cpp` per
+header). Three subdirectories carry arch- or OS-conditional code that
+`CMakeLists.txt` selects at configure time:
+
+- `src/timing/` — `x86_64.cpp` (`rdtscp`) **or** `aarch64.cpp`
+  (`cntvct_el0`), plus the shared `calibrate.cpp`. AArch64 reads the
+  exact frequency from `cntfrq_el0`; x86_64 calibrates against a short
+  wall-clock sleep, so its `ticks_per_ns()` is approximate (±1%
+  depending on scheduler jitter).
+- `src/pinning/` — `posix_common.cpp` for `boost_priority` /
+  `lock_memory`, plus `linux.cpp` (`pthread_setaffinity_np`) **or**
+  `macos.cpp` (`thread_policy_set` with a P-cluster QoS fallback —
+  Apple Silicon does not implement per-core affinity; see the README's
+  discipline section).
+- `src/padding/` — `x86_64.cpp` **or** `aarch64.cpp`, each emitting the
+  arch-correct NOP encoding for `emit_nops`.
+
+`benchmarks/` holds one `.cpp` per benchmark, compiled into the
+`ferret_benchmarks` OBJECT library (see `writing-a-benchmark.md`).
+
 ## Adding a benchmark
 
-See `writing-a-benchmark.md`. The two existing benchmarks under
+See `writing-a-benchmark.md`. The four existing benchmarks under
 `benchmarks/` are worked examples of the frequency-probe and
 parameter-sweep patterns.
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -20,8 +20,10 @@ ctest --test-dir build --output-on-failure
 ## Plain CMake
 
 Make sure the dependency requirements above are installed.
-CMake will FetchContent CLI11, GoogleTest, and sljit if they aren't on
-the system search path:
+CMake will FetchContent CLI11, GoogleTest, spdlog, and sljit if they
+aren't on the system search path. sljit is pinned to the same revision
+as the Nix flake input — `CMakeLists.txt` reads `flake.lock` at
+configure time so both build paths link identical sources.
 
 ```sh
 cmake -S . -B build -GNinja
@@ -29,15 +31,29 @@ cmake --build build
 ctest --test-dir build --output-on-failure
 ```
 
-Scripts under `scripts/` need matplotlib, numpy, and pandas (plus
-pytest and ruff for tests). Nix users get these via `flake.nix`;
-otherwise:
+Scripts under `scripts/` need `numpy`, `pandas`, `plotly>=6.1.1`, and
+`kaleido>=1.0` (pytest + ruff for tests). Nix users get these via
+`flake.nix`; otherwise:
 
 ```sh
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt      # runtime
 pip install -r requirements-dev.txt  # + pytest, ruff
 ```
+
+Static-image plot exports (`.png`, `.svg`, `.pdf`, `.jpg`, `.webp`)
+require Chrome or Chromium on `PATH` — kaleido runs a headless browser
+to rasterize. The Nix dev shell ships `pkgs.chromium` on Linux. HTML
+output has no such requirement.
+
+## CMake knobs
+
+| Option                            | Default | Purpose                                                                 |
+|-----------------------------------|---------|-------------------------------------------------------------------------|
+| `-DFERRET_WERROR=ON\|OFF`         | `ON`    | Treat warnings as errors on ferret's own targets (vendored deps unaffected). Turn off for one-off local builds against a newer compiler. CI runs with the default `ON`. |
+| `-DFERRET_SANITIZER=<mode>`       | unset   | Enable a sanitizer build (see below).                                   |
+| `-DCMAKE_BUILD_TYPE=<type>`       | unset   | Debug / Release / RelWithDebInfo. CI build job leaves this unset; sanitizer jobs set `Debug`. |
+| `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` | off  | Required for `scripts/lint.sh` (clang-tidy reads `build/compile_commands.json`). |
 
 ## Sanitizer builds
 
@@ -52,15 +68,50 @@ Off by default — timing-sensitive runs use clean code. Enable via
 | `thread`            | data races, deadlocks                                        |
 
 ```sh
-cmake -S . -B build-asan -GNinja -DFERRET_SANITIZER=address+undefined
+cmake -S . -B build-asan -GNinja -DCMAKE_BUILD_TYPE=Debug -DFERRET_SANITIZER=address+undefined
 cmake --build build-asan
-UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
-ASAN_OPTIONS=halt_on_error=1:detect_leaks=1 \
+ASAN_OPTIONS=halt_on_error=1:abort_on_error=0:exitcode=1:print_stacktrace=1 \
+UBSAN_OPTIONS=halt_on_error=1:exitcode=1:print_stacktrace=1 \
   ctest --test-dir build-asan --output-on-failure
 ```
 
-CI runs `address+undefined` and `thread` on Linux x86_64 and arm64
-(`.github/workflows/sanitizers.yml`). macOS sanitizer support depends
-on the toolchain; nixpkgs-clang ASan/TSan currently has runtime-init
-issues on Apple Silicon — use UBSan there or build under a Linux
-container.
+For TSan, swap the env block for:
+
+```sh
+TSAN_OPTIONS=halt_on_error=1:exitcode=1:second_deadlock_stack=1 \
+  ctest --test-dir build-tsan --output-on-failure
+```
+
+The env vars match `.github/workflows/sanitizers.yml` verbatim — they
+turn a sanitizer report into a non-zero exit. Notes:
+
+- **Do not set `detect_leaks` explicitly on macOS.** Apple's ASan
+  runtime aborts startup with "detect_leaks is not supported on this
+  platform" if the key appears at all. On Linux, LSan runs under ASan
+  by default without being named.
+- **TSan and ASan cannot share a build tree** — they require separate
+  compile-time instrumentation. Configure them into different
+  `build-*` directories.
+
+CI runs `address+undefined` and `thread` on Linux x86_64 and arm64,
+and `address+undefined` only on macOS arm64 (TSan on Apple Clang is
+patchy across Xcode versions). nixpkgs-clang ASan/TSan currently has
+runtime-init issues on Apple Silicon — use UBSan there or build under
+a Linux container.
+
+## Running a single test
+
+```sh
+ctest --test-dir build -R test_timing --output-on-failure   # one binary
+./build/tests/test_timing                                   # direct
+./build/tests/test_timing --gtest_filter='Timing.TicksPerNsIsPositive'
+
+./scripts/test_py.sh                                        # all Python (skips integration)
+python3 -m pytest tests/python/test_surface.py              # one Python file
+python3 -m pytest tests/python -m integration -v            # integration only (needs Chrome)
+```
+
+`ctest` only knows about C++ targets — Python tests are not
+registered with it. The `integration` marker gates pytest cases that
+spawn Chrome/kaleido; `scripts/test_py.sh` excludes them by passing
+`-m "not integration"`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,7 +14,7 @@ ferret run <name> [options] [--<axis>=value-or-range] [--<benchmark-option>=v]
   --freq=4.521GHz   running frequency, enables cycle columns
   --reps=K          repetitions per param point (default 7)
   --warmup=W        un-timed calls before measurement (default 1)
-  --log-level=L     trace|debug|info|warn|error|critical|off (default warn)
+  --log-level=L     trace|debug|info|warn(=warning)|error|critical|off (default warn)
   --seed=S          RNG seed for benchmarks that randomize (default 1)
 ```
 
@@ -51,13 +51,13 @@ Prints every registered benchmark name.
 
 ## Listing axes and options of a benchmark
 
-Pass an unknown axis to surface the declared ones:
-
-```sh
-build/ferret run direct_branch_footprint --bogus=1
-```
-
-The runner reports the accepted axes and options before exiting.
+The runtime does not currently introspect a benchmark's axes or
+options for the user — passing an unknown `--<flag>=<v>` prints
+`unknown axis or option --<flag> for benchmark <name>` to stderr and
+exits with status 2, without listing the accepted ones. To see what a
+benchmark accepts, read its page under
+[`docs/benchmarks/`](benchmarks/), or `grep` the benchmark's `.cpp`
+for the `axes()` and `options()` overrides.
 
 ## Plot subcommands
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,12 +1,20 @@
 # Contributing
 
-## Formatting and linting
+The operational checklist — what to run before opening a PR, commit
+message conventions, branch naming, CI behavior, footguns — lives in
+[`../AGENTS.md`](../AGENTS.md). Both human contributors and agentic
+workers should treat that as the source of truth.
+
+This page is a brief orientation:
+
+## Formatters and linters
 
 Formatters and linters run in CI and must pass before merging.
 
 - C++: `clang-format` (style in `.clang-format`) and `clang-tidy`
-  (checks in `.clang-tidy`).
-- Python: `ruff format` and `ruff check` (config in `pyproject.toml`).
+  (checks in `.clang-tidy`, `WarningsAsErrors: '*'`).
+- Python: `ruff format` and `ruff check` (config in `pyproject.toml`,
+  requires `ruff>=0.14`).
 
 Apply formatters locally:
 
@@ -14,17 +22,22 @@ Apply formatters locally:
 ./scripts/format.sh
 ```
 
-Verify the way CI does:
+Verify the way CI does (this is the gate — `lint.yml` runs `lint.sh`
+verbatim):
 
 ```sh
 cmake -S . -B build -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 ./scripts/lint.sh
 ```
 
-All tools are provided by `nix develop`.
+All tools are provided by `nix develop`. There are no pre-commit
+hooks; the only way to catch a CI lint failure before pushing is to
+run `lint.sh` locally.
 
 ## Adding a benchmark
 
 See [`writing-a-benchmark.md`](writing-a-benchmark.md) for the
-`Benchmark` vtable, the registration macro, and worked examples
-covering the frequency-probe and parameter-sweep patterns.
+`Benchmark` vtable (six pure virtuals plus the optional
+`verify_layout`), the registration macro, the `bench_helpers.hpp`
+JIT-time utilities, and worked examples covering the frequency-probe
+and parameter-sweep patterns.

--- a/docs/writing-a-benchmark.md
+++ b/docs/writing-a-benchmark.md
@@ -1,8 +1,9 @@
 # Writing a Benchmark
 
 A new Ferret benchmark is one C++ file under `benchmarks/`. It
-subclasses `ferret::Benchmark`, overrides six pure virtuals, and
-registers itself at file scope. The runner does the rest.
+subclasses `ferret::Benchmark`, overrides six pure virtuals (plus an
+optional `verify_layout` hook), and registers itself at file scope.
+The runner does the rest.
 
 ## The vtable
 
@@ -33,6 +34,13 @@ registers itself at file scope. The runner does the rest.
   `throw std::invalid_argument` *before* touching `c` so the compiler
   state stays clean. Any sljit error set on `c` propagates to
   `JittedKernel::ok() == false`.
+- **`verify_layout(c)`** *(optional, defaults to no-op)* — called once
+  per row after `sljit_generate_code` while the compiler is still
+  alive. Label addresses are only valid in that window, and post-
+  generate patches need `sljit_get_executable_offset(c)` to find the
+  writable mapping. Override to assert layout invariants (e.g., that
+  branch sites landed at the expected spacing). Throw on mismatch;
+  the runner records the row as a JIT failure.
 
 ## Registration
 
@@ -43,17 +51,49 @@ FERRET_BENCHMARK("my_bench", MyBench);
 ```
 
 The macro registers a factory at static-init time, so `ferret list`
-sees the new name automatically. Add the new file to the executable's
-source list in the top-level `CMakeLists.txt`:
+sees the new name automatically. Add the new file to the
+`ferret_benchmarks` OBJECT library in the top-level `CMakeLists.txt`
+— that library is reused by the `ferret` executable and by benchmark-
+specific tests:
 
 ```cmake
-add_executable(ferret
-  src/main.cpp
-  benchmarks/dependent_chain_throughput.cpp
+add_library(ferret_benchmarks OBJECT
+  benchmarks/branch_history_footprint.cpp
   benchmarks/direct_branch_footprint.cpp
+  benchmarks/nested_call_depth.cpp
+  benchmarks/dependent_chain_throughput.cpp
   benchmarks/my_bench.cpp        # <-- new
 )
 ```
+
+## Shared helpers — `bench_helpers.hpp`
+
+`include/ferret/bench_helpers.hpp` provides three JIT-time utilities
+that the existing benchmarks all use. The header pulls in the full
+`sljitLir.h`, so include it only from benchmark TUs and other JIT-only
+sources, not from public headers.
+
+- **`emit_outer_loop(c, counter_reg, iters, emit_body)`** — emits the
+  canonical scaffold (`MOV counter, iters` → loop label → body →
+  `SUB|SET_Z counter, 1` → `JNZ`). `counter_reg` must be a scratch
+  register the body neither reads nor writes. Prefer this over hand-
+  rolling a counter loop in `emit_kernel` so the runner-visible loop
+  shape stays consistent across benchmarks.
+- **`compute_iterations(target_ops, sites_per_kernel)`** — returns
+  `max(1, target_ops / sites_per_kernel)`. Use it from `iterations()`
+  to pick an outer-loop count that amortizes the tick-read overhead to
+  roughly `target_ops` ops per repetition.
+- **`verify_uniform_spacing(labels, spacing, strict, context)`** — call
+  from `verify_layout` to assert each label sits at `i * spacing` off
+  `labels[0]`. `strict=true` requires equality (used by
+  `direct_branch_footprint`); `strict=false` requires `>=` (sljit may
+  pick a longer encoding, so spacing is a floor —
+  `branch_history_footprint` uses this mode). Throws
+  `std::runtime_error` with the per-site delta on the first mismatch.
+
+The "frequency-probe pattern" example below sets `iterations=1` and so
+does not need `emit_outer_loop`; the "parameter-sweep pattern" example
+and the other benchmarks in `benchmarks/` use all three helpers.
 
 ## Worked example A — frequency-probe pattern
 


### PR DESCRIPTION
## Summary

- Fix accuracy drift across the doc set (writing-a-benchmark.md CMake target, missing `verify_layout` and `bench_helpers.hpp` coverage; build.md stale Python deps and macOS-incompatible `detect_leaks`; architecture.md stale benchmark count and missing modules/source-layout; cli.md inaccurate axis-discovery tip and missing `warning` log-level alias; docs/README.md missing `branch_history_footprint`).
- Add `AGENTS.md` at the repo root with the pre-PR command sequence, `build/` directory rule, lint.sh prerequisites, commit/branch conventions, CI workflow table, and footguns.
- Shrink `contributing.md` to a brief orientation that delegates operational detail to AGENTS.md; surface AGENTS.md in the Documentation lists in `README.md` and `docs/README.md`.

## Test plan

- [ ] Skim `AGENTS.md` against `scripts/lint.sh`, `scripts/format.sh`, `scripts/test_py.sh`, and `.github/workflows/` to confirm every quoted command matches what CI runs.
- [ ] Verify `docs/writing-a-benchmark.md` CMake snippet matches the `ferret_benchmarks` OBJECT library block in `CMakeLists.txt`.
- [ ] Confirm `verify_layout` description in `writing-a-benchmark.md` matches the signature and lifecycle window in `include/ferret/benchmark.hpp`.
- [ ] Cross-check `bench_helpers.hpp` section against the actual API in `include/ferret/bench_helpers.hpp`.
- [ ] Confirm `docs/build.md` sanitizer env vars match `.github/workflows/sanitizers.yml`.
- [ ] Open all cross-doc links in `AGENTS.md`, `docs/README.md`, and `README.md` to confirm they resolve.
- [ ] Run `./scripts/format.sh` + `cmake -S . -B build -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` + `./scripts/lint.sh` to confirm no incidental code regressions (docs-only change, but checks the doc set hasn't broken anything stylistic).