### PR TITLE
fix(ci): guard lint.sh against missing compile_commands.json; enforce -Werror on two test targets

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -13,6 +13,12 @@ mapfile -t CXX_FORMAT_FILES < <(
     -type f
 )
 
+if [ ! -f build/compile_commands.json ]; then
+  echo "lint.sh: build/compile_commands.json missing." >&2
+  echo "        Run: cmake -S . -B build -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON" >&2
+  exit 1
+fi
+
 # Lint exactly the .cpp files CMake compiled this build (per-platform
 # source selection in CMakeLists.txt excludes wrong-arch / wrong-OS files
 # from build/compile_commands.json; lint should follow the same set).
@@ -31,12 +37,6 @@ ruff format --check scripts/ tests/python/
 
 echo "==> ruff check"
 ruff check scripts/ tests/python/
-
-if [ ! -f build/compile_commands.json ]; then
-  echo "lint.sh: build/compile_commands.json missing." >&2
-  echo "        Run: cmake -S . -B build -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON" >&2
-  exit 1
-fi
 
 echo "==> clang-tidy"
 # clang-tidy from nixpkgs is unwrapped, so the C++ stdlib search paths

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,7 @@ target_link_libraries(test_nested_call_depth PRIVATE
   ferret_benchmarks
   sljit::sljit
   GTest::gtest GTest::gtest_main
+  ferret_warnings
 )
 gtest_discover_tests(test_nested_call_depth)
 
@@ -126,6 +127,7 @@ target_link_libraries(test_branch_history_footprint PRIVATE
   ferret_benchmarks
   sljit::sljit
   GTest::gtest GTest::gtest_main
+  ferret_warnings
 )
 gtest_discover_tests(test_branch_history_footprint)
 


### PR DESCRIPTION
## Summary

- `scripts/lint.sh`: moved the `build/compile_commands.json` existence check above the `jq`/`mapfile` block. With `set -euo pipefail` active, `jq` exiting non-zero on a missing file previously aborted the script before the helpful hint could print. The guard now fires first, giving a clear error message and the corrective `cmake` invocation.

- `tests/CMakeLists.txt`: added `ferret_warnings` to `target_link_libraries` for `test_nested_call_depth` and `test_branch_history_footprint`. Both targets were missing it while every other test target carried it, causing those two TUs to compile without `-Wall -Wextra -Wpedantic -Werror`.

## Verification

- Built with `-DFERRET_WERROR=ON`; both previously uncovered targets compiled cleanly under `-Werror` with no new warnings.
- `ctest --output-on-failure`: 197 tests passed, 0 failed (3 skipped for privilege/platform reasons unrelated to these changes).
- Confirmed lint guard: temporarily removed `build/compile_commands.json`, ran `scripts/lint.sh`, observed the actionable error message and exit 1; restored the file and confirmed the script proceeds past the guard.