### PR TITLE
docs(benchmark): correct vtable description

### DIFF
--- a/docs/writing-a-benchmark.md
+++ b/docs/writing-a-benchmark.md
@@ -1,8 +1,8 @@
 # Writing a Benchmark
 
 A new Ferret benchmark is one C++ file under `benchmarks/`. It
-subclasses `ferret::Benchmark`, overrides six pure virtuals (plus an
-optional `verify_layout` hook), and registers itself at file scope.
+subclasses `ferret::Benchmark`, overrides five pure virtuals (plus two
+optional virtual hooks), and registers itself at file scope.
 The runner does the rest.
 
 ## The vtable
@@ -20,9 +20,10 @@ The runner does the rest.
   `geom_range` is `log2_range` when `samples_per_octave == 1`; pick
   a larger `k` when the capacity cliff under test sits between two
   adjacent powers of two and you want denser default sampling.
-- **`options()`** — returns scalar non-swept knobs. Each appears as a
-  `--<name>=<v>` CLI flag and is recorded in the CSV one column after
-  the axes. Default to `{}` if your benchmark has no per-bench options.
+- **`options()`** *(optional, defaults to `{}`)* — returns scalar
+  non-swept knobs. Each appears as a `--<name>=<v>` CLI flag and is
+  recorded in the CSV one column after the axes. Override only when
+  your benchmark exposes per-bench options.
 - **`sites_per_kernel(p)`** — divisor the runner uses to convert
   `ticks` into per-site latency. Must be > 0; the runner rejects zero
   with exit code 2.


### PR DESCRIPTION
`docs/writing-a-benchmark.md` described "six pure virtuals" and listed
`options()` as one of them, with an instruction to "Default to `{}` if
your benchmark has no per-bench options."

`include/ferret/benchmark.hpp` has five pure-virtual methods (`name`,
`axes`, `sites_per_kernel`, `iterations`, `emit_kernel`). `options()` is
a non-pure virtual whose default body already returns `{}`, and
`verify_layout()` is a second non-pure virtual with a no-op default.

Changes:
- Correct the count from six to five pure virtuals.
- Note both non-pure virtuals (`options`, `verify_layout`) as optional hooks.
- Rephrase the `options()` entry to reflect its non-pure status and
  existing default; remove the redundant "Default to `{}`" instruction.