### PR TITLE
feat(mispredict_latency): add benchmark for per-branch mispredict penalty

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -89,3 +89,10 @@ jobs:
           name: ${{ matrix.label }}-branch_history_footprint.html
           path: benchmark-results/${{ matrix.label }}/${{ matrix.label }}-branch_history_footprint.html
           archive: false
+
+      - name: upload train_betray_latency html
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ matrix.label }}-train_betray_latency.html
+          path: benchmark-results/${{ matrix.label }}/${{ matrix.label }}-train_betray_latency.html
+          archive: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,8 +207,9 @@ target_compile_features(ferret_core PUBLIC cxx_std_20)
 # Benchmark TUs compiled once; both the ferret executable and benchmark-
 # specific tests reuse the resulting object files.
 add_library(
-  ferret_benchmarks OBJECT benchmarks/branch_history_footprint.cpp benchmarks/direct_branch_footprint.cpp
-                           benchmarks/nested_call_depth.cpp benchmarks/dependent_chain_throughput.cpp
+  ferret_benchmarks OBJECT
+  benchmarks/branch_history_footprint.cpp benchmarks/direct_branch_footprint.cpp benchmarks/nested_call_depth.cpp
+  benchmarks/dependent_chain_throughput.cpp benchmarks/train_betray_latency.cpp
 )
 target_link_libraries(ferret_benchmarks PRIVATE ferret_core sljit::sljit ferret_warnings)
 

--- a/README.md
+++ b/README.md
@@ -75,12 +75,13 @@ CLI flags and axis syntax: [`docs/cli.md`](docs/cli.md).
 
 ## Benchmarks
 
-| Name                                                                          | Targets                                         |
-| ----------------------------------------------------------------------------- | ----------------------------------------------- |
-| [`dependent_chain_throughput`](docs/benchmarks/dependent_chain_throughput.md) | running core frequency / 1-IPC baseline         |
-| [`direct_branch_footprint`](docs/benchmarks/direct_branch_footprint.md)       | direct-jump BTB capacity                        |
-| [`nested_call_depth`](docs/benchmarks/nested_call_depth.md)                   | Return Address Stack (RAS) depth                |
-| [`branch_history_footprint`](docs/benchmarks/branch_history_footprint.md)     | conditional-branch direction-predictor capacity |
+| Name                                                                          | Targets                                          |
+| ----------------------------------------------------------------------------- | ------------------------------------------------ |
+| [`dependent_chain_throughput`](docs/benchmarks/dependent_chain_throughput.md) | running core frequency / 1-IPC baseline          |
+| [`direct_branch_footprint`](docs/benchmarks/direct_branch_footprint.md)       | direct-jump BTB capacity                         |
+| [`nested_call_depth`](docs/benchmarks/nested_call_depth.md)                   | Return Address Stack (RAS) depth                 |
+| [`branch_history_footprint`](docs/benchmarks/branch_history_footprint.md)     | conditional-branch direction-predictor capacity  |
+| [`train_betray_latency`](docs/benchmarks/train_betray_latency.md)             | per-branch mispredict penalty (train-and-betray) |
 
 Each benchmark page has the kernel structure, CLI surface, and reading-the-curves guide.
 

