### PR TITLE
docs: drop step-narration comments; add --benchmark to plot synopsis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,22 +19,22 @@ mental model.
 Inside `nix develop` (or with the equivalent tools on `PATH`):
 
 ```sh
-# 1. Format C++ + Python in place.
+# format C++ + Python in place.
 ./scripts/format.sh
 
-# 2. Configure with compile_commands.json (lint.sh needs it).
+# generate compile_commands.json for lint.
 cmake -S . -B build -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
-# 3. Build.
+# build all targets.
 cmake --build build
 
-# 4. Run C++ tests.
+# run C++ tests.
 ctest --test-dir build --output-on-failure
 
-# 5. Run Python tests (skips the `integration` marker).
+# run Python tests (skips the `integration` marker).
 ./scripts/test_py.sh
 
-# 6. Verify everything CI verifies. This is the gate.
+# verify everything CI verifies — this is the gate.
 ./scripts/lint.sh
 ```
 
@@ -144,7 +144,7 @@ PRs target `main`. CI must be green:
 
 ## Footguns
 
-- **`lint.sh` exits 1 with no useful output if `build/compile_commands.json` is missing.** Step 2 of the TL;DR is not optional.
+- **`lint.sh` exits 1 with no useful output if `build/compile_commands.json` is missing.** The configure step is not optional.
 - **clang-tidy from non-Nix toolchains may diverge** from the version CI pins. If `./scripts/lint.sh` passes locally but the `lint.yml` job fails, suspect version skew — re-run under `nix develop`.
 - **kaleido version split.** The Nix dev shell currently ships kaleido 0.2.1 (nixpkgs-25.11); the pip path uses `>=1.0`. The two have different internal export paths. `test_integration_export.py` exercises both in CI; expect different code paths on each.
 - **`pinning` privileged operations skip silently.** `pin_to_core`, `boost_priority` (via `setpriority(-10)`), and `lock_memory` (`mlockall`) need elevated privileges. The corresponding tests skip themselves when `geteuid() != 0`. Benchmark *correctness* is unaffected, but *timing reproducibility* requires running as root or with the right capabilities.
@@ -161,7 +161,7 @@ PRs target `main`. CI must be green:
 | Global `ferret run` flags and axis syntax | [`docs/cli.md`](docs/cli.md)                        |
 | Full build options + sanitizer matrix     | [`docs/build.md`](docs/build.md)                    |
 | Per-benchmark kernel structure            | [`docs/benchmarks/`](docs/benchmarks/)              |
-| The two-step cycle workflow + caveats     | [`README.md`](README.md)                            |
+| Frequency probe, benchmark, and plot workflow + caveats | [`README.md`](README.md)                 |
 
 `superpowers/specs/` and `superpowers/plans/` are point-in-time
 artifacts. If they disagree with current code, the code is right.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ctest --test-dir build --output-on-failure
 
 Full build options, sanitizer matrix, and non-Nix recipes: [`docs/build.md`](docs/build.md).
 
-## The two-step cycle workflow
+## Frequency probe, benchmark, and plot workflow
 
 Ferret reports per-site cost in **CPU cycles** when you supply the
 running core frequency, in **nanoseconds** otherwise. Cycles are the
@@ -38,17 +38,17 @@ about the structure under test. Ferret never auto-probes the
 frequency — it asks you to do it explicitly.
 
 ```sh
-# Step 1: probe the running frequency on core 3.
+# probe core frequency on core 3.
 build/ferret run dependent_chain_throughput --core=3 --out=/tmp/freq.csv
 python3 scripts/freq.py /tmp/freq.csv
 # → estimated_freq=4.521GHz
 
-# Step 2: run the actual benchmark with --freq, pinned to the same core.
+# run benchmark with --freq, pinned to the same core, writing results to CSV.
 build/ferret run direct_branch_footprint --core=3 \
     --branches=1..32768 --spacing_bytes=16..128 \
     --freq=4.521GHz --out=/tmp/btb.csv
 
-# Step 3: line plot. Default --out=*.png writes a static image
+# render line plot; default --out=*.png writes a static image
 # (requires Chrome for kaleido; the Nix dev shell provides it on Linux).
 python3 scripts/plot.py line /tmp/btb.csv --out=/tmp/btb.png
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,10 +65,10 @@ for the `axes()` and `options()` overrides.
 produced by `ferret run`.
 
 ```
