### PR TITLE
fix(jit,bhf): plug two silent post-move/post-free latent failures

### DIFF
--- a/benchmarks/branch_history_footprint.cpp
+++ b/benchmarks/branch_history_footprint.cpp
@@ -88,6 +88,12 @@ struct BranchHistoryFootprint : Benchmark {
   size_t last_branches_ = 0;
   size_t last_spacing_ = 0;
 
+  ~BranchHistoryFootprint() override {
+    if (branch_history_footprint_internal::g_last_emitted == this) {
+      branch_history_footprint_internal::g_last_emitted = nullptr;
+    }
+  }
+
   [[nodiscard]] std::string name() const override { return "branch_history_footprint"; }
 
   [[nodiscard]] SweepAxes axes() const override {

--- a/src/jit.cpp
+++ b/src/jit.cpp
@@ -58,7 +58,10 @@ JittedKernel::~JittedKernel() {
   }
 }
 
-JittedKernel::JittedKernel(JittedKernel&& other) noexcept : code_(other.code_) { other.code_ = nullptr; }
+JittedKernel::JittedKernel(JittedKernel&& other) noexcept : code_(other.code_), code_size_(other.code_size_) {
+  other.code_ = nullptr;
+  other.code_size_ = 0;
+}
 
 JittedKernel& JittedKernel::operator=(JittedKernel&& other) noexcept {
   if (this != &other) {
@@ -66,7 +69,9 @@ JittedKernel& JittedKernel::operator=(JittedKernel&& other) noexcept {
       sljit_free_code(code_, nullptr);
     }
     code_ = other.code_;
+    code_size_ = other.code_size_;
     other.code_ = nullptr;
+    other.code_size_ = 0;
   }
   return *this;
 }


### PR DESCRIPTION
## What changed

**`src/jit.cpp`** — `JittedKernel` move constructor and move-assignment operator transferred `code_` but left `code_size_` at zero. After a move, `code_size()` silently returned 0 even when `ok()` was true. Both move operations now copy `code_size_` from the source and zero it on the moved-from object.

**`benchmarks/branch_history_footprint.cpp`** — `BranchHistoryFootprint::emit_kernel` sets the TU-local `g_last_emitted` pointer to `this`, but the class had no destructor to clear it. Any call to `last_layout_snapshot()` after the object's lifetime would dereference freed memory. The destructor now clears `g_last_emitted` when it still points to the instance being destroyed. `last_layout_snapshot()` already had a null guard, so callers after destruction receive an empty snapshot rather than undefined behaviour.

## Test plan

- `cmake --build build --parallel` — clean build with `-DFERRET_WERROR=ON`, no warnings
- `ctest --test-dir build --output-on-failure` — 197/197 passed (3 skipped: privilege/arch-specific)