### PR TITLE
fix(plot): convert anticipated errors to PlotError instead of raw tracebacks

### DIFF
--- a/scripts/ferret_plot/cli.py
+++ b/scripts/ferret_plot/cli.py
@@ -127,6 +127,9 @@ def main(argv: list[str] | None = None) -> int:
         fig = args.handler(df, args)
         output.emit(fig, out=args.out, fmt=args.format, html_js=args.html_js)
         return 0
+    except pd.errors.ParserError as e:
+        print(f"plot.py: malformed CSV: {e}", file=sys.stderr)
+        return EXIT_USER_ERROR
     except (PlotError, FileNotFoundError) as e:
         print(f"plot.py: {e}", file=sys.stderr)
         return EXIT_USER_ERROR

--- a/scripts/ferret_plot/kinds/_shared.py
+++ b/scripts/ferret_plot/kinds/_shared.py
@@ -18,10 +18,17 @@ _MISSING_PREVIEW_LIMIT = 5
 DEFAULT_CMAP = "turbo"
 
 
+def assert_finite_metric(values: np.ndarray, metric_col: str) -> None:
+    """Raise PlotError when a metric column contains no finite values."""
+    if not np.any(np.isfinite(values)):
+        raise PlotError(f"metric column {metric_col!r} contains no finite values; cannot plot")
+
+
 def assert_logz_positive(values: np.ndarray, *, metric_label: str | None = None) -> None:
     """Raise PlotError when --logz is requested but values contain non-positive entries."""