-python3 scripts/plot.py line     FILE.csv [--x=COL] [--xscale=log|linear] [--out=PATH] [--format=FMT] [--html-js=cdn|inline|sibling] [--metric=auto|cycles|ns] [--stat=min|median] [--ymax=N] [--series=COL,...]
-python3 scripts/plot.py heatmap  FILE.csv [--x=COL] [--y=COL] [--out=PATH] [--format=FMT] [--html-js=cdn|inline|sibling] [--cmap=NAME] [--metric=auto|cycles|ns] [--stat=min|median] [--logz]
-python3 scripts/plot.py surface  FILE.csv [--x=COL] [--y=COL] [--out=PATH] [--format=FMT] [--html-js=cdn|inline|sibling] [--cmap=NAME] [--metric=auto|cycles|ns] [--stat=min|median] [--logz] [--elev=DEG] [--azim=DEG]
-python3 scripts/plot.py facets   FILE.csv --facet=COL [--x=COL] [--y=COL] [--out=PATH] [--format=FMT] [--html-js=cdn|inline|sibling] [--cmap=NAME] [--metric=auto|cycles|ns] [--stat=min|median] [--logz]
+python3 scripts/plot.py line     FILE.csv [--benchmark=NAME] [--x=COL] [--xscale=log|linear] [--out=PATH] [--format=FMT] [--html-js=cdn|inline|sibling] [--metric=auto|cycles|ns] [--stat=min|median] [--ymax=N] [--series=COL,...]
+python3 scripts/plot.py heatmap  FILE.csv [--benchmark=NAME] [--x=COL] [--y=COL] [--out=PATH] [--format=FMT] [--html-js=cdn|inline|sibling] [--cmap=NAME] [--metric=auto|cycles|ns] [--stat=min|median] [--logz]
+python3 scripts/plot.py surface  FILE.csv [--benchmark=NAME] [--x=COL] [--y=COL] [--out=PATH] [--format=FMT] [--html-js=cdn|inline|sibling] [--cmap=NAME] [--metric=auto|cycles|ns] [--stat=min|median] [--logz] [--elev=DEG] [--azim=DEG]
+python3 scripts/plot.py facets   FILE.csv [--benchmark=NAME] --facet=COL [--x=COL] [--y=COL] [--out=PATH] [--format=FMT] [--html-js=cdn|inline|sibling] [--cmap=NAME] [--metric=auto|cycles|ns] [--stat=min|median] [--logz]
 ```
 
 The plot script reads row 0 of the CSV's `benchmark` column to choose


### PR DESCRIPTION
## Summary

- **README.md**: rename the "The two-step cycle workflow" section to "Frequency probe, benchmark, and plot workflow" (the section shows three actions, not two); replace `# Step N:` shell comments with intent-describing alternatives (`# probe core frequency on core 3.`, etc.).
- **AGENTS.md**: replace numbered `# N.` ordinals in the TL;DR pre-PR code block with intent-based comments; replace the "Step 2 of the TL;DR" prose reference in the Footguns section with "the configure step"; update the "Where to find things" table row to match the renamed README section heading.
- **docs/cli.md**: add `[--benchmark=NAME]` to the synopsis line of all four plot subcommands (`line`, `heatmap`, `surface`, `facets`) — the flag is registered by `_add_common()` for all four but was previously absent from the synopsis.

## Test plan

- [ ] Confirm `README.md` section heading reads "Frequency probe, benchmark, and plot workflow"
- [ ] Confirm no `# Step N:` or `# N.` ordinal comments remain in the two code blocks
- [ ] Confirm all four `scripts/plot.py` synopsis lines show `[--benchmark=NAME]`
- [ ] `./scripts/lint.sh` passes in CI (doc-only changes; no C++/Python modified)