### PR TITLE
fix(tests): free JIT executable mapping in VerifyUniformSpacing test

### DIFF
--- a/tests/test_bench_helpers.cpp
+++ b/tests/test_bench_helpers.cpp
@@ -86,7 +86,8 @@ TEST(BenchHelpers, VerifyUniformSpacingPassesOnExactSpacing) {
     labels.push_back(sljit_emit_label(ch.c));
   }
   sljit_emit_return_void(ch.c);
-  ASSERT_NE(sljit_generate_code(ch.c, 0, nullptr), nullptr);
+  void* code = sljit_generate_code(ch.c, 0, nullptr);
+  ASSERT_NE(code, nullptr);
 
   // After generate_code, every label has a real address. We cannot assert
   // the exact spacing because emit_outer_loop's size is non-zero and
@@ -95,6 +96,8 @@ TEST(BenchHelpers, VerifyUniformSpacingPassesOnExactSpacing) {
   size_t base = sljit_get_label_addr(labels[0]);
   size_t step = sljit_get_label_addr(labels[1]) - base;
   EXPECT_NO_THROW(ferret::verify_uniform_spacing(labels, step, /*strict=*/true));
+
+  sljit_free_code(code, nullptr);
 }
 
 TEST(BenchHelpers, VerifyUniformSpacingNoOpsOnEmpty) {


### PR DESCRIPTION
## Summary

- `VerifyUniformSpacingPassesOnExactSpacing` called `sljit_generate_code` but
  discarded the return value, leaking an executable `mmap` region on every test run.
- Two adjacent tests in the same file (`EmitOuterLoopRunsIterTimes`,
  `EmitOuterLoopOneIterationStillRunsBody`) correctly call `sljit_free_code` — this
  was an unintentional omission.
- Fix: capture the return value in `void* code` and call `sljit_free_code(code, nullptr)`
  before the test returns, matching the adjacent-test pattern.

## Verification

- Release build: `ctest --output-on-failure -R BenchHelpers` — 6/6 passed.
- Full suite: 197/197 passed (3 skipped for privilege reasons, unrelated).
- ASan + UBSan (`FERRET_SANITIZER=address+undefined`): 6/6 BenchHelpers passed with no sanitizer errors or leak reports.