-    if np.nanmin(values) <= 0:
-        raise PlotError("--logz requires positive metric values")
+    finite = values[np.isfinite(values)]
+    if len(finite) == 0 or np.any(finite <= 0):
+        raise PlotError("--logz requires at least one finite positive value")
 
 
 def hover_text_grid(  # noqa: PLR0913

--- a/scripts/ferret_plot/kinds/facets.py
+++ b/scripts/ferret_plot/kinds/facets.py
@@ -13,6 +13,7 @@ from plotly.subplots import make_subplots
 from ferret_plot.columns import bench_name, resolve_metric
 from ferret_plot.errors import PlotError
 from ferret_plot.kinds._shared import (
+    assert_finite_metric,
     assert_logz_positive,
     axis_ticks,
     build_heatmap_trace,
@@ -56,7 +57,8 @@ def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> go.Figure:
 
     cmap = validate_cmap(args.cmap)
 
-    metric_values = df[metric.column].to_numpy()
+    metric_values = df[metric.column].to_numpy(dtype=float)
+    assert_finite_metric(metric_values, metric.column)
     if args.logz:
         assert_logz_positive(metric_values)
         cmin = float(np.log10(np.nanmin(metric_values)))

--- a/scripts/ferret_plot/kinds/surface.py
+++ b/scripts/ferret_plot/kinds/surface.py
@@ -12,6 +12,7 @@ import plotly.graph_objects as go
 from ferret_plot.columns import bench_name, resolve_metric
 from ferret_plot.errors import PlotError
 from ferret_plot.kinds._shared import (
+    assert_finite_metric,
     assert_logz_positive,
     axis_ticks,
     hover_text_grid,
@@ -243,6 +244,7 @@ def make_figure(df: pd.DataFrame, args: argparse.Namespace) -> go.Figure:
     xcol, ycol = resolve_heatmap_xy(df, args, defaults)
     grid = prepare_grid(df, xcol=xcol, ycol=ycol, value_col=metric.column, require_complete=True)
     z = _z_values(grid)
+    assert_finite_metric(z, metric.column)
 
     cmap = validate_cmap(args.cmap)
 

--- a/scripts/ferret_plot/output.py
+++ b/scripts/ferret_plot/output.py
@@ -259,4 +259,4 @@ def emit(fig: Any, *, out: str | None, fmt: str | None, html_js: str) -> None:
         if resolved == "png" and _has_surface_trace(fig) and _is_kaleido_canvas_error(e):
             _write_chromium_webgl_png(fig, out, width=width, height=height)
             return
-        raise
+        raise PlotError(f"image export failed: {e}") from e

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -121,6 +121,15 @@ class TestFacetsSubcommand:
         assert out_path.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
 
 
+class TestMalformedCsv:
+    def test_malformed_csv_exits_2(self, tmp_path, capsys):
+        bad_csv = tmp_path / "bad.csv"
+        bad_csv.write_text("a,b\n1,2\n3,4,5,extra\n")
+        rc = cli.main(["line", str(bad_csv), "--out", str(tmp_path / "x.png")])
+        assert rc == EXIT_USER_ERROR
+        assert "malformed CSV" in capsys.readouterr().err
+
+
 class TestErrorPaths:
     def test_mixed_benchmark_csv_exits_2(self, tmp_path, capsys):
         mixed = pd.concat([dbf_df(), dct_df()], ignore_index=True)

--- a/tests/python/test_facets.py
+++ b/tests/python/test_facets.py
@@ -47,6 +47,18 @@ class TestFacetsMakeFigure:
         with pytest.raises(PlotError, match="same as --facet"):
             facets_kind.make_figure(df, _args(facet="variant", x="variant"))
 
+    def test_logz_rejects_non_positive_metric(self):
+        df = three_axis_df(variants=("a", "b"))
+        df.loc[df.index[0], "cycles_per_site_min"] = 0.0
+        with pytest.raises(PlotError, match="--logz requires"):
+            facets_kind.make_figure(df, _args(facet="variant", logz=True))
+
+    def test_logz_rejects_negative_metric(self):
+        df = three_axis_df(variants=("a", "b"))
+        df["cycles_per_site_min"] = -0.5
+        with pytest.raises(PlotError, match="--logz requires"):
+            facets_kind.make_figure(df, _args(facet="variant", logz=True))
+
     def test_invalid_cmap_raises(self):
         df = three_axis_df(variants=("a", "b"))
         with pytest.raises(PlotError, match="not a valid colorscale"):

--- a/tests/python/test_output.py
+++ b/tests/python/test_output.py
@@ -84,6 +84,33 @@ class TestChromeProbe:
             output.emit(fig, out=str(tmp_path / "x.png"), fmt=None, html_js="cdn")
 
 
+class TestNonCanvasValueError:
+    def test_non_canvas_value_error_becomes_plot_error(self, tmp_path, monkeypatch):
+        fig = _fig()
+
+        def fail_write_image(*_args, **_kwargs):
+            raise ValueError("kaleido internal: unexpected codec failure")
+
+        monkeypatch.setattr(output, "_chrome_available", lambda: True)
+        monkeypatch.setattr(fig, "write_image", fail_write_image)
+
+        with pytest.raises(PlotError, match="image export failed"):
+            output.emit(fig, out=str(tmp_path / "x.png"), fmt=None, html_js="cdn")
+
+    def test_non_canvas_value_error_preserves_original_text(self, tmp_path, monkeypatch):
+        fig = _fig()
+        original_msg = "kaleido: some unexpected internal problem"
+
+        def fail_write_image(*_args, **_kwargs):
+            raise ValueError(original_msg)
+
+        monkeypatch.setattr(output, "_chrome_available", lambda: True)
+        monkeypatch.setattr(fig, "write_image", fail_write_image)
+
+        with pytest.raises(PlotError, match=original_msg):
+            output.emit(fig, out=str(tmp_path / "x.png"), fmt=None, html_js="cdn")
+
+
 class TestSurfaceWebglFallback:
     def test_surface_png_uses_chromium_webgl_when_kaleido_canvas_fails(self, tmp_path, monkeypatch):
         fig = go.Figure(data=[go.Surface(z=[[1.0, 2.0], [3.0, 4.0]])])

--- a/tests/python/test_shared_grid.py
+++ b/tests/python/test_shared_grid.py
@@ -7,7 +7,7 @@ import pandas as pd
 import plotly.graph_objects as go
 import pytest
 from ferret_plot.errors import PlotError
-from ferret_plot.kinds._shared import build_heatmap_trace, prepare_grid
+from ferret_plot.kinds._shared import assert_finite_metric, assert_logz_positive, build_heatmap_trace, prepare_grid
 from fixtures import dbf_df
 
 _MISSING_BRANCH = 2
@@ -59,6 +59,42 @@ class TestPrepareGrid:
                 value_col="cycles_per_site_min",
                 require_complete=True,
             )
+
+
+class TestAssertFiniteMetric:
+    def test_all_nan_raises(self):
+        values = np.array([float("nan"), float("nan")])
+        with pytest.raises(PlotError, match="no finite values"):
+            assert_finite_metric(values, "my_metric")
+
+    def test_finite_values_pass(self):
+        values = np.array([1.0, 2.0, float("nan")])
+        assert_finite_metric(values, "my_metric")  # no exception
+
+
+class TestAssertLogzPositive:
+    def test_all_nan_raises(self):
+        values = np.array([float("nan"), float("nan")])
+        with pytest.raises(PlotError, match="--logz requires at least one finite positive value"):
+            assert_logz_positive(values)
+
+    def test_non_positive_raises(self):
+        values = np.array([0.0, 1.0, 2.0])
+        with pytest.raises(PlotError, match="--logz requires"):
+            assert_logz_positive(values)
+
+    def test_negative_raises(self):
+        values = np.array([-1.0, 2.0])
+        with pytest.raises(PlotError, match="--logz requires"):
+            assert_logz_positive(values)
+
+    def test_positive_values_pass(self):
+        values = np.array([0.5, 1.0, 2.0])
+        assert_logz_positive(values)  # no exception
+
+    def test_positive_with_nan_passes(self):
+        values = np.array([1.0, float("nan"), 2.0])
+        assert_logz_positive(values)  # no exception
 
 
 class TestBuildHeatmapTrace:

--- a/tests/python/test_surface.py
+++ b/tests/python/test_surface.py
@@ -104,7 +104,13 @@ class TestSurfaceMakeFigure:
     def test_logz_rejects_non_positive_values(self):
         df = tage_capacity_df()
         df.loc[df.index[0], "cycles_per_site_min"] = 0.0
-        with pytest.raises(PlotError, match="--logz requires positive"):
+        with pytest.raises(PlotError, match="--logz requires"):
+            surface_kind.make_figure(df, _args(logz=True))
+
+    def test_logz_rejects_negative_values(self):
+        df = tage_capacity_df()
+        df["cycles_per_site_min"] = -1.0
+        with pytest.raises(PlotError, match="--logz requires"):
             surface_kind.make_figure(df, _args(logz=True))
 
     def test_invalid_cmap_raises(self):


### PR DESCRIPTION
## Summary

Three error paths previously escaped as unhandled exceptions are now caught and surfaced as `PlotError` with exit code `EXIT_USER_ERROR`:

- **Malformed CSV**: `pd.errors.ParserError` (a `ValueError` subclass) was not in `cli.main`'s except tuple and propagated as a raw traceback. Now caught and converted to a user-facing error.

- **All-NaN metric column**: `surface.make_figure` crashed via `math.floor(nan)`, `facets.make_figure` silently rendered a NaN colorbar, and `--logz` positivity checks slipped through because `nan <= 0` is `False`. A new `assert_finite_metric()` helper in `kinds/_shared.py` is called from both `make_figure` implementations; `assert_logz_positive` now requires at least one finite positive value.

- **Non-canvas `ValueError` from kaleido**: `output.emit` previously re-raised any non-canvas `ValueError` raw. Now converts it to `PlotError` preserving the original message.

Five test modules cover the three new code paths.

## Test plan

- `uv run --with pytest,ruff --with-requirements requirements.txt python3 -m pytest tests/python -m "not integration"` — 124 passed, 2 deselected
- `uv run --with ruff ruff format --check scripts/ferret_plot tests/python` — 25 files already formatted (clean)
- `uv run --with ruff ruff check scripts/ferret_plot tests/python` — pre-existing `PLW0108` on an untouched line in `test_output.py`; no new violations