--- a/benchmarks/branch_history_footprint.cpp
+++ b/benchmarks/branch_history_footprint.cpp
@@ -14,6 +14,7 @@ extern "C" {
 #include "ferret/benchmark.hpp"
 #include "ferret/padding.hpp"
 #include "ferret/permute.hpp"
+#include "ferret/runner.hpp"
 
 namespace ferret {
 
@@ -125,6 +126,10 @@ struct BranchHistoryFootprint : Benchmark {
 
   void emit_kernel(sljit_compiler* c, const Params& p) override;
   void verify_layout(sljit_compiler* c) override;
+
+  MeasurementRow measure_row(const Params& p, int reps, int warmup) override {
+    return runner::single_kernel_measure(*this, p, reps, warmup);
+  }
 };
 
 void BranchHistoryFootprint::emit_kernel(sljit_compiler* c, const Params& p) {

--- a/benchmarks/dependent_chain_throughput.cpp
+++ b/benchmarks/dependent_chain_throughput.cpp
@@ -4,6 +4,7 @@ extern "C" {
 
 #include "ferret/bench_helpers.hpp"
 #include "ferret/benchmark.hpp"
+#include "ferret/runner.hpp"
 
 namespace ferret {
 
@@ -25,6 +26,10 @@ struct DependentChainThroughput : Benchmark {
   [[nodiscard]] size_t sites_per_kernel(const Params& p) const override { return p.get<size_t>("chain_length"); }
 
   [[nodiscard]] size_t iterations(const Params& /*p*/) const override { return 1; }
+
+  MeasurementRow measure_row(const Params& p, int reps, int warmup) override {
+    return runner::single_kernel_measure(*this, p, reps, warmup);
+  }
 
   void emit_kernel(sljit_compiler* c, const Params& p) override {
     auto total = p.get<size_t>("chain_length");

--- a/benchmarks/direct_branch_footprint.cpp
+++ b/benchmarks/direct_branch_footprint.cpp
@@ -28,6 +28,7 @@ extern "C" {
 #include "ferret/benchmark.hpp"
 #include "ferret/padding.hpp"
 #include "ferret/permute.hpp"
+#include "ferret/runner.hpp"
 
 namespace ferret {
 
@@ -185,6 +186,10 @@ struct DirectBranchFootprint : Benchmark {
     last_next_ = std::move(next);
     last_branches_ = branches;
     last_spacing_ = spacing;
+  }
+
+  MeasurementRow measure_row(const Params& p, int reps, int warmup) override {
+    return runner::single_kernel_measure(*this, p, reps, warmup);
   }
 
   // First verifies each branch site sits at base + i*spacing — throws

--- a/benchmarks/nested_call_depth.cpp
+++ b/benchmarks/nested_call_depth.cpp
@@ -11,6 +11,7 @@ extern "C" {
 #include "ferret/bench_helpers.hpp"
 #include "ferret/benchmark.hpp"
 #include "ferret/permute.hpp"
+#include "ferret/runner.hpp"
 
 namespace ferret {
 
@@ -329,6 +330,10 @@ struct NestedCallDepth : Benchmark {
 
   [[nodiscard]] size_t iterations(const Params& p) const override {
     return compute_iterations(kOpBudget, p.get<size_t>("depth") + 1);
+  }
+
+  MeasurementRow measure_row(const Params& p, int reps, int warmup) override {
+    return runner::single_kernel_measure(*this, p, reps, warmup);
   }
 
   void emit_kernel(sljit_compiler* c, const Params& p) override {

--- a/benchmarks/train_betray_latency.cpp
+++ b/benchmarks/train_betray_latency.cpp
@@ -1,0 +1,362 @@
+extern "C" {
+#include <sljitLir.h>
+}
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "ferret/bench_helpers.hpp"
+#include "ferret/benchmark.hpp"
+#include "ferret/jit.hpp"
+#include "ferret/log.hpp"
+#include "ferret/padding.hpp"
+#include "ferret/runner.hpp"
+#include "ferret/timing.hpp"
+
+namespace ferret {
+
+namespace {
+// Minimum bytes a load + cmp-and-branch can occupy (matches
+// branch_history_footprint). 8 on AArch64, 6 on x86_64.
+#if defined(__aarch64__) || defined(_M_ARM64)
+constexpr size_t kMinSiteBytes = 8;
+#elif defined(__x86_64__) || defined(_M_X64)
+constexpr size_t kMinSiteBytes = 6;
+#else
+#error "ferret supports only x86_64 and aarch64"
+#endif
+}  // namespace
+
+struct TrainBetrayLatency;  // forward decl for internal namespace use
+
+namespace train_betray_latency_internal {
+
+enum class FillMode : std::uint8_t { Betray, Control };
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+std::vector<uint32_t> generate_pattern_fill(size_t branches, size_t train_iters, FillMode mode) {
+  const size_t rows = train_iters + 1;
+  std::vector<uint32_t> flat(branches * rows, mode == FillMode::Control ? 1U : 0U);
+  if (mode == FillMode::Betray) {
+    // Training rows are all 1; betrayal row (last) stays 0.
+    for (size_t row = 0; row < train_iters; ++row) {
+      for (size_t j = 0; j < branches; ++j) {
+        flat[(row * branches) + j] = 1U;
+      }
+    }
+  }
+  return flat;
+}
+
+struct LayoutSnapshot {
+  std::vector<sljit_label*> labels;
+  size_t branches;
+  size_t spacing;
+};
+
+namespace {
+// Set by emit_kernel as a side effect so tests can inspect the most
+// recent post-codegen layout. Anonymous namespace → TU-local.
+const TrainBetrayLatency* g_last_emitted = nullptr;
+}  // namespace
+
+LayoutSnapshot last_layout_snapshot();  // defined after struct below
+
+}  // namespace train_betray_latency_internal
+
+struct TrainBetrayLatency : Benchmark {
+  using FillMode = train_betray_latency_internal::FillMode;
+
+  // Per-emission state. emit_kernel bakes a buffer pointer into the
+  // JIT'd code as SLJIT_IMM. We pre-build distinct Betray and Control
+  // buffers and emit_kernel picks one based on fill_mode_, so every
+  // JittedKernel built during one measure_row call reads from the same
+  // (stable, unchanging) buffer — multiple kernels can stay alive
+  // simultaneously without invalidating each other's baked pointers.
+  std::vector<uint32_t> flat_betray_;
+  std::vector<uint32_t> flat_control_;
+  std::vector<sljit_label*> last_labels_;
+  size_t last_branches_ = 0;
+  size_t last_spacing_ = 0;
+  FillMode fill_mode_ = FillMode::Betray;
+
+  ~TrainBetrayLatency() override {
+    if (train_betray_latency_internal::g_last_emitted == this) {
+      train_betray_latency_internal::g_last_emitted = nullptr;
+    }
+  }
+
+  [[nodiscard]] std::string name() const override { return "train_betray_latency"; }
+
+  // K must be large enough that K * c_misp ≫ timer quantum (24 MHz
+  // CNTVCT on Apple Silicon = ~190 cycles/tick) AND ≫ typical OS
+  // interrupt cost (~10 µs ≈ 45 K cycles). At K ≥ 16K, the per-trial
+  // signal is ~45 µs+, putting interrupts at < 25 % of the measurement
+  // — the median across reps stabilizes within a few cycles. Below
+  // ~8K, fixed overheads (JIT prologue, training-round cost not
+  // captured in differencing) inflate the apparent per-mispredict cost.
+  [[nodiscard]] SweepAxes axes() const override {
+    return {Axis::geom_range("branches", 16384, 65536, /*samples_per_octave=*/1)};
+  }
+
+  [[nodiscard]] BenchOptions options() const override {
+    return {
+        BenchOption{.name = "train_iters", .default_value = 8},
+        BenchOption{.name = "spacing_bytes", .default_value = 16},
+    };
+  }
+
+  // "Site" for CSV normalization = "mispredict". One betrayal round
+  // of K branches per kernel call.
+  [[nodiscard]] size_t sites_per_kernel(const Params& p) const override { return p.get<size_t>("branches"); }
+
+  // One outer-loop cycle = train_iters training rounds + 1 betrayal round.
+  // We want exactly one full cycle per kernel call so the betrayal happens
+  // on a cold-but-2-trained predictor; running additional cycles would
+  // give TAGE the chance to learn the period.
+  [[nodiscard]] size_t iterations(const Params& p) const override {
+    return static_cast<size_t>(p.get<int64_t>("train_iters") + 1);
+  }
+
+  void emit_kernel(sljit_compiler* c, const Params& p) override;
+  void verify_layout(sljit_compiler* c) override;
+  MeasurementRow measure_row(const Params& p, int reps, int warmup) override;
+};
+
+void TrainBetrayLatency::emit_kernel(sljit_compiler* c, const Params& p) {
+  auto branches = p.get<size_t>("branches");
+  auto train_iters_signed = p.get<int64_t>("train_iters");
+  auto spacing = p.get<size_t>("spacing_bytes");
+
+  if (branches < 1) {
+    throw std::invalid_argument("branches must be >= 1");
+  }
+  if (train_iters_signed < 0) {
+    throw std::invalid_argument("train_iters must be >= 0; got " + std::to_string(train_iters_signed));
+  }
+  const auto train_iters = static_cast<size_t>(train_iters_signed);
+  if (spacing < kMinSiteBytes) {
+    throw std::invalid_argument("spacing_bytes=" + std::to_string(spacing) +
+                                " is smaller than the minimum site encoding (" + std::to_string(kMinSiteBytes) +
+                                " bytes) on this architecture");
+  }
+#if defined(__aarch64__) || defined(_M_ARM64)
+  if (spacing % 4 != 0) {
+    throw std::invalid_argument("spacing_bytes=" + std::to_string(spacing) +
+                                " must be a multiple of 4 on this architecture");
+  }
+#endif
+
+  const size_t rows = train_iters + 1;
+  const size_t iters = iterations(p);
+
+  // Lazily populate the buffer for the currently-requested fill mode.
+  // measure_row pre-fills both once per (K, M); single-kernel callers
+  // (verify_layout tests) hit this fall-back path.
+  auto& flat = (fill_mode_ == FillMode::Control) ? flat_control_ : flat_betray_;
+  if (flat.size() != branches * rows) {
+    flat = train_betray_latency_internal::generate_pattern_fill(branches, train_iters, fill_mode_);
+  }
+
+  // 3 scratches + 2 saveds, same shape as branch_history_footprint.
+  // SLJIT_S0 = flat_base, SLJIT_S1 = hist_idx, SLJIT_R0 = iter counter.
+  // SLJIT_R1 = row_ptr, SLJIT_R2 = loaded value.
+  sljit_emit_enter(c, 0, SLJIT_ARGS0V(), /*scratches=*/3, /*saved=*/2, /*local_size=*/0);
+  sljit_emit_op1(c, SLJIT_MOV, SLJIT_S0, 0, SLJIT_IMM, reinterpret_cast<sljit_sw>(flat.data()));
+  sljit_emit_op1(c, SLJIT_MOV, SLJIT_S1, 0, SLJIT_IMM, 0);
+
+  emit_outer_loop(c, SLJIT_R0, iters, [&] {
+    // row_ptr = flat_base + hist_idx * (branches * 4)
+    sljit_emit_op2(c, SLJIT_MUL, SLJIT_R1, 0, SLJIT_S1, 0, SLJIT_IMM, static_cast<sljit_sw>(branches * 4));
+    sljit_emit_op2(c, SLJIT_ADD, SLJIT_R1, 0, SLJIT_R1, 0, SLJIT_S0, 0);
+
+    last_labels_.clear();
+    last_labels_.reserve(branches + 1);
+
+    for (size_t j = 0; j < branches; ++j) {
+      last_labels_.push_back(sljit_emit_label(c));
+      sljit_emit_op1(c, SLJIT_MOV_U32, SLJIT_R2, 0, SLJIT_MEM1(SLJIT_R1), static_cast<sljit_sw>(j * 4));
+      sljit_jump* jmp = sljit_emit_cmp(c, SLJIT_NOT_EQUAL | SLJIT_32, SLJIT_R2, 0, SLJIT_IMM, 0);
+      sljit_label* after = sljit_emit_label(c);
+      sljit_set_label(jmp, after);
+      emit_nops(c, spacing - kMinSiteBytes);
+    }
+    last_labels_.push_back(sljit_emit_label(c));
+
+    // hist_idx = (hist_idx + 1 == rows) ? 0 : hist_idx + 1
+    sljit_emit_op2(c, SLJIT_ADD, SLJIT_S1, 0, SLJIT_S1, 0, SLJIT_IMM, 1);
+    sljit_emit_op2u(c, SLJIT_SUB | SLJIT_SET_Z, SLJIT_S1, 0, SLJIT_IMM, static_cast<sljit_sw>(rows));
+    sljit_jump* skip_reset = sljit_emit_jump(c, SLJIT_NOT_ZERO);
+    sljit_emit_op1(c, SLJIT_MOV, SLJIT_S1, 0, SLJIT_IMM, 0);
+    sljit_label* after_wrap = sljit_emit_label(c);
+    sljit_set_label(skip_reset, after_wrap);
+  });
+
+  sljit_emit_return_void(c);
+
+  last_branches_ = branches;
+  last_spacing_ = spacing;
+  train_betray_latency_internal::g_last_emitted = this;
+}
+
+void TrainBetrayLatency::verify_layout(sljit_compiler* /*c*/) {
+  if (last_branches_ == 0 || last_labels_.empty()) {
+    return;
+  }
+  verify_uniform_spacing(last_labels_, last_spacing_, /*strict=*/false, "train_betray_latency");
+}
+
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+MeasurementRow TrainBetrayLatency::measure_row(const Params& p, int reps, int warmup) {
+  const auto K = p.get<size_t>("branches");
+  const auto M = static_cast<size_t>(p.get<int64_t>("train_iters"));
+  if (reps <= 0) {
+    throw std::invalid_argument("train_betray_latency: reps must be >= 1");
+  }
+  // Internal warmup: extra trials whose samples we discard. Smooths
+  // out first-kernel cold-cache / freq-ramp jitter without forcing the
+  // user to bump --reps. Bounded below at 3 even when the caller
+  // requests less; below that the IQM has too few samples to be robust.
+  constexpr int kMinInternalWarmup = 3;
+  const int internal_warmup = std::max(warmup, kMinInternalWarmup);
+  if (internal_warmup > warmup) {
+    log::info("train_betray_latency: clamping warmup to {} (was {}) for stable IQM aggregation", internal_warmup,
+              warmup);
+  }
+  const int total_trials = reps + internal_warmup;
+
+  // Pre-build BOTH fill buffers once. They never change across trials.
+  // Pre-building decouples emit_kernel's flat-buffer side effect from
+  // kernel lifetime, so we can hold many kernels alive simultaneously
+  // without the JIT's baked SLJIT_IMM pointers going stale.
+  flat_betray_ = train_betray_latency_internal::generate_pattern_fill(K, M, FillMode::Betray);
+  flat_control_ = train_betray_latency_internal::generate_pattern_fill(K, M, FillMode::Control);
+
+  // Build ALL kernels first (and keep them alive throughout). This
+  // matters because sljit's allocator (sljitExecAllocatorCore.c) reuses
+  // freed blocks within the same 64 KiB chunk — emit/free/emit returns
+  // the same VA, putting the new "trial" on PCs the predictor just
+  // trained at. Holding all kernels alive forces sljit to walk
+  // forward through the chunk, giving each kernel a distinct address
+  // (typically 64-byte stride between sites).
+  std::vector<JittedKernel> kernels_B;
+  std::vector<JittedKernel> kernels_C;
+  kernels_B.reserve(total_trials);
+  kernels_C.reserve(total_trials);
+  for (int t = 0; t < total_trials; ++t) {
+    fill_mode_ = FillMode::Betray;
+    kernels_B.emplace_back(*this, p);
+    if (!kernels_B.back().ok()) {
+      MeasurementRow fail;
+      fail.jit_failed = true;
+      fail.iters = 1;
+      fail.sites = sites_per_kernel(p);
+      fail.reps = static_cast<size_t>(reps);
+      return fail;
+    }
+    fill_mode_ = FillMode::Control;
+    kernels_C.emplace_back(*this, p);
+    if (!kernels_C.back().ok()) {
+      MeasurementRow fail;
+      fail.jit_failed = true;
+      fail.iters = 1;
+      fail.sites = sites_per_kernel(p);
+      fail.reps = static_cast<size_t>(reps);
+      return fail;
+    }
+  }
+
+  // Time each pair. Predictor state from prior trials persists, but
+  // every trial's B and C kernels are at fresh PCs (different from
+  // each other AND from prior trials), so TAGE entries built up by
+  // earlier trials don't bias this trial's betrayal. First
+  // internal_warmup trials are discarded.
+  std::vector<uint64_t> samples;
+  samples.reserve(total_trials);
+  for (int t = 0; t < total_trials; ++t) {
+    auto fn_B = kernels_B[t].fn();
+    uint64_t t0 = timing::arch_now_ticks();
+    fn_B();
+    uint64_t t1 = timing::arch_now_ticks();
+    auto fn_C = kernels_C[t].fn();
+    uint64_t t2 = timing::arch_now_ticks();
+    fn_C();
+    uint64_t t3 = timing::arch_now_ticks();
+    uint64_t b = t1 - t0;
+    uint64_t c = t3 - t2;
+    samples.push_back(b > c ? b - c : 0);
+  }
+  // Discard internal warmup samples.
+  samples.erase(samples.begin(), samples.begin() + internal_warmup);
+  // Drop trials where the saturating subtract clamped to zero (B < C).
+  // These are noise — a single OS interrupt or cache miss biased C
+  // larger than B for that trial. Including them in the aggregate
+  // pulls the result toward zero. If too many trials clamp, the
+  // measurement window is too small for the underlying signal and the
+  // user should bump --branches or --reps.
+  const size_t before_filter = samples.size();
+  std::erase(samples, 0U);
+  if (samples.empty()) {
+    // Distinct from jit_failed: the JIT worked, but the per-trial
+    // signal was below the timer's resolution + scheduling noise.
+    // Return a zero-cost row and let the user adjust parameters.
+    log::warn(
+        "train_betray_latency: all {} timed samples clamped to zero (B<C); "
+        "signal below noise floor — increase --branches or --reps",
+        before_filter);
+    MeasurementRow row;
+    row.iters = 1;
+    row.sites = sites_per_kernel(p);
+    row.reps = 0;  // 0 samples actually contributed
+    return row;
+  }
+
+  std::ranges::sort(samples);
+  MeasurementRow row;
+  row.ticks_min = samples.front();
+  // Inter-quartile mean: average the middle 50% of samples. Robust
+  // against OS-interrupt-inflated outliers (top tail) AND against
+  // saturating-subtract zeros from spuriously-fast C runs (bottom
+  // tail). With reps=21+ this typically converges within ~0.3 cycles
+  // run-to-run.
+  if (samples.size() >= 4) {
+    const size_t q1 = samples.size() / 4;
+    const size_t q3 = samples.size() - (samples.size() / 4);
+    uint64_t sum = 0;
+    for (size_t i = q1; i < q3; ++i) {
+      sum += samples[i];
+    }
+    row.ticks_median = sum / (q3 - q1);
+  } else {
+    row.ticks_median = samples[samples.size() / 2];
+  }
+  // iters=1, sites=K → CSV's ns_per_site == ns per mispredict.
+  // reps reports the count of *contributing* samples (post-warmup,
+  // post-zero-filter), so downstream tooling can compute correct
+  // standard errors.
+  row.iters = 1;
+  row.sites = sites_per_kernel(p);
+  row.reps = samples.size();
+  return row;
+}
+
+namespace train_betray_latency_internal {
+
+LayoutSnapshot last_layout_snapshot() {
+  if (g_last_emitted == nullptr) {
+    return {};
+  }
+  return {.labels = g_last_emitted->last_labels_,
+          .branches = g_last_emitted->last_branches_,
+          .spacing = g_last_emitted->last_spacing_};
+}
+
+}  // namespace train_betray_latency_internal
+
+FERRET_BENCHMARK("train_betray_latency", TrainBetrayLatency);
+
+}  // namespace ferret

--- a/docs/benchmarks/train_betray_latency.md
+++ b/docs/benchmarks/train_betray_latency.md
@@ -1,0 +1,167 @@
+# `train_betray_latency` — conditional-branch misprediction penalty
+
+`K` data-dependent conditional branches in a chain, branch-target =
+next instruction. Each kernel call runs **one full cycle** of `M`
+training rounds (all-taken at every PC) followed by **one betrayal
+round** (all-not-taken at every PC). With the bimodal counter
+saturated to TAKEN by training, every betrayal branch mispredicts —
+giving exactly `K` mispredicts per kernel call.
+
+Per parameter point, the benchmark builds many JIT'd kernel pairs
+(B = betray fill, C = control fill) at **distinct PCs**, runs each
+once, and differences the wall-clock ticks. Aggregation is
+inter-quartile mean over the per-trial differences. With `--freq`
+the CSV's `cycles_per_site_median` is _cycles per mispredict_;
+without it, `ns_per_site_median` is _ns per mispredict_.
+
+## Why the design looks like this
+
+Classical train-and-betray (saturate a branch in one direction, then
+flip it) **fails on modern global-history predictors** like the TAGE
+variant in Apple Firestorm/M-series and recent AMD/Intel cores. The
+predictor recognises the `(M+1)*K`-branch cycle after a few
+iterations and starts predicting the betrayal round correctly. To
+defeat this, the benchmark:
+
+- Uses **fresh PCs per trial.** TAGE entries are keyed by
+  `hash(PC, GHR)`. New PCs hit empty tables → TAGE falls back to
+  bimodal, which we _can_ saturate.
+- Holds every trial's `JittedKernel` alive throughout the
+  measurement loop. sljit's executable allocator
+  (`sljitExecAllocatorCore.c`) reuses freed blocks within its 64 KiB
+  chunks, so a `build/free/build` cycle returns the same VA. Keeping
+  blocks alive forces sljit to walk forward through the chunk,
+  giving each trial a distinct code address.
+- Pre-builds both pattern buffers (`flat_betray_`, `flat_control_`)
+  once per `measure_row` call. Avoids the dangling-pointer race the
+  earlier "reassign-flat-per-emit" design had with kernels' baked
+  `SLJIT_IMM` buffer pointers.
+
+## Kernel structure
+
+```text
+   PC                  site (>= spacing_bytes apart)
+ 0x0000   ┌──────────────────────────────────────┐
+          │  MOV  r2, [row_ptr + 0]              │  load 32-bit outcome
+          │  CMP  r2, 0                          │
+          │  JNE  .Lnext_0                       │ ──┐  branch-to-next
+          │ .Lnext_0:                            │ ◄─┘
+          │  <NOP pad>                           │
+          ├──────────────────────────────────────┤
+          │   ... K branches total ...           │
+          ├──────────────────────────────────────┤
+          │  ADD  hist_idx, hist_idx, 1          │
+          │  CMP  hist_idx, M+1  → wrap to 0     │
+          │  SUBS iters, iters, 1; B.NE loop_top │
+          └──────────────────────────────────────┘
+```
+
+- `row_ptr = flat_base + hist_idx * (K * 4)` recomputed once per
+  outer iter.
+- `hist_idx` wraps mod `(M+1)`; one full cycle = `M` training rounds
+  followed by `1` betrayal round.
+- The outer loop runs exactly `M+1` times per kernel call — one full
+  cycle. Running more cycles would give TAGE entries indexed by the
+  cycle's GHR signatures the chance to gain confidence and start
+  predicting the betrayal correctly.
+- B and C differ only in `flat[M]`: B has all-0s (betrayal), C has
+  all-1s (continued training).
+
+## Per-benchmark options
+
+| flag                | meaning                                                                                                                                                                                   |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--train_iters=M`   | Training rounds per kernel call. Default `8` — enough to saturate the bimodal counter on every documented predictor, low enough that TAGE entries don't gain confidence within one trial. |
+| `--spacing_bytes=N` | Minimum per-site PC stride. Min 8 (AArch64) / 6 (x86_64). Default 16.                                                                                                                     |
+
+## CLI surface
+
+| flag                 | meaning                                                                                                                                                            |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--branches=A..B`    | Geometric sweep, default `k=1`, e.g. `16384..65536`.                                                                                                               |
+| `--branches=A..B@k`  | Geometric sweep with `k` samples per octave.                                                                                                                       |
+| `--branches=v1,v2,…` | Explicit list.                                                                                                                                                     |
+| `--train_iters=N`    | See above. Default 8.                                                                                                                                              |
+| `--spacing_bytes=N`  | See above. Default 16.                                                                                                                                             |
+| `--reps=N`           | Trials whose differenced ticks contribute to the IQM. Default 7 (framework). For tight measurements use `--reps=99` or higher; precision scales as `1/sqrt(reps)`. |
+| `--seed=…`           | Accepted but unused (pattern is deterministic).                                                                                                                    |
+
+See [`../cli.md`](../cli.md) for global flags.
+
+## How to read the output
+
+```sh
+build/ferret run dependent_chain_throughput --core=3 --out=/tmp/freq.csv
+python3 scripts/freq.py /tmp/freq.csv
+# → estimated_freq=4.484GHz (Apple M4 P-core example)
+
+build/ferret run train_betray_latency --core=3 --reps=99 \
+    --freq=4.484GHz --out=/tmp/misp.csv
+
+python3 scripts/plot.py line /tmp/misp.csv --out=/tmp/misp.png
+```
+
+The headline number is `cycles_per_site_median` at the largest K in
+the sweep. On Apple M4 P-core this is **~15 cycles per mispredict**
+(reproducible to ±0.5 cycles across reps=99 runs).
+
+## Reading the K-sweep curve
+
+A wider sweep `--branches=4096..131072` exposes two uarch features
+in one plot:
+
+- **Linear region (K ≤ predictor capacity)**: per-mispredict cost
+  converges from ~25 cycles down to ~15 cycles as K grows. At small
+  K, fixed overheads (kernel prologue/epilogue, training-round cold
+  starts, JIT compile timing) inflate the differenced value. At
+  large K, those overheads are a tiny fraction and the reading
+  converges to the true misprediction penalty.
+
+- **Capacity cliff (K > 2 × bimodal-table-size)**: apparent
+  cost _halves_ (drops to ~7 cycles on M4 at K=131072). This is not
+  a faster mispredict — it's a _lower mispredict rate_. With P
+  distinct PCs sharing one bimodal table entry, only the first 2
+  betrayals at that entry flip the saturating counter; subsequent
+  branches at the entry get a correct prediction "for free". For P=4
+  collisions per entry, rate drops to 50%; the benchmark divides
+  by `K` assuming 100%, so the headline number halves.
+
+  This cliff lets you infer the bimodal table size:
+
+  ```text
+  rate ≈ (cycles_at_high_K / cycles_at_low_K) ≈ 0.5  →  P ≈ 4  →  B ≈ K/4
+  ```
+
+  On Apple M4 this gives bimodal table ≈ 32 K entries.
+
+A linear-regression fit of `ticks_median` vs `branches` across the
+linear region gives **`c_misp − c_baseline`** directly (~12.5 cycles
+on M4), with overheads cancelled in the intercept. This is the
+"pipeline depth" reading you'd find in vendor pipeline diagrams.
+
+## Caveats
+
+- **Memory cost scales with reps × K.** Each kernel is ~K × 16 bytes;
+  `total_trials = reps + 3` kernel pairs are kept alive concurrently.
+  At default K=65536 reps=99 peak RSS is ~500 MB. On memory-constrained
+  targets (Android, low-end VMs), reduce `--reps` first, then K.
+- **First-run wobble.** First-trial cold-cache and freq-ramp effects
+  make `reps=21` runs vary by ~1–2 cycles run-to-run. The internal
+  3-trial warmup absorbs most of it. For ±0.5 cycle precision use
+  `--reps=99`; for ±0.1 cycles, average the median across several
+  invocations externally.
+- **All-clamped-to-zero rows.** If every per-trial `B − C` clamps to
+  zero (signal below the timer's resolution + scheduling noise), the
+  benchmark logs a warn and emits a zero-cost row with `reps=0`. Bump
+  K or `--reps`.
+- **Apple Silicon pinning.** Same caveat as every other ferret
+  benchmark — probe and target may land on different P-cores. macOS
+  doesn't expose per-core pinning to userspace.
+
+## Related docs
+
+- Design spec:
+  [`../superpowers/specs/2026-05-27-train-betray-latency-design.md`](../superpowers/specs/2026-05-27-train-betray-latency-design.md).
+- Sister benchmark (capacity, not latency):
+  [`branch_history_footprint`](branch_history_footprint.md).
+- Project two-step workflow: [project README](../../README.md).

--- a/docs/superpowers/plans/2026-05-27-train-betray-latency.md
+++ b/docs/superpowers/plans/2026-05-27-train-betray-latency.md
@@ -1,0 +1,1492 @@
+# `train_betray_latency` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `train_betray_latency` — a train-and-betray microbenchmark that reports per-branch mispredict penalty in cycles (or nanoseconds without `--freq`).
+
+**Architecture:** Reuses the `branch_history_footprint` chain shape (data-dependent conditional branches with branch-target = next instruction). Pattern buffer is fixed: M rows of all-1 (training) plus 1 row of all-0 (betrayal). Per-row measurement does two-kernel differencing — betray kernel minus an all-train control kernel — so the residual ticks are exactly the K mispredicts. Requires a small framework refactor that moves per-row measurement responsibility from `run_command::measure_all` to a new `Benchmark::measure_row` virtual.
+
+**Tech Stack:** C++20, sljit (JIT), CMake/Ninja, GoogleTest, ferret's existing benchmark framework.
+
+**Reference docs:**
+- Spec: [`../specs/2026-05-27-mispredict-latency-design.md`](../specs/2026-05-27-mispredict-latency-design.md)
+- Sister benchmark (capacity, not latency): [`../specs/2026-05-17-branch-history-footprint-design.md`](../specs/2026-05-17-branch-history-footprint-design.md), [`benchmarks/branch_history_footprint.cpp`](../../../benchmarks/branch_history_footprint.cpp)
+- Build/test recipes: [`docs/build.md`](../../build.md), [`AGENTS.md`](../../../AGENTS.md)
+
+**Build & test cycle (used in every task):**
+```sh
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+If you don't have a build dir yet:
+```sh
+nix develop -c cmake -S . -B build -GNinja
+```
+
+---
+
+## File Structure
+
+**New files:**
+- `benchmarks/train_betray_latency.cpp` — benchmark class, pattern fill, kernel emit, measure_row.
+- `tests/test_train_betray_latency.cpp` — unit + integration tests for the benchmark.
+- `docs/benchmarks/train_betray_latency.md` — per-benchmark documentation page.
+
+**Modified files:**
+- `include/ferret/benchmark.hpp` — add pure-virtual `Benchmark::measure_row`.
+- `include/ferret/runner.hpp` — declare `runner::single_kernel_measure` helper.
+- `src/runner.cpp` — implement the helper (lifted from `measure_all`'s inner block).
+- `src/run_command.cpp` — collapse `measure_all` to a `bench.measure_row(...)` call per row.
+- `benchmarks/branch_history_footprint.cpp` — add one-line `measure_row` override.
+- `benchmarks/direct_branch_footprint.cpp` — add one-line `measure_row` override.
+- `benchmarks/nested_call_depth.cpp` — add one-line `measure_row` override.
+- `benchmarks/dependent_chain_throughput.cpp` — add one-line `measure_row` override.
+- `tests/test_runner.cpp` — add unit test for `single_kernel_measure`.
+- `tests/CMakeLists.txt` — add `test_train_betray_latency` target; ensure `test_runner` links sljit + benchmark.
+- `CMakeLists.txt` — add `benchmarks/train_betray_latency.cpp` to `ferret_benchmarks`.
+- `README.md` — add the benchmark to the benchmark table.
+
+---
+
+### Task 1: Add `runner::single_kernel_measure` helper
+
+Pull the "build one JittedKernel, time it, fill a row" logic out of `measure_all` so the new differencing benchmark can build its own measurement strategy on top of the same primitive.
+
+**Files:**
+- Modify: `include/ferret/runner.hpp`
+- Modify: `src/runner.cpp`
+- Modify: `tests/test_runner.cpp`
+- Modify: `tests/CMakeLists.txt`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_runner.cpp`:
+
+```cpp
+#include "ferret/benchmark.hpp"
+#include "ferret/jit.hpp"
+#include "ferret/params.hpp"
+
+extern "C" {
+#include <sljitLir.h>
+}
+
+namespace {
+struct NoopBenchmark : public ferret::Benchmark {
+  std::string name() const override { return "noop"; }
+  ferret::SweepAxes axes() const override { return {}; }
+  size_t sites_per_kernel(const ferret::Params&) const override { return 1; }
+  size_t iterations(const ferret::Params&) const override { return 1; }
+  void emit_kernel(sljit_compiler* c, const ferret::Params&) override {
+    sljit_emit_enter(c, 0, SLJIT_ARGS0V(), 1, 0, 0);
+    sljit_emit_return_void(c);
+  }
+};
+}  // namespace
+
+TEST(SingleKernelMeasure, RunsNoopBenchmarkSuccessfully) {
+  NoopBenchmark b;
+  ferret::Params p;
+  auto row = ferret::runner::single_kernel_measure(b, p, /*reps=*/3, /*warmup=*/1);
+  EXPECT_FALSE(row.jit_failed);
+  EXPECT_EQ(row.sites, 1u);
+  EXPECT_EQ(row.iters, 1u);
+  EXPECT_EQ(row.reps, 3u);
+  EXPECT_GE(row.ticks_median, row.ticks_min);
+}
+```
+
+Note: `NoopBenchmark` does not implement `measure_row` because that virtual doesn't exist yet (Task 2 adds it). Task 2 adds the one-line override to `NoopBenchmark` when it makes the virtual pure.
+
+- [ ] **Step 2: Add `single_kernel_measure` declaration to `runner.hpp`**
+
+Edit `include/ferret/runner.hpp`. Forward-declare `Benchmark` and `Params`, then add the declaration to the `runner` namespace:
+
+```cpp
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace ferret {
+class Benchmark;
+class Params;
+}  // namespace ferret
+
+namespace ferret {
+
+struct MeasurementRow {
+  uint64_t ticks_min = 0;
+  uint64_t ticks_median = 0;
+  size_t iters = 0;
+  size_t sites = 0;
+  size_t reps = 0;
+  bool jit_failed = false;
+};
+
+namespace runner {
+
+using KernelFn = void (*)(void);
+
+struct MeasureOptions {
+  size_t iters;
+  size_t sites;
+  int reps;
+  int warmup;
+};
+
+MeasurementRow measure(KernelFn fn, const MeasureOptions& opts);
+
+// Builds a JittedKernel for `b` at `p`, runs runner::measure on it, and
+// fills the resulting MeasurementRow with iters / sites taken from the
+// benchmark. The default measure_row strategy for benchmarks that time
+// a single JIT'd kernel — differencing benchmarks override measure_row
+// directly and don't use this helper.
+//
+// On JIT failure, returns a row with .jit_failed = true and
+// .iters/.sites pre-populated. Propagates std::exception from
+// emit_kernel/verify_layout to the caller.
+MeasurementRow single_kernel_measure(Benchmark& b, const Params& p,
+                                     int reps, int warmup);
+
+}  // namespace runner
+}  // namespace ferret
+```
+
+- [ ] **Step 3: Implement `single_kernel_measure` in `runner.cpp`**
+
+Edit `src/runner.cpp`. Add includes and the new function body. Lift the logic out of `measure_all` (don't delete the original yet — Task 2 does that):
+
+```cpp
+#include "ferret/runner.hpp"
+
+#include "ferret/benchmark.hpp"
+#include "ferret/jit.hpp"
+#include "ferret/log.hpp"
+#include "ferret/params.hpp"
+#include "ferret/timing.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <vector>
+
+namespace flog = ferret::log;
+
+namespace ferret::runner {
+
+MeasurementRow measure(KernelFn fn, const MeasureOptions& opts) {
+  if (opts.reps <= 0) {
+    throw std::invalid_argument("runner::measure: reps must be >= 1");
+  }
+  if (opts.warmup < 0) {
+    throw std::invalid_argument("runner::measure: warmup must be >= 0");
+  }
+  MeasurementRow row;
+  row.iters = opts.iters;
+  row.sites = opts.sites;
+  row.reps = static_cast<size_t>(opts.reps);
+
+  for (int i = 0; i < opts.warmup; ++i) {
+    fn();
+  }
+
+  std::vector<uint64_t> samples;
+  samples.reserve(opts.reps);
+  for (int i = 0; i < opts.reps; ++i) {
+    uint64_t t0 = timing::arch_now_ticks();
+    fn();
+    uint64_t t1 = timing::arch_now_ticks();
+    samples.push_back(t1 - t0);
+  }
+
+  std::ranges::sort(samples);
+  row.ticks_min = samples.front();
+  row.ticks_median = samples[samples.size() / 2];
+  return row;
+}
+
+MeasurementRow single_kernel_measure(Benchmark& b, const Params& p,
+                                     int reps, int warmup) {
+  size_t pre_iters = b.iterations(p);
+  size_t pre_sites = b.sites_per_kernel(p);
+  if (pre_iters == 0 || pre_sites == 0) {
+    throw std::invalid_argument("single_kernel_measure: iterations and sites_per_kernel must be > 0");
+  }
+  JittedKernel kern(b, p);
+  if (!kern.ok()) {
+    MeasurementRow row;
+    row.jit_failed = true;
+    row.iters = pre_iters;
+    row.sites = pre_sites;
+    flog::warn("sljit_error on params; emitting empty row");
+    return row;
+  }
+  flog::info("jit kernel: {} bytes", kern.code_size());
+  return measure(kern.fn(), {.iters = pre_iters, .sites = pre_sites, .reps = reps, .warmup = warmup});
+}
+
+}  // namespace ferret::runner
+```
+
+- [ ] **Step 4: Update `tests/CMakeLists.txt` so `test_runner` can link sljit and the benchmark machinery**
+
+Edit `tests/CMakeLists.txt`. Replace the `test_runner` target block:
+
+```cmake
+add_executable(test_runner test_runner.cpp)
+target_link_libraries(test_runner PRIVATE
+  ferret_core
+  sljit::sljit
+  GTest::gtest GTest::gtest_main
+  ferret_warnings
+)
+gtest_discover_tests(test_runner)
+```
+
+(The only change is the addition of `sljit::sljit`.)
+
+- [ ] **Step 5: Run the new test**
+
+```sh
+cmake --build build
+ctest --test-dir build --output-on-failure -R SingleKernelMeasure
+```
+Expected: PASS — `single_kernel_measure` is declared, defined, and exercises the JIT/measure pipeline against a noop benchmark.
+
+- [ ] **Step 6: Run the full suite to confirm no regressions**
+
+```sh
+ctest --test-dir build --output-on-failure
+```
+Expected: PASS. `measure_all` in `src/run_command.cpp` is unchanged at this point — it still constructs `JittedKernel` and calls `runner::measure` directly. The new helper duplicates that logic; Task 2 deletes the duplicate.
+
+- [ ] **Step 7: Commit**
+
+```sh
+git add include/ferret/runner.hpp src/runner.cpp \
+        tests/test_runner.cpp tests/CMakeLists.txt
+git commit --no-gpg-sign -m "feat(runner): add single_kernel_measure helper"
+```
+
+---
+
+### Task 2: Introduce `Benchmark::measure_row`, port all benchmarks, simplify `measure_all`
+
+Add the pure-virtual `measure_row` contract to `Benchmark`. Every existing benchmark gets a one-line override that delegates to `runner::single_kernel_measure`. `run_command::measure_all` collapses to a `bench.measure_row(p, reps, warmup)` call per row.
+
+**Files:**
+- Modify: `include/ferret/benchmark.hpp`
+- Modify: `benchmarks/branch_history_footprint.cpp`
+- Modify: `benchmarks/direct_branch_footprint.cpp`
+- Modify: `benchmarks/nested_call_depth.cpp`
+- Modify: `benchmarks/dependent_chain_throughput.cpp`
+- Modify: `tests/test_runner.cpp` (NoopBenchmark needs to implement the new pure-virtual)
+- Modify: `src/run_command.cpp`
+
+- [ ] **Step 1: Add `measure_row` pure-virtual to `Benchmark`**
+
+Edit `include/ferret/benchmark.hpp`. Add `runner.hpp` include for `MeasurementRow`, and add the pure-virtual to the class:
+
+```cpp
+#include "ferret/runner.hpp"
+
+namespace ferret {
+
+class Benchmark {
+ public:
+  virtual ~Benchmark() = default;
+  virtual std::string name() const = 0;
+  virtual SweepAxes axes() const = 0;
+  virtual BenchOptions options() const { return {}; }
+  virtual size_t sites_per_kernel(const Params& p) const = 0;
+  virtual size_t iterations(const Params& p) const = 0;
+  virtual void emit_kernel(sljit_compiler* c, const Params& p) = 0;
+  virtual void verify_layout(sljit_compiler* c) { (void)c; }
+
+  // Per-row measurement strategy. Most benchmarks build one JIT'd
+  // kernel and time it; they implement this as a one-liner that calls
+  // runner::single_kernel_measure(*this, p, reps, warmup). Benchmarks
+  // that need a richer strategy (e.g. train_betray_latency, which times
+  // two kernels and reports the difference) override directly.
+  virtual MeasurementRow measure_row(const Params& p, int reps, int warmup) = 0;
+};
+```
+
+- [ ] **Step 2: Add the one-liner override to each existing benchmark**
+
+For each of:
+- `benchmarks/branch_history_footprint.cpp`
+- `benchmarks/direct_branch_footprint.cpp`
+- `benchmarks/nested_call_depth.cpp`
+- `benchmarks/dependent_chain_throughput.cpp`
+
+Add the include and the override. For `branch_history_footprint.cpp`, the include is already present indirectly — add `#include "ferret/runner.hpp"` to the includes block, then add this method to the `BranchHistoryFootprint` struct (placement: right after `verify_layout`'s declaration):
+
+```cpp
+  MeasurementRow measure_row(const Params& p, int reps, int warmup) override {
+    return runner::single_kernel_measure(*this, p, reps, warmup);
+  }
+```
+
+For each of the other three benchmarks, do the analogous edit — add `#include "ferret/runner.hpp"` to the includes block, then add the one-liner override to the struct definition.
+
+- [ ] **Step 2b: Add the same override to `NoopBenchmark` in `tests/test_runner.cpp`**
+
+Edit `tests/test_runner.cpp`. Add the override to the `NoopBenchmark` struct from Task 1:
+
+```cpp
+ferret::MeasurementRow measure_row(const ferret::Params& p, int reps, int warmup) override {
+  return ferret::runner::single_kernel_measure(*this, p, reps, warmup);
+}
+```
+
+Without this, the test target fails to link because `NoopBenchmark` becomes abstract (cannot be instantiated) once `measure_row` is pure-virtual.
+
+- [ ] **Step 3: Simplify `measure_all` in `src/run_command.cpp`**
+
+Replace the body of `measure_all` (lines ~121-151) with:
+
+```cpp
+std::optional<std::vector<MeasuredRow>> measure_all(Benchmark& bench, const std::vector<Params>& rows, int reps,
+                                                    int warmup) {
+  std::vector<MeasuredRow> out;
+  out.reserve(rows.size());
+  for (const auto& p : rows) {
+    MeasurementRow m;
+    try {
+      m = bench.measure_row(p, reps, warmup);
+    } catch (const std::exception& e) {
+      flog::error("benchmark error on params: {}", e.what());
+      return std::nullopt;
+    }
+    out.push_back({p, m});
+  }
+  return out;
+}
+```
+
+Remove the now-unused `#include "ferret/jit.hpp"` from `src/run_command.cpp` if and only if no other code in the file references `JittedKernel` (search the file for `JittedKernel` first).
+
+- [ ] **Step 4: Build everything**
+
+```sh
+cmake --build build
+```
+Expected: PASS — Task 1's test now compiles (the override on `NoopBenchmark` is satisfied because `Benchmark::measure_row` exists), all 4 production benchmarks compile (each has a one-liner override), `measure_all` compiles against the new contract.
+
+- [ ] **Step 5: Run all tests**
+
+```sh
+ctest --test-dir build --output-on-failure
+```
+Expected: PASS — `SingleKernelMeasure.RunsNoopBenchmarkSuccessfully` and all 19 existing test binaries pass. Behaviour is unchanged for every existing benchmark — `measure_all` now goes through one extra virtual call per row, which delegates to the same JIT+measure path it executed before.
+
+- [ ] **Step 6: Commit**
+
+```sh
+git add include/ferret/benchmark.hpp \
+        benchmarks/branch_history_footprint.cpp \
+        benchmarks/direct_branch_footprint.cpp \
+        benchmarks/nested_call_depth.cpp \
+        benchmarks/dependent_chain_throughput.cpp \
+        tests/test_runner.cpp \
+        src/run_command.cpp
+git commit --no-gpg-sign -m "refactor(framework): route per-row measurement through Benchmark::measure_row"
+```
+
+---
+
+### Task 3: Skeleton `train_betray_latency` benchmark (registry, axes, options, stubs)
+
+Get the new benchmark wired into the build and registry. `emit_kernel` and `measure_row` throw "not implemented" — implementation lands in later tasks.
+
+**Files:**
+- Create: `benchmarks/train_betray_latency.cpp`
+- Modify: `CMakeLists.txt`
+- Create: `tests/test_train_betray_latency.cpp`
+- Modify: `tests/CMakeLists.txt`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_train_betray_latency.cpp`:
+
+```cpp
+#include <gtest/gtest.h>
+
+#include "ferret/benchmark.hpp"
+#include "ferret/params.hpp"
+#include "sljit_test_helpers.hpp"
+
+using ferret::testing::find_option;
+
+namespace {
+ferret::Params make_params(int64_t branches, int64_t train_iters = 32, int64_t spacing = 16) {
+  ferret::Params p;
+  p.set("branches", branches);
+  p.set("train_iters", train_iters);
+  p.set("spacing_bytes", spacing);
+  p.set("seed", 1);
+  return p;
+}
+}  // namespace
+
+TEST(TrainBetrayLatency, RegistryLookupReturnsBenchmark) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->name(), "train_betray_latency");
+}
+
+TEST(TrainBetrayLatency, ExposesBranchesAxis) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  auto axes = b->axes();
+  ASSERT_EQ(axes.size(), 1u);
+  EXPECT_EQ(axes[0].name(), "branches");
+}
+
+TEST(TrainBetrayLatency, BranchesAxisDefaultRangeMatchesSpec) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  auto vs = b->axes()[0].expand();
+  // 256..1024 with k=1: {256, 512, 1024} = 3 points.
+  EXPECT_EQ(vs.size(), 3u);
+  EXPECT_EQ(vs.front(), 256);
+  EXPECT_EQ(vs.back(), 1024);
+}
+
+TEST(TrainBetrayLatency, ExposesTrainItersAndSpacingBytesOptions) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  auto opts = b->options();
+  ASSERT_EQ(opts.size(), 2u);
+
+  const auto* train = find_option(opts, "train_iters");
+  ASSERT_NE(train, nullptr);
+  EXPECT_EQ(train->default_value, 32);
+
+  const auto* spacing = find_option(opts, "spacing_bytes");
+  ASSERT_NE(spacing, nullptr);
+  EXPECT_EQ(spacing->default_value, 16);
+}
+
+TEST(TrainBetrayLatency, SitesPerKernelEqualsBranches) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->sites_per_kernel(make_params(256)), 256u);
+  EXPECT_EQ(b->sites_per_kernel(make_params(1024)), 1024u);
+}
+
+TEST(TrainBetrayLatency, IterationsAmortizesAtTenMillionSites) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->iterations(make_params(256)), 10'000'000u / 256u);
+  EXPECT_EQ(b->iterations(make_params(1024)), 10'000'000u / 1024u);
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+First add the test target so it builds. Edit `tests/CMakeLists.txt`, appending:
+
+```cmake
+add_executable(test_train_betray_latency
+  test_train_betray_latency.cpp
+)
+target_sources(test_train_betray_latency PRIVATE $<TARGET_OBJECTS:ferret_benchmarks>)
+target_link_libraries(test_train_betray_latency PRIVATE
+  ferret_core
+  ferret_benchmarks
+  sljit::sljit
+  GTest::gtest GTest::gtest_main
+  ferret_warnings
+)
+gtest_discover_tests(test_train_betray_latency)
+```
+
+Then build:
+```sh
+cmake -S . -B build -GNinja
+cmake --build build
+```
+Expected: build failure because `benchmarks/train_betray_latency.cpp` does not yet exist (CMake will refuse to construct the `ferret_benchmarks` object library once we add it in the next step). Don't add it to CMakeLists yet — instead, create the source file in Step 3 then update CMakeLists in Step 4 so the build moves from "missing source" to "missing registry entry" to "passing".
+
+- [ ] **Step 3: Create the skeleton benchmark source**
+
+Create `benchmarks/train_betray_latency.cpp`:
+
+```cpp
+extern "C" {
+#include <sljitLir.h>
+}
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include "ferret/bench_helpers.hpp"
+#include "ferret/benchmark.hpp"
+#include "ferret/runner.hpp"
+
+namespace ferret {
+
+namespace {
+constexpr size_t kOpBudget = 10'000'000;
+}  // namespace
+
+struct TrainBetrayLatency : Benchmark {
+  [[nodiscard]] std::string name() const override { return "train_betray_latency"; }
+
+  [[nodiscard]] SweepAxes axes() const override {
+    return {Axis::geom_range("branches", 256, 1024, /*samples_per_octave=*/1)};
+  }
+
+  [[nodiscard]] BenchOptions options() const override {
+    return {
+        BenchOption{.name = "train_iters", .default_value = 32},
+        BenchOption{.name = "spacing_bytes", .default_value = 16},
+    };
+  }
+
+  [[nodiscard]] size_t sites_per_kernel(const Params& p) const override {
+    return p.get<size_t>("branches");
+  }
+
+  [[nodiscard]] size_t iterations(const Params& p) const override {
+    return compute_iterations(kOpBudget, p.get<size_t>("branches"));
+  }
+
+  void emit_kernel(sljit_compiler* /*c*/, const Params& /*p*/) override {
+    throw std::runtime_error("train_betray_latency::emit_kernel not yet implemented");
+  }
+
+  MeasurementRow measure_row(const Params& /*p*/, int /*reps*/, int /*warmup*/) override {
+    throw std::runtime_error("train_betray_latency::measure_row not yet implemented");
+  }
+};
+
+FERRET_BENCHMARK("train_betray_latency", TrainBetrayLatency);
+
+}  // namespace ferret
+```
+
+- [ ] **Step 4: Register the new TU in CMake**
+
+Edit `CMakeLists.txt`. Find the `ferret_benchmarks` `add_library` block and add the new source:
+
+```cmake
+add_library(ferret_benchmarks OBJECT
+  benchmarks/branch_history_footprint.cpp
+  benchmarks/direct_branch_footprint.cpp
+  benchmarks/nested_call_depth.cpp
+  benchmarks/dependent_chain_throughput.cpp
+  benchmarks/train_betray_latency.cpp
+)
+```
+
+- [ ] **Step 5: Build and run the test**
+
+```sh
+cmake --build build
+ctest --test-dir build --output-on-failure -R TrainBetrayLatency
+```
+Expected: PASS for all 6 tests in `test_train_betray_latency` (registry, axes, axis default range, options, sites_per_kernel, iterations).
+
+- [ ] **Step 6: Run the full suite to confirm no regressions**
+
+```sh
+ctest --test-dir build --output-on-failure
+```
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```sh
+git add benchmarks/train_betray_latency.cpp \
+        tests/test_train_betray_latency.cpp \
+        tests/CMakeLists.txt CMakeLists.txt
+git commit --no-gpg-sign -m "feat(train_betray_latency): scaffold benchmark with axes/options stubs"
+```
+
+---
+
+### Task 4: Pattern fill function + `FillMode` enum
+
+The fill produces `flat[(M+1) * K]` (`uint32_t` per slot). Two modes: `Betray` (M rows of 1, then row M of 0) and `Control` (all M+1 rows of 1). Pure function — no JIT, no state.
+
+**Files:**
+- Modify: `benchmarks/train_betray_latency.cpp`
+- Modify: `tests/test_train_betray_latency.cpp`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_train_betray_latency.cpp`:
+
+```cpp
+namespace ferret::train_betray_latency_internal {
+enum class FillMode { Betray, Control };
+std::vector<uint32_t> generate_pattern_fill(size_t branches, size_t train_iters, FillMode mode);
+}  // namespace ferret::train_betray_latency_internal
+
+TEST(TrainBetrayLatency, BetrayFillTrainRowsAreOnesBetrayRowIsZeros) {
+  using namespace ferret::train_betray_latency_internal;
+  const size_t K = 4;
+  const size_t M = 3;
+  auto v = generate_pattern_fill(K, M, FillMode::Betray);
+  ASSERT_EQ(v.size(), K * (M + 1));
+  for (size_t row = 0; row < M; ++row) {
+    for (size_t j = 0; j < K; ++j) {
+      EXPECT_EQ(v[row * K + j], 1u) << "training row " << row << " col " << j;
+    }
+  }
+  for (size_t j = 0; j < K; ++j) {
+    EXPECT_EQ(v[M * K + j], 0u) << "betrayal row col " << j;
+  }
+}
+
+TEST(TrainBetrayLatency, ControlFillAllRowsAreOnes) {
+  using namespace ferret::train_betray_latency_internal;
+  const size_t K = 4;
+  const size_t M = 3;
+  auto v = generate_pattern_fill(K, M, FillMode::Control);
+  ASSERT_EQ(v.size(), K * (M + 1));
+  for (uint32_t x : v) EXPECT_EQ(x, 1u);
+}
+
+TEST(TrainBetrayLatency, FillHandlesTrainItersZero) {
+  using namespace ferret::train_betray_latency_internal;
+  // M=0: Betray collapses to a single all-0 row; Control to a single all-1 row.
+  auto betray = generate_pattern_fill(4, 0, FillMode::Betray);
+  ASSERT_EQ(betray.size(), 4u);
+  for (uint32_t x : betray) EXPECT_EQ(x, 0u);
+  auto control = generate_pattern_fill(4, 0, FillMode::Control);
+  ASSERT_EQ(control.size(), 4u);
+  for (uint32_t x : control) EXPECT_EQ(x, 1u);
+}
+```
+
+Make sure `#include <vector>` is at the top of the test file (add it if missing).
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```sh
+cmake --build build
+```
+Expected: build failure — undefined reference to `generate_pattern_fill`.
+
+- [ ] **Step 3: Add `FillMode` and `generate_pattern_fill` to the benchmark TU**
+
+Edit `benchmarks/train_betray_latency.cpp`. Add `<vector>` to includes. After the anonymous-namespace `kOpBudget` definition and before the `TrainBetrayLatency` struct, add the namespace + helper:
+
+```cpp
+#include <vector>
+
+namespace ferret {
+
+namespace {
+constexpr size_t kOpBudget = 10'000'000;
+}  // namespace
+
+namespace train_betray_latency_internal {
+
+enum class FillMode { Betray, Control };
+
+std::vector<uint32_t> generate_pattern_fill(size_t branches, size_t train_iters, FillMode mode) {
+  const size_t rows = train_iters + 1;
+  std::vector<uint32_t> flat(branches * rows, mode == FillMode::Control ? 1U : 0U);
+  if (mode == FillMode::Betray) {
+    // Training rows are all 1; betrayal row (last) stays 0.
+    for (size_t row = 0; row < train_iters; ++row) {
+      for (size_t j = 0; j < branches; ++j) {
+        flat[row * branches + j] = 1U;
+      }
+    }
+  }
+  return flat;
+}
+
+}  // namespace train_betray_latency_internal
+
+struct TrainBetrayLatency : Benchmark {
+  // ... existing struct ...
+};
+```
+
+- [ ] **Step 4: Build and run the new tests**
+
+```sh
+cmake --build build
+ctest --test-dir build --output-on-failure -R TrainBetrayLatency
+```
+Expected: PASS — original 6 tests + 3 new fill tests = 9 PASS.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add benchmarks/train_betray_latency.cpp tests/test_train_betray_latency.cpp
+git commit --no-gpg-sign -m "feat(train_betray_latency): add pattern fill function"
+```
+
+---
+
+### Task 5: `emit_kernel` implementation + layout snapshot exposure
+
+Lift the chain shape from `branch_history_footprint`: K data-dependent conditional branches, branch-target = next instruction, NOP padding to enforce minimum spacing, outer loop with `hist_idx` wrapping mod `(M+1)`. Pattern buffer is the `generate_pattern_fill` output stashed on the benchmark instance; `fill_mode_` selects which mode `emit_kernel` uses. Expose a layout snapshot for tests, the same way `branch_history_footprint` does.
+
+**Files:**
+- Modify: `benchmarks/train_betray_latency.cpp`
+- Modify: `tests/test_train_betray_latency.cpp`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_train_betray_latency.cpp`:
+
+```cpp
+namespace ferret::train_betray_latency_internal {
+struct LayoutSnapshot {
+  std::vector<sljit_label*> labels;
+  size_t branches;
+  size_t spacing;
+};
+LayoutSnapshot last_layout_snapshot();
+}  // namespace ferret::train_betray_latency_internal
+
+TEST(TrainBetrayLatency, RejectsZeroBranches) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  ferret::testing::CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(0)), std::invalid_argument);
+}
+
+TEST(TrainBetrayLatency, RejectsNegativeTrainIters) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  ferret::testing::CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(4, /*train_iters=*/-1)),
+               std::invalid_argument);
+}
+
+TEST(TrainBetrayLatency, RejectsSpacingBytesTooSmall) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  ferret::testing::CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(4, /*train_iters=*/32, /*spacing=*/4)),
+               std::invalid_argument);
+}
+
+TEST(TrainBetrayLatency, EmitsValidKernelForSmallParams) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  ferret::testing::CompilerHandle ch;
+  auto p = make_params(/*branches=*/4, /*train_iters=*/8, /*spacing=*/16);
+  ASSERT_NO_THROW(b->emit_kernel(ch.c, p));
+  ASSERT_EQ(sljit_get_compiler_error(ch.c), SLJIT_SUCCESS);
+  void* code = sljit_generate_code(ch.c, 0, nullptr);
+  ASSERT_NE(code, nullptr);
+  ASSERT_NO_THROW(b->verify_layout(ch.c));
+  sljit_free_code(code, nullptr);
+}
+
+TEST(TrainBetrayLatency, LayoutSnapshotMeetsMinimumSpacing) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  ferret::testing::CompilerHandle ch;
+  b->emit_kernel(ch.c, make_params(/*branches=*/4, /*train_iters=*/4, /*spacing=*/16));
+  void* code = sljit_generate_code(ch.c, 0, nullptr);
+  ASSERT_NE(code, nullptr);
+  b->verify_layout(ch.c);
+
+  auto snap = ferret::train_betray_latency_internal::last_layout_snapshot();
+  EXPECT_EQ(snap.branches, 4u);
+  EXPECT_EQ(snap.spacing, 16u);
+  ASSERT_EQ(snap.labels.size(), 5u);  // branches + 1 chain-exit label
+  sljit_uw base = sljit_get_label_addr(snap.labels[0]);
+  for (size_t i = 1; i <= snap.branches; ++i) {
+    sljit_uw addr = sljit_get_label_addr(snap.labels[i]);
+    EXPECT_GE(addr - base, i * snap.spacing) << "site " << i;
+  }
+  sljit_free_code(code, nullptr);
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```sh
+cmake --build build
+ctest --test-dir build --output-on-failure -R "TrainBetrayLatency.(Rejects|Emits|Layout)"
+```
+Expected: FAIL on every new test — emit_kernel still throws "not yet implemented" (and `last_layout_snapshot` is undefined, so some tests fail to link).
+
+- [ ] **Step 3: Implement `emit_kernel`, `verify_layout`, and layout snapshot**
+
+Edit `benchmarks/train_betray_latency.cpp`. Replace the `TrainBetrayLatency` struct (everything from `struct TrainBetrayLatency : Benchmark { ... };` through the `FERRET_BENCHMARK(...)` macro) with the following. This is a near-clone of `branch_history_footprint.cpp` lines 39-227, adapted for the fixed-pattern fill and the `(M+1)`-row layout.
+
+```cpp
+struct TrainBetrayLatency;  // forward decl for internal namespace use
+
+namespace {
+// Minimum bytes a load + cmp-and-branch can occupy (matches
+// branch_history_footprint). 8 on AArch64, 6 on x86_64.
+#if defined(__aarch64__) || defined(_M_ARM64)
+constexpr size_t kMinSiteBytes = 8;
+#elif defined(__x86_64__) || defined(_M_X64)
+constexpr size_t kMinSiteBytes = 6;
+#else
+#error "ferret supports only x86_64 and aarch64"
+#endif
+}  // namespace
+
+namespace train_betray_latency_internal {
+
+namespace {
+const TrainBetrayLatency* g_last_emitted = nullptr;
+}  // namespace
+
+LayoutSnapshot last_layout_snapshot();  // defined after struct below
+
+}  // namespace train_betray_latency_internal
+
+struct TrainBetrayLatency : Benchmark {
+  using FillMode = train_betray_latency_internal::FillMode;
+
+  // Per-emission state, lives across emit_kernel → verify_layout for one
+  // parameter point. flat_ ownership invariant matches branch_history_-
+  // footprint: the JIT bakes flat_.data() as SLJIT_IMM, so flat_ must
+  // not be reassigned while any kernel that emitted it is still alive.
+  // measure_row enforces this by destroying each JittedKernel before
+  // building the next one.
+  std::vector<uint32_t> flat_;
+  std::vector<sljit_label*> last_labels_;
+  size_t last_branches_ = 0;
+  size_t last_spacing_ = 0;
+  FillMode fill_mode_ = FillMode::Betray;
+
+  ~TrainBetrayLatency() override {
+    if (train_betray_latency_internal::g_last_emitted == this) {
+      train_betray_latency_internal::g_last_emitted = nullptr;
+    }
+  }
+
+  [[nodiscard]] std::string name() const override { return "train_betray_latency"; }
+
+  [[nodiscard]] SweepAxes axes() const override {
+    return {Axis::geom_range("branches", 256, 1024, /*samples_per_octave=*/1)};
+  }
+
+  [[nodiscard]] BenchOptions options() const override {
+    return {
+        BenchOption{.name = "train_iters", .default_value = 32},
+        BenchOption{.name = "spacing_bytes", .default_value = 16},
+    };
+  }
+
+  [[nodiscard]] size_t sites_per_kernel(const Params& p) const override {
+    return p.get<size_t>("branches");
+  }
+
+  [[nodiscard]] size_t iterations(const Params& p) const override {
+    return compute_iterations(kOpBudget, p.get<size_t>("branches"));
+  }
+
+  void emit_kernel(sljit_compiler* c, const Params& p) override;
+  void verify_layout(sljit_compiler* c) override;
+  MeasurementRow measure_row(const Params& p, int reps, int warmup) override;
+};
+
+void TrainBetrayLatency::emit_kernel(sljit_compiler* c, const Params& p) {
+  auto branches = p.get<size_t>("branches");
+  auto train_iters_signed = p.get<int64_t>("train_iters");
+  auto spacing = p.get<size_t>("spacing_bytes");
+
+  if (branches < 1) {
+    throw std::invalid_argument("branches must be >= 1");
+  }
+  if (train_iters_signed < 0) {
+    throw std::invalid_argument("train_iters must be >= 0; got " + std::to_string(train_iters_signed));
+  }
+  const auto train_iters = static_cast<size_t>(train_iters_signed);
+  if (spacing < kMinSiteBytes) {
+    throw std::invalid_argument("spacing_bytes=" + std::to_string(spacing) +
+                                " is smaller than the minimum site encoding (" + std::to_string(kMinSiteBytes) +
+                                " bytes) on this architecture");
+  }
+#if defined(__aarch64__) || defined(_M_ARM64)
+  if (spacing % 4 != 0) {
+    throw std::invalid_argument("spacing_bytes=" + std::to_string(spacing) +
+                                " must be a multiple of 4 on this architecture");
+  }
+#endif
+
+  const size_t rows = train_iters + 1;
+  const size_t iters = iterations(p);
+
+  flat_ = train_betray_latency_internal::generate_pattern_fill(branches, train_iters, fill_mode_);
+
+  // 3 scratches + 2 saveds, same shape as branch_history_footprint.
+  // SLJIT_S0 = flat_base, SLJIT_S1 = hist_idx, SLJIT_R0 = iter counter.
+  // SLJIT_R1 = row_ptr, SLJIT_R2 = loaded value.
+  sljit_emit_enter(c, 0, SLJIT_ARGS0V(), /*scratches=*/3, /*saved=*/2, /*local_size=*/0);
+  sljit_emit_op1(c, SLJIT_MOV, SLJIT_S0, 0, SLJIT_IMM, reinterpret_cast<sljit_sw>(flat_.data()));
+  sljit_emit_op1(c, SLJIT_MOV, SLJIT_S1, 0, SLJIT_IMM, 0);
+
+  emit_outer_loop(c, SLJIT_R0, iters, [&] {
+    // row_ptr = flat_base + hist_idx * (branches * 4)
+    sljit_emit_op2(c, SLJIT_MUL, SLJIT_R1, 0, SLJIT_S1, 0, SLJIT_IMM, static_cast<sljit_sw>(branches * 4));
+    sljit_emit_op2(c, SLJIT_ADD, SLJIT_R1, 0, SLJIT_R1, 0, SLJIT_S0, 0);
+
+    last_labels_.clear();
+    last_labels_.reserve(branches + 1);
+
+    for (size_t j = 0; j < branches; ++j) {
+      last_labels_.push_back(sljit_emit_label(c));
+      sljit_emit_op1(c, SLJIT_MOV_U32, SLJIT_R2, 0, SLJIT_MEM1(SLJIT_R1), static_cast<sljit_sw>(j * 4));
+      sljit_jump* jmp = sljit_emit_cmp(c, SLJIT_NOT_EQUAL | SLJIT_32, SLJIT_R2, 0, SLJIT_IMM, 0);
+      sljit_label* after = sljit_emit_label(c);
+      sljit_set_label(jmp, after);
+      emit_nops(c, spacing - kMinSiteBytes);
+    }
+    last_labels_.push_back(sljit_emit_label(c));
+
+    // hist_idx = (hist_idx + 1 == rows) ? 0 : hist_idx + 1
+    sljit_emit_op2(c, SLJIT_ADD, SLJIT_S1, 0, SLJIT_S1, 0, SLJIT_IMM, 1);
+    sljit_emit_op2u(c, SLJIT_SUB | SLJIT_SET_Z, SLJIT_S1, 0, SLJIT_IMM, static_cast<sljit_sw>(rows));
+    sljit_jump* skip_reset = sljit_emit_jump(c, SLJIT_NOT_ZERO);
+    sljit_emit_op1(c, SLJIT_MOV, SLJIT_S1, 0, SLJIT_IMM, 0);
+    sljit_label* after_wrap = sljit_emit_label(c);
+    sljit_set_label(skip_reset, after_wrap);
+  });
+
+  sljit_emit_return_void(c);
+
+  last_branches_ = branches;
+  last_spacing_ = spacing;
+  train_betray_latency_internal::g_last_emitted = this;
+}
+
+void TrainBetrayLatency::verify_layout(sljit_compiler* /*c*/) {
+  if (last_branches_ == 0 || last_labels_.empty()) {
+    return;
+  }
+  verify_uniform_spacing(last_labels_, last_spacing_, /*strict=*/false, "train_betray_latency");
+}
+
+MeasurementRow TrainBetrayLatency::measure_row(const Params& /*p*/, int /*reps*/, int /*warmup*/) {
+  throw std::runtime_error("train_betray_latency::measure_row not yet implemented");
+}
+
+namespace train_betray_latency_internal {
+
+LayoutSnapshot last_layout_snapshot() {
+  if (g_last_emitted == nullptr) {
+    return {};
+  }
+  return {.labels = g_last_emitted->last_labels_,
+          .branches = g_last_emitted->last_branches_,
+          .spacing = g_last_emitted->last_spacing_};
+}
+
+}  // namespace train_betray_latency_internal
+
+FERRET_BENCHMARK("train_betray_latency", TrainBetrayLatency);
+
+}  // namespace ferret
+```
+
+Also add `#include "ferret/padding.hpp"` to the includes block (for `emit_nops`).
+
+- [ ] **Step 4: Build and run all tests**
+
+```sh
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+Expected: PASS — all `TrainBetrayLatency.*` tests pass (registry/axes/options/fill from before + 5 new emit/layout tests).
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add benchmarks/train_betray_latency.cpp tests/test_train_betray_latency.cpp
+git commit --no-gpg-sign -m "feat(train_betray_latency): emit kernel chain and verify layout"
+```
+
+---
+
+### Task 6: Differencing helper + unit tests
+
+Pure function that takes two `MeasurementRow`s (B and C) and produces the differenced row. Saturating subtraction handles the case where noise pushes C above B for a given rep. Carries through `iters`, `sites`, `reps`. Unit-testable without any JIT.
+
+**Files:**
+- Modify: `benchmarks/train_betray_latency.cpp`
+- Modify: `tests/test_train_betray_latency.cpp`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_train_betray_latency.cpp`:
+
+```cpp
+namespace ferret::train_betray_latency_internal {
+ferret::MeasurementRow difference(const ferret::MeasurementRow& betray,
+                                  const ferret::MeasurementRow& control,
+                                  size_t iters, size_t sites, int reps);
+}  // namespace ferret::train_betray_latency_internal
+
+TEST(TrainBetrayLatency, DifferenceReturnsBMinusCWhenBGreater) {
+  ferret::MeasurementRow B{.ticks_min = 1000, .ticks_median = 1100};
+  ferret::MeasurementRow C{.ticks_min =  300, .ticks_median =  400};
+  auto d = ferret::train_betray_latency_internal::difference(B, C, /*iters=*/2, /*sites=*/100, /*reps=*/3);
+  EXPECT_EQ(d.ticks_min, 700u);
+  EXPECT_EQ(d.ticks_median, 700u);
+  EXPECT_EQ(d.iters, 2u);
+  EXPECT_EQ(d.sites, 100u);
+  EXPECT_EQ(d.reps, 3u);
+  EXPECT_FALSE(d.jit_failed);
+}
+
+TEST(TrainBetrayLatency, DifferenceSaturatesToZeroWhenCExceedsB) {
+  ferret::MeasurementRow B{.ticks_min = 100, .ticks_median = 200};
+  ferret::MeasurementRow C{.ticks_min = 150, .ticks_median = 180};
+  auto d = ferret::train_betray_latency_internal::difference(B, C, 1, 1, 1);
+  EXPECT_EQ(d.ticks_min, 0u);     // saturated (C > B)
+  EXPECT_EQ(d.ticks_median, 20u); // not saturated
+}
+
+TEST(TrainBetrayLatency, DifferencePropagatesJitFailure) {
+  ferret::MeasurementRow B{};
+  B.jit_failed = true;
+  ferret::MeasurementRow C{.ticks_min = 100};
+  auto d = ferret::train_betray_latency_internal::difference(B, C, 1, 1, 1);
+  EXPECT_TRUE(d.jit_failed);
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```sh
+cmake --build build
+```
+Expected: build failure — undefined reference to `difference`.
+
+- [ ] **Step 3: Implement `difference`**
+
+Edit `benchmarks/train_betray_latency.cpp`. Inside `namespace train_betray_latency_internal`, after `generate_pattern_fill`, add:
+
+```cpp
+MeasurementRow difference(const MeasurementRow& betray, const MeasurementRow& control,
+                          size_t iters, size_t sites, int reps) {
+  MeasurementRow row;
+  if (betray.jit_failed || control.jit_failed) {
+    row.jit_failed = true;
+    row.iters = iters;
+    row.sites = sites;
+    row.reps = static_cast<size_t>(reps);
+    return row;
+  }
+  auto sat_sub = [](uint64_t a, uint64_t b) -> uint64_t { return a > b ? a - b : 0; };
+  row.ticks_min = sat_sub(betray.ticks_min, control.ticks_min);
+  row.ticks_median = sat_sub(betray.ticks_median, control.ticks_median);
+  row.iters = iters;
+  row.sites = sites;
+  row.reps = static_cast<size_t>(reps);
+  return row;
+}
+```
+
+- [ ] **Step 4: Build and run the tests**
+
+```sh
+cmake --build build
+ctest --test-dir build --output-on-failure -R "TrainBetrayLatency.Difference"
+```
+Expected: PASS — 3 difference tests pass.
+
+- [ ] **Step 5: Commit**
+
+```sh
+git add benchmarks/train_betray_latency.cpp tests/test_train_betray_latency.cpp
+git commit --no-gpg-sign -m "feat(train_betray_latency): add differencing helper"
+```
+
+---
+
+### Task 7: `measure_row` two-kernel differencing implementation
+
+Compose Tasks 4-6. Build kernel B (FillMode::Betray), time it; destroy it; build kernel C (FillMode::Control), time it; difference the rows. The two `JittedKernel`s must not be alive at the same time — see spec §6 lifetime constraint.
+
+**Files:**
+- Modify: `benchmarks/train_betray_latency.cpp`
+- Modify: `tests/test_train_betray_latency.cpp`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_train_betray_latency.cpp`:
+
+```cpp
+#include "ferret/jit.hpp"
+
+TEST(TrainBetrayLatency, MeasureRowReturnsNonNegativeTicksForRealRun) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  // Small K + small M to keep the test fast; we are checking the
+  // wiring, not the absolute mispredict cost.
+  auto p = make_params(/*branches=*/64, /*train_iters=*/8, /*spacing=*/16);
+  auto row = b->measure_row(p, /*reps=*/3, /*warmup=*/1);
+  EXPECT_FALSE(row.jit_failed);
+  EXPECT_EQ(row.sites, 64u);
+  EXPECT_GT(row.iters, 0u);
+  // ticks_min is unsigned so the saturating subtract guarantees >= 0;
+  // the more interesting check is that it is finite and the run
+  // completed without throwing.
+  SUCCEED();
+}
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```sh
+cmake --build build
+ctest --test-dir build --output-on-failure -R MeasureRowReturnsNonNegativeTicksForRealRun
+```
+Expected: FAIL — `measure_row` throws "not yet implemented".
+
+- [ ] **Step 3: Implement `measure_row`**
+
+Edit `benchmarks/train_betray_latency.cpp`. Add `#include "ferret/jit.hpp"` to the includes. Replace the stub body of `TrainBetrayLatency::measure_row` with the real implementation:
+
+```cpp
+MeasurementRow TrainBetrayLatency::measure_row(const Params& p, int reps, int warmup) {
+  const auto K = p.get<size_t>("branches");
+  const auto iters = iterations(p);
+  const runner::MeasureOptions opts{.iters = iters, .sites = K, .reps = reps, .warmup = warmup};
+
+  MeasurementRow B;
+  {
+    fill_mode_ = FillMode::Betray;
+    JittedKernel kB(*this, p);  // emit_kernel installs betray pattern in flat_
+    if (!kB.ok()) {
+      return train_betray_latency_internal::difference({}, {}, iters, K, reps);
+    }
+    B = runner::measure(kB.fn(), opts);
+  }  // kB destroyed before flat_ is mutated by the next emit_kernel.
+  MeasurementRow C;
+  {
+    fill_mode_ = FillMode::Control;
+    JittedKernel kC(*this, p);
+    if (!kC.ok()) {
+      return train_betray_latency_internal::difference({}, {}, iters, K, reps);
+    }
+    C = runner::measure(kC.fn(), opts);
+  }
+  return train_betray_latency_internal::difference(B, C, iters, K, reps);
+}
+```
+
+(The `difference({}, {}, ...)` call on JIT failure returns a row with `jit_failed=true` — `difference` checks `B.jit_failed || C.jit_failed`. The default-constructed `MeasurementRow` does not have `jit_failed=true` though, so we must pass a row that does. Tighten the JIT-failure path:)
+
+Replace the two `if (!kX.ok())` branches with:
+
+```cpp
+    if (!kB.ok()) {
+      MeasurementRow fail;
+      fail.jit_failed = true;
+      return train_betray_latency_internal::difference(fail, {}, iters, K, reps);
+    }
+```
+
+and the analogous version for `kC`.
+
+- [ ] **Step 4: Run the test**
+
+```sh
+cmake --build build
+ctest --test-dir build --output-on-failure -R TrainBetrayLatency
+```
+Expected: PASS — all `TrainBetrayLatency.*` tests pass.
+
+- [ ] **Step 5: Run the full suite**
+
+```sh
+ctest --test-dir build --output-on-failure
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```sh
+git add benchmarks/train_betray_latency.cpp tests/test_train_betray_latency.cpp
+git commit --no-gpg-sign -m "feat(train_betray_latency): implement two-kernel differencing in measure_row"
+```
+
+---
+
+### Task 8: Integration test — end-to-end run via `build/ferret`
+
+Smoke-test the full pipeline: CLI → sweep → measure_row → CSV. Asserts the binary exits 0 and the CSV has the expected columns/rows for a tiny sweep.
+
+**Files:**
+- Modify: `tests/test_integration.cpp`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_integration.cpp` (place after the existing `BranchHistoryFootprint*` integration tests, around line 180). Reuses the file's existing `run`, `slurp`, and `TempFileGuard` helpers — same shape as `BranchHistoryFootprintProducesExpectedRowCount`:
+
+```cpp
+TEST(Integration, TrainBetrayLatencyProducesExpectedRowCount) {
+  auto out = std::filesystem::temp_directory_path() / "ferret_misp.csv";
+  TempFileGuard guard_out{out};
+  // branches ∈ {256, 512} → 2 data rows. train_iters small so the test
+  // finishes quickly on CI; the absolute number doesn't matter for a
+  // wiring smoke test.
+  std::string cmd = std::string(FERRET_BINARY) +
+                    " run train_betray_latency"
+                    " --branches=256,512"
+                    " --train_iters=8"
+                    " --reps=3 --warmup=1"
+                    " --out=" +
+                    out.string();
+  ASSERT_EQ(0, run(cmd));
+
+  std::string contents = slurp(out.string());
+  size_t newlines = std::count(contents.begin(), contents.end(), '\n');
+  EXPECT_EQ(newlines, 3u);  // header + 2 data rows
+  EXPECT_EQ(contents.find(",,\n"), std::string::npos);
+}
+
+TEST(Integration, TrainBetrayLatencyHeaderHasExpectedColumns) {
+  auto out = std::filesystem::temp_directory_path() / "ferret_misp_hdr.csv";
+  TempFileGuard guard_out{out};
+  std::string cmd = std::string(FERRET_BINARY) +
+                    " run train_betray_latency"
+                    " --branches=256"
+                    " --train_iters=8"
+                    " --reps=2 --warmup=1"
+                    " --out=" +
+                    out.string();
+  ASSERT_EQ(0, run(cmd));
+
+  std::string contents = slurp(out.string());
+  EXPECT_NE(contents.find("branches"), std::string::npos);
+  EXPECT_NE(contents.find("train_iters"), std::string::npos);
+  EXPECT_NE(contents.find("spacing_bytes"), std::string::npos);
+  EXPECT_NE(contents.find("ns_per_site_min"), std::string::npos);
+}
+```
+
+- [ ] **Step 2: Run the new tests**
+
+```sh
+cmake --build build
+ctest --test-dir build --output-on-failure -R TrainBetrayLatency
+```
+Expected: PASS — both integration tests pass. The benchmark is fully implemented by Task 7, so end-to-end works. If either test fails, the failure points at a real wiring bug — fix the root cause (not the test).
+
+- [ ] **Step 3: Run the full suite**
+
+```sh
+ctest --test-dir build --output-on-failure
+```
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```sh
+git add tests/test_integration.cpp
+git commit --no-gpg-sign -m "test(train_betray_latency): add end-to-end integration test"
+```
+
+---
+
+### Task 9: Per-benchmark documentation page
+
+Create `docs/benchmarks/train_betray_latency.md` following the format of `docs/benchmarks/branch_history_footprint.md`.
+
+**Files:**
+- Create: `docs/benchmarks/train_betray_latency.md`
+
+- [ ] **Step 1: Reference the existing doc structure**
+
+```sh
+cat docs/benchmarks/branch_history_footprint.md | head -40
+```
+Sections (in order): one-paragraph intro, "Kernel structure" with ASCII art, "Per-benchmark options" table, "CLI surface" table, "Reading the curves", "Caveats", "Related docs".
+
+- [ ] **Step 2: Write the doc page**
+
+Create `docs/benchmarks/train_betray_latency.md`:
+
+````markdown
+# `train_betray_latency` — per-branch mispredict penalty
+
+`K` data-dependent conditional branches in a chain, branch-target =
+next instruction (so taken / not-taken converge architecturally —
+direction prediction is the sole measured variable). Per outer-loop
+iteration, the chain reads its outcomes from a per-branch row of a
+flat `uint32_t` buffer indexed by a history position that cycles
+through `M+1` rows. `M` of those rows are all-1s (training: always-
+taken, saturates the direction predictor on every PC); the last is
+all-0s (betrayal: every branch in the chain mispredicts at once).
+
+Per parameter point the benchmark emits **two** kernels — a betray
+kernel with the M-of-1s + 1-of-0s pattern, and a control kernel with
+all `M+1` rows of 1s — times each, and reports the difference as
+ticks per mispredict. With `--freq`, the CSV's `cycles_per_site` is
+*cycles per mispredict*; without it, `ns_per_site` is ns per
+mispredict.
+
+## Kernel structure
+
+```
+   PC                  site (>= spacing_bytes apart)
+ 0x0000   ┌──────────────────────────────────────┐
+          │  MOV  r2, [row_ptr + 0]              │  load 32-bit outcome
+          │  CMP  r2, 0                          │
+          │  JNE  .Lnext_0                       │ ──┐  branch-to-next
+          │ .Lnext_0:                            │ ◄─┘
+          │  <NOP pad>                           │
+          ├──────────────────────────────────────┤
+          │   ... K branches total ...           │
+          ├──────────────────────────────────────┤
+          │  ADD  hist_idx, hist_idx, 1          │
+          │  CMP  hist_idx, M+1  → wrap to 0     │
+          │  SUBS iters, iters, 1; B.NE loop_top │
+          └──────────────────────────────────────┘
+```
+
+- `row_ptr = flat_base + hist_idx * (K * 4)` recomputed once per
+  outer iter.
+- `hist_idx` wraps mod `(M+1)`; one full cycle = `M` training rounds
+  followed by `1` betrayal round.
+- The betray kernel and control kernel differ only in the *contents*
+  of `flat[]`. They are emitted as two distinct JITted functions so
+  the differencing residual (B - C) reflects the mispredict cost of
+  the K betrayed branches, with everything else (chain shape, outer-
+  loop tax, training-round cost) cancelling.
+
+## Per-benchmark options
+
+| flag                  | meaning                                                  |
+| --------------------- | -------------------------------------------------------- |
+| `--train_iters=M`     | Training rounds per (M+1)-iter cycle. Default 32.       |
+| `--spacing_bytes=N`   | Minimum per-site PC stride. Min 8 (AArch64) / 6 (x86_64). Default 16. |
+
+## CLI surface
+
+| flag                       | meaning                                                                |
+| -------------------------- | ---------------------------------------------------------------------- |
+| `--branches=A..B`          | Geometric sweep, default `k=1`, e.g. `256..1024`.                       |
+| `--branches=A..B@k`        | Geometric sweep with `k` samples per octave.                            |
+| `--branches=v1,v2,…`       | Explicit list.                                                          |
+| `--train_iters=N`          | See above. Default 32.                                                  |
+| `--spacing_bytes=N`        | See above. Default 16.                                                  |
+| `--seed=…`                 | Accepted but unused (pattern is deterministic).                         |
+
+See [`../cli.md`](../cli.md) for global flags.
+
+## Reading the curves
+
+Plot `branches` on X, `ns_per_site_min` (or `cycles_per_site_min` with
+`--freq`) on Y:
+
+```sh
+python3 scripts/plot.py line /tmp/misp.csv --out=/tmp/misp.png
+```
+
+- **Flat curve at ~12–25 cycles**: the headline per-mispredict
+  penalty for this core. Read it off any point in the flat region.
+- **Curve bends downward as K grows**: the chain outgrew what the
+  predictor confidently trained, so fewer than `K` betrayal branches
+  actually mispredicted. The reported per-mispredict cost is the
+  *average* per-betrayal-branch cost — an underestimate.
+- **Curve bends upward as K grows**: investigate. Most likely
+  candidates are iL1 / iTLB capacity effects at the larger chain
+  byte sizes.
+
+## Caveats
+
+- **Differencing-vs-noise floor.** Saturating subtract clamps `B - C`
+  to 0 when noise pushes a single rep's control above its betray. If
+  reported `ticks_min == 0` across the sweep, bump `--reps`.
+- **`M=32` is a defensible default, not a proof.** The construction
+  saturates bimodal counters in ~2-3 updates and gives TAGE many
+  rounds of confident global history. If a future core shows non-flat
+  K-sweeps, `--train_iters` can be raised as a diagnostic (though it
+  is not a documented sweep axis).
+- **No HW counter cross-check.** The "100% mispredict" claim rests on
+  train-and-betray construction; the K-sweep is the only diagnostic.
+- **Apple Silicon pinning.** Same caveat as every other ferret
+  benchmark — probe and target may land on different P-cores.
+
+## Related docs
+
+- Design spec:
+  [`../superpowers/specs/2026-05-27-mispredict-latency-design.md`](../superpowers/specs/2026-05-27-mispredict-latency-design.md).
+- Sister benchmark (capacity, not latency):
+  [`branch_history_footprint`](branch_history_footprint.md).
+- Project two-step workflow: [project README](../../README.md).
+````
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add docs/benchmarks/train_betray_latency.md
+git commit --no-gpg-sign -m "docs(train_betray_latency): add benchmark documentation page"
+```
+
+---
+
+### Task 10: README table update
+
+Add the new benchmark to the benchmarks table in `README.md`.
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add the row to the table**
+
+Edit `README.md`. Find the benchmarks table (line 78-83 in the current README) and add a new row at the end:
+
+```markdown
+| [`train_betray_latency`](docs/benchmarks/train_betray_latency.md)                 | per-branch mispredict penalty (train-and-betray)|
+```
+
+The full table after edit:
+
+```markdown
+| Name                                                                          | Targets                                         |
+| ----------------------------------------------------------------------------- | ----------------------------------------------- |
+| [`dependent_chain_throughput`](docs/benchmarks/dependent_chain_throughput.md) | running core frequency / 1-IPC baseline         |
+| [`direct_branch_footprint`](docs/benchmarks/direct_branch_footprint.md)       | direct-jump BTB capacity                        |
+| [`nested_call_depth`](docs/benchmarks/nested_call_depth.md)                   | Return Address Stack (RAS) depth                |
+| [`branch_history_footprint`](docs/benchmarks/branch_history_footprint.md)     | conditional-branch direction-predictor capacity |
+| [`train_betray_latency`](docs/benchmarks/train_betray_latency.md)                 | per-branch mispredict penalty (train-and-betray)|
+```
+
+- [ ] **Step 2: Verify the benchmark appears in `ferret list`**
+
+```sh
+build/ferret list
+```
+Expected output includes `train_betray_latency`.
+
+- [ ] **Step 3: Commit**
+
+```sh
+git add README.md
+git commit --no-gpg-sign -m "docs(readme): list train_betray_latency in benchmarks table"
+```
+
+---
+
+## Final verification
+
+After all tasks complete, run the full test + a real one-shot benchmark sweep:
+
+```sh
+cmake --build build
+ctest --test-dir build --output-on-failure
+build/ferret run train_betray_latency --branches=256..1024 --reps=5 --warmup=2 --out=/tmp/misp_final.csv
+column -ts, /tmp/misp_final.csv
+```
+
+Sanity-check the printed table: `ns_per_site_min` should be monotonically near-flat across K=256/512/1024 (not strictly monotone — noise — but order-of-magnitude flat). On a 4 GHz x86 core, expect roughly 3-6 ns per mispredict (~15-22 cycles). On Apple Silicon P-core, expect roughly 3-5 ns (~12-18 cycles).
+
+A wildly non-flat K-sweep (e.g. ten-fold drop from K=256 to K=1024) means the chain outgrew predictor confidence — the spec's expected failure mode for very large K. A constant zero across the sweep means noise dominated the differencing — bump `--reps` to 9 or 11 and rerun.

--- a/docs/superpowers/specs/2026-05-27-train-betray-latency-design.md
+++ b/docs/superpowers/specs/2026-05-27-train-betray-latency-design.md
@@ -1,0 +1,215 @@
+# `train_betray_latency` — Microbenchmark Design
+
+Date: 2026-05-27 (revised 2026-05-28 after empirical pivot)
+Status: as-shipped.
+
+## 1. Goal
+
+`train_betray_latency` is the fifth ferret microbenchmark. It measures
+the **per-branch misprediction penalty** in cycles (or nanoseconds
+when `--freq` is omitted) for the direction predictor of a single
+conditional branch.
+
+The headline number is one scalar per core. On Apple M4 P-core the
+benchmark reports ~15 cycles per mispredict with ±0.5 cycle
+run-to-run precision at default settings.
+
+Where `branch_history_footprint` measures *whether* a predictor can
+track a workload (capacity cliff), this benchmark measures *how
+expensive a single failure is* once one occurs. The two are
+complementary.
+
+## 2. Why the obvious design doesn't work
+
+The microbenchmark literature describes a "train-and-betray"
+construction: pin a branch's bimodal counter in one direction by
+running it many times with a consistent outcome, then flip the
+outcome once. The flipped branch is guaranteed to mispredict because
+the saturated counter votes the wrong way.
+
+This works on cores with bimodal-only direction prediction (pre-2010
+roughly). It **fails on modern global-history predictors** (TAGE
+variants in Apple Firestorm/M-series, recent AMD Zen, Intel Lion
+Cove). TAGE entries are indexed by `hash(PC, GHR_window)`; when the
+benchmark runs the same `(M+1) × K`-branch deterministic cycle
+repeatedly, TAGE allocates entries indexed by the cycle's GHR
+signatures and after enough warmup confidently predicts both the
+training rounds *and* the betrayal round. The "guaranteed" mispredict
+disappears.
+
+We saw this directly on Apple M4 with the v1 implementation:
+~1 cycle/mispredict measured against an expected ~13 — i.e. TAGE
+correctly predicted the betrayal almost every time.
+
+## 3. The fresh-PC differencing design
+
+The pivot that made this work: **every measurement trial uses kernels
+at distinct code addresses (fresh PCs).** TAGE entries built by
+earlier trials don't apply because the new trial's `(PC, GHR)` tuples
+don't collide with prior ones. The predictor falls back to bimodal
+for these fresh PCs, and bimodal *can* be saturated in 8 training
+rounds — short enough that TAGE within a single trial doesn't gain
+override confidence.
+
+### Per-call kernel structure
+
+Each `JittedKernel` runs **exactly one** train-and-betray cycle per
+call: `M` training rounds + 1 betrayal round, all at the same K PCs
+within that kernel.
+
+```
+outer_loop M+1 times {
+  row_ptr = flat_base + hist_idx * (K * 4)
+  for j in 0..K-1:
+    load r2, [row_ptr + 4*j]
+    cmp r2, 0
+    jne next_j          // branch-to-next
+  next_j:
+    NOP padding to spacing_bytes
+  hist_idx = (hist_idx + 1) mod (M+1)
+}
+```
+
+- B kernel: `flat[0..M-1]` = all-1s (training, outcome TAKEN),
+  `flat[M]` = all-0s (betrayal, outcome NOT-TAKEN, mispredicts).
+- C kernel: `flat[0..M]` = all-1s (training only; no betrayal).
+- Differenced: `K * (c_misp - c_baseline)` per kernel call.
+
+Running more outer cycles per call would let TAGE allocate and
+confirm entries at the same `(PC, GHR)` tuples → betrayal predicted
+correctly → signal collapses. Hence `iterations() = M + 1`.
+
+### Per-trial measurement loop
+
+```
+for t in 0..(reps + internal_warmup - 1):
+  fill_mode_ = Betray;  kernels_B[t] = build()
+  fill_mode_ = Control; kernels_C[t] = build()
+# Hold all 2*total_trials kernels alive — see §4.
+for t in 0..(reps + internal_warmup - 1):
+  b_ticks = time(kernels_B[t]())
+  c_ticks = time(kernels_C[t]())
+  samples[t] = sat_sub(b_ticks, c_ticks)
+discard first `internal_warmup` samples
+drop zero samples
+return inter_quartile_mean(samples)
+```
+
+The reported `ticks_median` is the IQM of the surviving samples.
+Per-sample SNR scales as `K × c_misp` (signal) vs OS interrupt
+inflation (~10 µs noise floor). The benchmark's default `K=65536`
+puts per-trial signal at ~200 µs — well above the noise floor.
+
+## 4. The sljit allocator trick
+
+The "fresh PCs per trial" requirement collides with sljit's
+executable allocator (`sljit_src/allocator_src/sljitExecAllocatorCore.c`):
+
+- `sljit_malloc_exec(size)` searches a per-process free-block list
+  before mmap'ing a new 64 KiB chunk. A `build/free/build` cycle on
+  same-sized kernels returns the **same VA**.
+- Even calling `sljit_free_unused_memory_exec()` doesn't help, since
+  the OS hands back the same VA on `munmap`/`mmap` of equal-sized
+  regions (verified empirically on macOS arm64).
+
+The fix is non-invasive of sljit: **don't free until measurement
+ends.** With all `total_trials` × 2 kernels alive in
+`std::vector<JittedKernel>`, sljit must walk forward through its
+chunk pool — each new emit lands at a fresh offset (~64-byte stride
+within a chunk; full-chunk stride when chunks fill). Distinct enough
+PCs that bimodal-table collisions are statistical, not deterministic.
+
+## 5. Pattern-buffer ownership invariant
+
+The JIT bakes `flat_.data()` as `SLJIT_IMM`. The v1 design
+reassigned `flat_` inside every `emit_kernel` call, which freed the
+buffer the previous kernel's code pointed at. The fix: keep two
+member-field buffers, `flat_betray_` and `flat_control_`, populated
+once per `measure_row` call. `emit_kernel` picks one based on
+`fill_mode_` and bakes that address. The buffers outlive every
+kernel built in one `measure_row` invocation.
+
+## 6. Parameters
+
+| flag                       | default       | role                                                                 |
+| -------------------------- | ------------- | -------------------------------------------------------------------- |
+| `--branches=K` (sweep)     | `16384..65536 @1` | mispredicts per kernel call. Large K is mandatory for SNR.       |
+| `--train_iters=M`          | `8`           | training rounds before the betrayal. Bimodal saturates by M=8.       |
+| `--spacing_bytes=N`        | `16`          | minimum per-site PC stride. Same role as in `branch_history_footprint`. |
+| `--reps=N`                 | `7` (framework) | trials contributing to the IQM. Practical: 21..99. Memory scales with reps × K. |
+
+Internal mechanism (not exposed via CLI):
+- `internal_warmup = max(--warmup, 3)`. First 3 trials are discarded.
+- Zero samples (B<C) are dropped before aggregation.
+- Empty-after-filter rows return `reps=0`, `ticks=0`, with a `warn` log.
+
+## 7. Framework refactor
+
+To support a measurement that doesn't fit the single-JIT-kernel
+mould, the spec adds one virtual to `Benchmark`:
+
+```cpp
+virtual MeasurementRow measure_row(const Params& p, int reps, int warmup) = 0;
+```
+
+`run_command::measure_all` calls `bench.measure_row(p, reps, warmup)`
+per row instead of building a `JittedKernel` + calling `runner::measure`
+directly. The previous code path is preserved as a one-line helper
+`runner::single_kernel_measure(b, p, reps, warmup)`; the four
+existing benchmarks delegate to it.
+
+This split lets a benchmark with a richer measurement strategy
+(differencing, multi-rep aggregation, etc.) own its measurement
+without leaking into the framework.
+
+## 8. Reading the K-sweep
+
+The default 3-point sweep `K ∈ {16K, 32K, 64K}` is enough to verify
+the headline is stable across K. A wider sweep
+`--branches=4096..131072` exposes two uarch features:
+
+1. **Convergence**: per-mispredict cost drops from ~25 cycles
+   (K=4K, overhead-inflated) to ~15 cycles (K=64K, overhead
+   negligible).
+2. **Cliff** at K ≈ 2× bimodal-table-size: apparent cost halves
+   because shared bimodal entries flip after the first 2 betrayals.
+   On M4 the cliff at K=131072 implies a bimodal table of ~32K
+   entries.
+
+A linear-regression fit of `ticks_median` vs `K` across the linear
+region gives `c_misp − c_baseline` directly (~12.5 cycles on M4),
+overhead cancelled in the intercept.
+
+## 9. Validation
+
+- **K=1 emission**: smoke test — kernel builds and verifies at the
+  smallest possible chain.
+- **Layout snapshot**: same `verify_uniform_spacing` machinery as
+  `branch_history_footprint`.
+- **Sites-per-kernel = K**: the CSV's per-site normalization gives
+  ns/cycles per *mispredict* (one betrayal round per kernel = K
+  mispredicts per kernel call).
+- **Repeatability**: 10× back-to-back invocations at default
+  settings on Apple M4 P-core gave 14.4–15.2 cycles (spread 0.8).
+
+## 10. Out of scope
+
+- **PMU integration**. `perf_event_open` (Linux) and `kperf` (macOS,
+  root) would let us count mispredicts directly and dispense with the
+  K-divided-by-assumption derivation. Defer to a future benchmark
+  that needs ground-truth mispredict counts.
+- **Long-latency-load amplification** (Wong, stuffedcow.net) — would
+  widen the mispredict resolution window but doesn't help once the
+  predictor learns the cycle. Not needed given fresh-PC design works.
+- **`train_iters` as a sweep axis**. Fixed at default; M=8 saturates
+  bimodal on all documented predictors.
+
+## 11. Related docs
+
+- Sister benchmark (capacity): [`branch_history_footprint`
+  spec](2026-05-17-branch-history-footprint-design.md) /
+  [doc](../../benchmarks/branch_history_footprint.md).
+- Per-benchmark page: [`train_betray_latency`
+  doc](../../benchmarks/train_betray_latency.md).
+- Original v1 plan (historical, not as-shipped):
+  [implementation plan](../plans/2026-05-27-train-betray-latency.md).

--- a/include/ferret/benchmark.hpp
+++ b/include/ferret/benchmark.hpp
@@ -8,6 +8,7 @@
 
 #include "ferret/axis.hpp"
 #include "ferret/params.hpp"
+#include "ferret/runner.hpp"
 
 // Forward-declare sljit_compiler so headers don't pull in sljitLir.h
 // transitively. Implementations include sljitLir.h directly.
@@ -67,6 +68,13 @@ class Benchmark {
   // resolve hand-emitted jump displacements. Throw on mismatch; the
   // runner emits the row as a JIT failure.
   virtual void verify_layout(sljit_compiler* c) { (void)c; }
+
+  // Per-row measurement strategy. Most benchmarks build one JIT'd
+  // kernel and time it; they implement this as a one-liner that calls
+  // runner::single_kernel_measure(*this, p, reps, warmup). Benchmarks
+  // that need a richer strategy (e.g. train_betray_latency, which times
+  // two kernels and reports the difference) override directly.
+  virtual MeasurementRow measure_row(const Params& p, int reps, int warmup) = 0;
 };
 
 // Static singleton registry. Benchmark subclasses normally register

--- a/include/ferret/runner.hpp
+++ b/include/ferret/runner.hpp
@@ -4,6 +4,11 @@
 #include <cstdint>
 
 namespace ferret {
+class Benchmark;
+class Params;
+}  // namespace ferret
+
+namespace ferret {
 
 struct MeasurementRow {
   uint64_t ticks_min = 0;
@@ -31,6 +36,17 @@ struct MeasureOptions {
 // through to MeasurementRow purely for normalization downstream — they
 // are not used by measure() to drive iteration count.
 MeasurementRow measure(KernelFn fn, const MeasureOptions& opts);
+
+// Builds a JittedKernel for `b` at `p`, runs runner::measure on it, and
+// fills the resulting MeasurementRow with iters / sites taken from the
+// benchmark. The default measure_row strategy for benchmarks that time
+// a single JIT'd kernel — differencing benchmarks override measure_row
+// directly and don't use this helper.
+//
+// On JIT failure, returns a row with .jit_failed = true and
+// .iters/.sites pre-populated. Propagates std::exception from
+// emit_kernel/verify_layout to the caller.
+MeasurementRow single_kernel_measure(Benchmark& b, const Params& p, int reps, int warmup);
 
 }  // namespace runner
 }  // namespace ferret

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -183,3 +183,4 @@ esac
 run_benchmark "direct_branch_footprint" "line" "" "$FREQ" "--branches=16..32768@2 --spacing_bytes=${DIRECT_BRANCH_SPACING_LO}..128"
 run_benchmark "nested_call_depth" "line" "" "$FREQ"
 run_benchmark "branch_history_footprint" "surface" "" "$FREQ" "--branches=16..1024@2 --history_len=1..1024@2"
+run_benchmark "train_betray_latency" "line" "" "$FREQ"

--- a/src/run_command.cpp
+++ b/src/run_command.cpp
@@ -14,7 +14,6 @@
 #include "ferret/benchmark.hpp"
 #include "ferret/cli_axis.hpp"
 #include "ferret/csv.hpp"
-#include "ferret/jit.hpp"
 #include "ferret/log.hpp"
 #include "ferret/params.hpp"
 #include "ferret/pinning.hpp"
@@ -139,16 +138,7 @@ std::optional<std::vector<MeasuredRow>> measure_all(Benchmark& bench, const std:
       return std::nullopt;
     }
     try {
-      JittedKernel kern(bench, p);
-      if (!kern.ok()) {
-        m.jit_failed = true;
-        m.iters = pre_iters;
-        m.sites = pre_sites;
-        flog::warn("sljit_error on params; emitting empty row");
-      } else {
-        flog::info("jit kernel: {} bytes", kern.code_size());
-        m = runner::measure(kern.fn(), {.iters = pre_iters, .sites = pre_sites, .reps = reps, .warmup = warmup});
-      }
+      m = bench.measure_row(p, reps, warmup);
     } catch (const std::invalid_argument& e) {
       flog::error("benchmark error on params: {}", e.what());
       return std::nullopt;

--- a/src/runner.cpp
+++ b/src/runner.cpp
@@ -1,10 +1,16 @@
 #include "ferret/runner.hpp"
 
+#include "ferret/benchmark.hpp"
+#include "ferret/jit.hpp"
+#include "ferret/log.hpp"
+#include "ferret/params.hpp"
 #include "ferret/timing.hpp"
 
 #include <algorithm>
 #include <stdexcept>
 #include <vector>
+
+namespace flog = ferret::log;
 
 namespace ferret::runner {
 
@@ -37,6 +43,25 @@ MeasurementRow measure(KernelFn fn, const MeasureOptions& opts) {
   row.ticks_min = samples.front();
   row.ticks_median = samples[samples.size() / 2];
   return row;
+}
+
+MeasurementRow single_kernel_measure(Benchmark& b, const Params& p, int reps, int warmup) {
+  size_t pre_iters = b.iterations(p);
+  size_t pre_sites = b.sites_per_kernel(p);
+  if (pre_iters == 0 || pre_sites == 0) {
+    throw std::invalid_argument("single_kernel_measure: iterations and sites_per_kernel must be > 0");
+  }
+  JittedKernel kern(b, p);
+  if (!kern.ok()) {
+    MeasurementRow row;
+    row.jit_failed = true;
+    row.iters = pre_iters;
+    row.sites = pre_sites;
+    flog::warn("jit failure in {}; emitting empty row", b.name());
+    return row;
+  }
+  flog::info("jit kernel: {} bytes", kern.code_size());
+  return measure(kern.fn(), {.iters = pre_iters, .sites = pre_sites, .reps = reps, .warmup = warmup});
 }
 
 }  // namespace ferret::runner

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,14 @@ add_executable(test_run_options test_run_options.cpp)
 target_link_libraries(test_run_options PRIVATE ferret_core GTest::gtest GTest::gtest_main ferret_warnings)
 gtest_discover_tests(test_run_options)
 
+add_executable(test_train_betray_latency test_train_betray_latency.cpp)
+target_sources(test_train_betray_latency PRIVATE $<TARGET_OBJECTS:ferret_benchmarks>)
+target_link_libraries(
+  test_train_betray_latency PRIVATE ferret_core ferret_benchmarks sljit::sljit GTest::gtest GTest::gtest_main
+                                    ferret_warnings
+)
+gtest_discover_tests(test_train_betray_latency)
+
 add_executable(test_integration test_integration.cpp)
 target_compile_definitions(test_integration PRIVATE FERRET_BINARY="$<TARGET_FILE:ferret>")
 add_dependencies(test_integration ferret)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(test_csv PRIVATE ferret_core GTest::gtest GTest::gtest_mai
 gtest_discover_tests(test_csv)
 
 add_executable(test_runner test_runner.cpp)
-target_link_libraries(test_runner PRIVATE ferret_core GTest::gtest GTest::gtest_main ferret_warnings)
+target_link_libraries(test_runner PRIVATE ferret_core sljit::sljit GTest::gtest GTest::gtest_main ferret_warnings)
 gtest_discover_tests(test_runner)
 
 add_executable(test_padding test_padding.cpp)

--- a/tests/test_benchmark_registry.cpp
+++ b/tests/test_benchmark_registry.cpp
@@ -13,6 +13,9 @@ struct DummyBench : Benchmark {
   size_t sites_per_kernel(const Params& p) const override { return p.get<size_t>("x"); }
   size_t iterations(const Params&) const override { return 1; }
   void emit_kernel(sljit_compiler*, const Params&) override {}
+  MeasurementRow measure_row(const Params& p, int reps, int warmup) override {
+    return runner::single_kernel_measure(*this, p, reps, warmup);
+  }
 };
 FERRET_BENCHMARK("dummy_for_test", DummyBench);
 }  // namespace

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -666,3 +666,43 @@ TEST(Integration, NestedCallDepthLongSweepRowCount) {
   EXPECT_EQ(newlines, 65u) << "expected 1 header + 64 data rows";
   EXPECT_EQ(contents.find(",,"), std::string::npos);
 }
+
+TEST(Integration, TrainBetrayLatencyProducesExpectedRowCount) {
+  auto out = std::filesystem::temp_directory_path() / "ferret_misp.csv";
+  TempFileGuard guard_out{out};
+  // branches ∈ {256, 512} → 2 data rows. train_iters small so the test
+  // finishes quickly on CI; the absolute number doesn't matter for a
+  // wiring smoke test.
+  std::string cmd = std::string(FERRET_BINARY) +
+                    " run train_betray_latency"
+                    " --branches=256,512"
+                    " --train_iters=8"
+                    " --reps=3 --warmup=1"
+                    " --out=" +
+                    out.string();
+  ASSERT_EQ(0, run(cmd));
+
+  std::string contents = slurp(out.string());
+  size_t newlines = std::count(contents.begin(), contents.end(), '\n');
+  EXPECT_EQ(newlines, 3u);  // header + 2 data rows
+  EXPECT_EQ(contents.find(",,\n"), std::string::npos);
+}
+
+TEST(Integration, TrainBetrayLatencyHeaderHasExpectedColumns) {
+  auto out = std::filesystem::temp_directory_path() / "ferret_misp_hdr.csv";
+  TempFileGuard guard_out{out};
+  std::string cmd = std::string(FERRET_BINARY) +
+                    " run train_betray_latency"
+                    " --branches=256"
+                    " --train_iters=8"
+                    " --reps=2 --warmup=1"
+                    " --out=" +
+                    out.string();
+  ASSERT_EQ(0, run(cmd));
+
+  std::string contents = slurp(out.string());
+  EXPECT_NE(contents.find("branches"), std::string::npos);
+  EXPECT_NE(contents.find("train_iters"), std::string::npos);
+  EXPECT_NE(contents.find("spacing_bytes"), std::string::npos);
+  EXPECT_NE(contents.find("ns_per_site_min"), std::string::npos);
+}

--- a/tests/test_jit.cpp
+++ b/tests/test_jit.cpp
@@ -22,6 +22,9 @@ struct EmptyBench : Benchmark {
     sljit_emit_enter(c, 0, SLJIT_ARGS0V(), 0, 0, 0);
     sljit_emit_return_void(c);
   }
+  MeasurementRow measure_row(const Params& p, int reps, int warmup) override {
+    return runner::single_kernel_measure(*this, p, reps, warmup);
+  }
 };
 
 }  // namespace

--- a/tests/test_runner.cpp
+++ b/tests/test_runner.cpp
@@ -3,7 +3,14 @@
 #include <chrono>
 #include <thread>
 
+#include "ferret/benchmark.hpp"
+#include "ferret/jit.hpp"
+#include "ferret/params.hpp"
 #include "ferret/runner.hpp"
+
+extern "C" {
+#include <sljitLir.h>
+}
 
 using namespace ferret;
 
@@ -43,4 +50,31 @@ TEST(Runner, RejectsNonPositiveK) {
 
 TEST(Runner, RejectsNegativeWarmup) {
   EXPECT_THROW(runner::measure(noop_kernel, {.iters = 1, .sites = 1, .reps = 3, .warmup = -1}), std::invalid_argument);
+}
+
+namespace {
+struct NoopBenchmark : public ferret::Benchmark {
+  std::string name() const override { return "noop"; }
+  ferret::SweepAxes axes() const override { return {}; }
+  size_t sites_per_kernel(const ferret::Params&) const override { return 1; }
+  size_t iterations(const ferret::Params&) const override { return 1; }
+  void emit_kernel(sljit_compiler* c, const ferret::Params&) override {
+    sljit_emit_enter(c, 0, SLJIT_ARGS0V(), 1, 0, 0);
+    sljit_emit_return_void(c);
+  }
+  ferret::MeasurementRow measure_row(const ferret::Params& p, int reps, int warmup) override {
+    return ferret::runner::single_kernel_measure(*this, p, reps, warmup);
+  }
+};
+}  // namespace
+
+TEST(SingleKernelMeasure, RunsNoopBenchmarkSuccessfully) {
+  NoopBenchmark b;
+  ferret::Params p;
+  auto row = ferret::runner::single_kernel_measure(b, p, /*reps=*/3, /*warmup=*/1);
+  EXPECT_FALSE(row.jit_failed);
+  EXPECT_EQ(row.sites, 1u);
+  EXPECT_EQ(row.iters, 1u);
+  EXPECT_EQ(row.reps, 3u);
+  EXPECT_GE(row.ticks_median, row.ticks_min);
 }

--- a/tests/test_train_betray_latency.cpp
+++ b/tests/test_train_betray_latency.cpp
@@ -1,0 +1,220 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "ferret/benchmark.hpp"
+#include "ferret/params.hpp"
+#include "sljit_test_helpers.hpp"
+
+using ferret::testing::find_option;
+
+namespace {
+ferret::Params make_params(int64_t branches, int64_t train_iters = 8, int64_t spacing = 16) {
+  ferret::Params p;
+  p.set("branches", branches);
+  p.set("train_iters", train_iters);
+  p.set("spacing_bytes", spacing);
+  p.set("seed", 1);
+  return p;
+}
+}  // namespace
+
+TEST(TrainBetrayLatency, RegistryLookupReturnsBenchmark) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->name(), "train_betray_latency");
+}
+
+TEST(TrainBetrayLatency, ExposesBranchesAxis) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  auto axes = b->axes();
+  ASSERT_EQ(axes.size(), 1u);
+  EXPECT_EQ(axes[0].name(), "branches");
+}
+
+TEST(TrainBetrayLatency, BranchesAxisDefaultRangeMatchesSpec) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  auto vs = b->axes()[0].expand();
+  // 16384..65536 with k=1: {16384, 32768, 65536} = 3 points.
+  EXPECT_EQ(vs.size(), 3u);
+  EXPECT_EQ(vs.front(), 16384);
+  EXPECT_EQ(vs.back(), 65536);
+}
+
+TEST(TrainBetrayLatency, ExposesTrainItersAndSpacingBytesOptions) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  auto opts = b->options();
+  ASSERT_EQ(opts.size(), 2u);
+
+  const auto* train = find_option(opts, "train_iters");
+  ASSERT_NE(train, nullptr);
+  EXPECT_EQ(train->default_value, 8);
+
+  const auto* spacing = find_option(opts, "spacing_bytes");
+  ASSERT_NE(spacing, nullptr);
+  EXPECT_EQ(spacing->default_value, 16);
+}
+
+TEST(TrainBetrayLatency, SitesPerKernelEqualsBranches) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->sites_per_kernel(make_params(256)), 256u);
+  EXPECT_EQ(b->sites_per_kernel(make_params(1024)), 1024u);
+}
+
+TEST(TrainBetrayLatency, IterationsEqualsTrainItersPlusOne) {
+  // One kernel call runs exactly one train-and-betray cycle:
+  // train_iters training rounds + 1 betrayal round. Anything more would
+  // give TAGE the chance to learn the period.
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->iterations(make_params(256, /*train_iters=*/2)), 3u);
+  EXPECT_EQ(b->iterations(make_params(1024, /*train_iters=*/8)), 9u);
+}
+
+namespace ferret::train_betray_latency_internal {
+enum class FillMode : std::uint8_t { Betray, Control };
+// NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+std::vector<uint32_t> generate_pattern_fill(size_t branches, size_t train_iters, FillMode mode);
+}  // namespace ferret::train_betray_latency_internal
+
+// If FillMode in benchmarks/train_betray_latency.cpp gains or reorders
+// values, this static_assert catches the shadow-declaration drift.
+static_assert(static_cast<int>(ferret::train_betray_latency_internal::FillMode::Betray) == 0);
+static_assert(static_cast<int>(ferret::train_betray_latency_internal::FillMode::Control) == 1);
+
+TEST(TrainBetrayLatency, BetrayFillTrainRowsAreOnesBetrayRowIsZeros) {
+  using namespace ferret::train_betray_latency_internal;
+  const size_t K = 4;
+  const size_t M = 3;
+  auto v = generate_pattern_fill(K, M, FillMode::Betray);
+  ASSERT_EQ(v.size(), K * (M + 1));
+  for (size_t row = 0; row < M; ++row) {
+    for (size_t j = 0; j < K; ++j) {
+      EXPECT_EQ(v[row * K + j], 1u) << "training row " << row << " col " << j;
+    }
+  }
+  for (size_t j = 0; j < K; ++j) {
+    EXPECT_EQ(v[M * K + j], 0u) << "betrayal row col " << j;
+  }
+}
+
+TEST(TrainBetrayLatency, ControlFillAllRowsAreOnes) {
+  using namespace ferret::train_betray_latency_internal;
+  const size_t K = 4;
+  const size_t M = 3;
+  auto v = generate_pattern_fill(K, M, FillMode::Control);
+  ASSERT_EQ(v.size(), K * (M + 1));
+  for (uint32_t x : v) EXPECT_EQ(x, 1u);
+}
+
+TEST(TrainBetrayLatency, FillHandlesTrainItersZero) {
+  using namespace ferret::train_betray_latency_internal;
+  // M=0: Betray collapses to a single all-0 row; Control to a single all-1 row.
+  auto betray = generate_pattern_fill(4, 0, FillMode::Betray);
+  ASSERT_EQ(betray.size(), 4u);
+  for (uint32_t x : betray) EXPECT_EQ(x, 0u);
+  auto control = generate_pattern_fill(4, 0, FillMode::Control);
+  ASSERT_EQ(control.size(), 4u);
+  for (uint32_t x : control) EXPECT_EQ(x, 1u);
+}
+
+namespace ferret::train_betray_latency_internal {
+struct LayoutSnapshot {
+  std::vector<sljit_label*> labels;
+  size_t branches;
+  size_t spacing;
+};
+LayoutSnapshot last_layout_snapshot();
+}  // namespace ferret::train_betray_latency_internal
+
+TEST(TrainBetrayLatency, RejectsZeroBranches) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  ferret::testing::CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(0)), std::invalid_argument);
+}
+
+TEST(TrainBetrayLatency, RejectsNegativeTrainIters) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  ferret::testing::CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(4, /*train_iters=*/-1)), std::invalid_argument);
+}
+
+TEST(TrainBetrayLatency, RejectsSpacingBytesTooSmall) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  ferret::testing::CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(4, /*train_iters=*/32, /*spacing=*/4)), std::invalid_argument);
+}
+
+TEST(TrainBetrayLatency, EmitsValidKernelForSmallParams) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  ferret::testing::CompilerHandle ch;
+  auto p = make_params(/*branches=*/4, /*train_iters=*/8, /*spacing=*/16);
+  ASSERT_NO_THROW(b->emit_kernel(ch.c, p));
+  ASSERT_EQ(sljit_get_compiler_error(ch.c), SLJIT_SUCCESS);
+  void* code = sljit_generate_code(ch.c, 0, nullptr);
+  ASSERT_NE(code, nullptr);
+  ASSERT_NO_THROW(b->verify_layout(ch.c));
+  sljit_free_code(code, nullptr);
+}
+
+TEST(TrainBetrayLatency, EmitsValidKernelForBranchesEqualsOne) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  ferret::testing::CompilerHandle ch;
+  auto p = make_params(/*branches=*/1, /*train_iters=*/8, /*spacing=*/16);
+  ASSERT_NO_THROW(b->emit_kernel(ch.c, p));
+  ASSERT_EQ(sljit_get_compiler_error(ch.c), SLJIT_SUCCESS);
+  void* code = sljit_generate_code(ch.c, 0, nullptr);
+  ASSERT_NE(code, nullptr);
+  ASSERT_NO_THROW(b->verify_layout(ch.c));
+  sljit_free_code(code, nullptr);
+}
+
+TEST(TrainBetrayLatency, LayoutSnapshotMeetsMinimumSpacing) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  ferret::testing::CompilerHandle ch;
+  b->emit_kernel(ch.c, make_params(/*branches=*/4, /*train_iters=*/4, /*spacing=*/16));
+  void* code = sljit_generate_code(ch.c, 0, nullptr);
+  ASSERT_NE(code, nullptr);
+  b->verify_layout(ch.c);
+
+  auto snap = ferret::train_betray_latency_internal::last_layout_snapshot();
+  EXPECT_EQ(snap.branches, 4u);
+  EXPECT_EQ(snap.spacing, 16u);
+  ASSERT_EQ(snap.labels.size(), 5u);  // branches + 1 chain-exit label
+  sljit_uw base = sljit_get_label_addr(snap.labels[0]);
+  for (size_t i = 1; i <= snap.branches; ++i) {
+    sljit_uw addr = sljit_get_label_addr(snap.labels[i]);
+    EXPECT_GE(addr - base, i * snap.spacing) << "site " << i;
+  }
+  sljit_free_code(code, nullptr);
+}
+
+#include "ferret/jit.hpp"
+
+TEST(TrainBetrayLatency, MeasureRowReturnsRowShapedForCsvDivision) {
+  auto b = ferret::BenchmarkRegistry::create("train_betray_latency");
+  ASSERT_NE(b, nullptr);
+  // Small K + default train_iters keeps the test fast; we are checking
+  // the wiring (per-trial fresh-emit + differencing returns a sensible
+  // row), not the absolute mispredict cost.
+  auto p = make_params(/*branches=*/64, /*train_iters=*/2, /*spacing=*/16);
+  auto row = b->measure_row(p, /*reps=*/3, /*warmup=*/0);
+  EXPECT_FALSE(row.jit_failed);
+  EXPECT_EQ(row.sites, 64u);
+  EXPECT_EQ(row.iters, 1u);  // CSV divides by iters*sites; iters=1 makes sites=K = "mispredict count"
+  // row.reps reports contributing samples (post-warmup, post-zero-filter), which
+  // can be < the user-supplied reps when noisy trials clamp. Bound it loosely.
+  EXPECT_LE(row.reps, 3u);
+  EXPECT_GE(row.ticks_median, row.ticks_min);
+}


### PR DESCRIPTION
## Summary

Adds `mispredict_latency`, ferret's fifth microbenchmark. Measures the per-branch direction-mispredict penalty in cycles. On Apple M4 P-core: **~15 cycles/mispredict, ±0.5 cycle reproducibility** at default settings (`K=65536`, `--reps=99`).

Also includes a small framework refactor (`Benchmark::measure_row` virtual + `runner::single_kernel_measure` helper) so the new benchmark can implement its own multi-kernel measurement strategy without leaking into the framework.

### Why this design (the story behind 19 commits)

Classical train-and-betray fails on TAGE-style predictors. After a few warmups TAGE memorises the deterministic `(M+1)*K`-branch cycle and starts predicting the betrayal round correctly — measured ~1 cycle/site on M4 instead of the expected ~13. The pivot: **fresh PCs per trial**. New code addresses each measurement → TAGE entries from prior trials don't apply → predictor falls back to bimodal, which we saturate in 8 training rounds.

Two non-invasive sljit tricks make this work without touching sljit itself:
- **Hold every trial's JittedKernel alive** across the measurement loop. sljit's allocator (`sljitExecAllocatorCore.c`) reuses freed blocks within 64 KiB chunks — `build/free/build` returns the same VA. Keep-alive forces sljit forward through its chunk pool, giving each trial a distinct PC.
- **Pre-build both fill buffers** (`flat_betray_`, `flat_control_`) once per `measure_row`. The earlier `emit_kernel`-reallocates-`flat_` design had a dangling-pointer race with kernels' baked `SLJIT_IMM` pointers.

### Bonus uarch feature

A wider K-sweep (`--branches=4096..131072`) also exposes a **bimodal-capacity cliff** at K=131072 where the apparent cost halves — this isn't faster mispredicts, it's lower *rate* (shared bimodal entries flip after the first 2 betrayals). Implies M4's bimodal table is ~32K entries. Two uarch features in one plot.

### Stabilizers (final commit)

Three small aggregation tweaks tighten run-to-run variance from ~1.2 cycles → ~0.7 cycles at `--reps=99`:
- Internal 3-trial warmup (smooths first-kernel cold-cache jitter).
- Inter-quartile mean (robust to both OS-interrupt outliers and zero-clamped samples).
- Zero-filter (drop trials where `B<C` clamped to zero; treat as noise, not signal).

## Test plan

- [x] `ctest --test-dir build --output-on-failure` — 217/217 pass (3 platform-skipped).
- [x] Smoke test on Apple M4: `build/ferret run mispredict_latency --reps=99 --freq=4.484GHz` reproducibly returns ~15 cycles.
- [x] Wider sweep `--branches=4096..131072` exposes the bimodal-capacity cliff at K=131072.
- [x] Per-task code review by Senior Reviewer subagent + final pass — all important issues addressed.
- [ ] Verify on Linux x86_64 (Zen / Intel) — expected ~15-20 cycles based on published pipeline depths.
- [ ] Verify on Android AArch64 — memory cost (~500 MB at defaults) may need lower default `--reps` on low-end devices.

## Notes for reviewers

- The original spec/plan (commits `60c5dcd`, `0c1255c`) describe the v1 train-and-betray design that empirically failed. The shipped design is the pivot in `fe0306c`. The spec at `docs/superpowers/specs/2026-05-27-mispredict-latency-design.md` was rewritten in `5c3523e` to match what shipped.
- The per-benchmark doc page (`docs/benchmarks/mispredict_latency.md`) covers the methodology rationale, K-sweep reading guide, and the bimodal-cliff interpretation.
- `compute_iterations` is now unused by this benchmark but is still used by the other four — left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)