### PR TITLE
fix(plot): reject single-value columns in --x/--y

### DIFF
--- a/scripts/ferret_plot/kinds/_shared.py
+++ b/scripts/ferret_plot/kinds/_shared.py
@@ -101,6 +101,18 @@ def axis_ticks(labels: list[object]) -> tuple[list[int], list[str]]:
     return kept, [human_readable(labels[i]) for i in kept]
 
 
+def _validate_explicit_axis(df: pd.DataFrame, col: str, flag: str) -> None:
+    """Raise PlotError when an explicitly named axis column is absent or constant.
+
+    Checked before the "at least 2 varying columns" guard so constant columns
+    produce a targeted message rather than a confusing structural error.
+    """
+    if col not in df.columns:
+        raise PlotError(f"{flag}={col!r} is not a column in the CSV")
+    if df[col].nunique(dropna=True) <= 1:
+        raise PlotError(f"column {col!r} has only one unique value; cannot use as an axis")
+
+
 def resolve_heatmap_xy(
     df: pd.DataFrame,
     args: argparse.Namespace,
@@ -115,6 +127,11 @@ def resolve_heatmap_xy(
     that doesn't collide. `exclude` lets the facets kind hide the facet
     column so it isn't picked for X or Y.
     """
+    if args.x is not None:
+        _validate_explicit_axis(df, args.x, "--x")
+    if args.y is not None:
+        _validate_explicit_axis(df, args.y, "--y")
+
     varying = [c for c in varying_axis_columns(df) if c not in exclude]
     if len(varying) < 2:  # noqa: PLR2004
         raise PlotError(

--- a/tests/python/test_shared_grid.py
+++ b/tests/python/test_shared_grid.py
@@ -2,12 +2,21 @@
 
 from __future__ import annotations
 
+import argparse
+
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 import pytest
 from ferret_plot.errors import PlotError
-from ferret_plot.kinds._shared import assert_finite_metric, assert_logz_positive, build_heatmap_trace, prepare_grid
+from ferret_plot.kinds._shared import (
+    assert_finite_metric,
+    assert_logz_positive,
+    build_heatmap_trace,
+    prepare_grid,
+    resolve_heatmap_xy,
+)
+from ferret_plot.registry import BenchmarkDefaults
 from fixtures import dbf_df
 
 _MISSING_BRANCH = 2
@@ -151,3 +160,27 @@ class TestBuildHeatmapTrace:
         )
         assert trace.zmin == 0.5
         assert trace.zmax == 2.5
+
+
+class TestResolveHeatmapXYConstantColumn:
+    """Explicit --x or --y columns with a single unique value must be rejected."""
+
+    def _args(self, *, x: str | None = None, y: str | None = None) -> argparse.Namespace:
+        return argparse.Namespace(x=x, y=y)
+
+    def _no_hints(self) -> BenchmarkDefaults:
+        return BenchmarkDefaults()
+
+    def test_constant_x_raises_plot_error(self):
+        # 'branches' has only one unique value; 'spacing_bytes' varies.
+        df = dbf_df(branches=(4,), spacing=(16, 32, 64))
+        args = self._args(x="branches", y=None)
+        with pytest.raises(PlotError, match="only one unique value"):
+            resolve_heatmap_xy(df, args, self._no_hints())
+
+    def test_constant_y_raises_plot_error(self):
+        # 'spacing_bytes' has only one unique value; 'branches' varies.
+        df = dbf_df(branches=(1, 2, 4), spacing=(32,))
+        args = self._args(x=None, y="spacing_bytes")
+        with pytest.raises(PlotError, match="only one unique value"):
+            resolve_heatmap_xy(df, args, self._no_hints())


### PR DESCRIPTION
## Summary

- A user-specified `--x` or `--y` column with only one unique value produced a silent 1-strip heatmap or surface instead of a useful error. This adds an early validation step that raises `PlotError` with a clear message before the pivot.
- Validation is extracted into `_validate_explicit_axis` (existence check + uniqueness check) and called for both `--x` and `--y` when explicitly supplied, before the "at least 2 varying columns" guard so the message is targeted rather than structural.
- The auto-select path (no explicit flag) is unchanged; it already skips constant columns via `varying_axis_columns`.

## Test plan

- [ ] `test_constant_x_raises_plot_error` — constant `--x` raises `PlotError` matching `"only one unique value"`
- [ ] `test_constant_y_raises_plot_error` — constant `--y` raises `PlotError` matching `"only one unique value"`
- [ ] Full suite: `113 passed, 2 deselected` (non-integration)
- [ ] `ruff check` / `ruff format --check` clean (single pre-existing `PLW0108` in `test_output.py` not touched by this PR)