### PR TITLE
fix(plot): classify seed as metadata, not a plot axis

### DIFF
--- a/scripts/ferret_plot/columns.py
+++ b/scripts/ferret_plot/columns.py
@@ -1,7 +1,7 @@
 """Column classification and metric resolution.
 
 A ferret CSV has three classes of columns:
-- Metadata: emitted by every benchmark (benchmark name, timing,
+- Metadata: emitted by every benchmark (benchmark name, seed, timing,
   iters, sites_per_iter, reps, ns/cycles columns, freq_hz).
 - Axes: per-benchmark sweep parameters (e.g. branches, spacing_bytes).
 - (Future) Options: per-benchmark scalar options. Today these appear
@@ -25,6 +25,7 @@ _UNKNOWN_BENCH = "ferret"
 METADATA_COLS: frozenset[str] = frozenset(
     {
         "benchmark",
+        "seed",
         "ticks_min",
         "ticks_median",
         "iters",

--- a/tests/python/test_columns.py
+++ b/tests/python/test_columns.py
@@ -103,6 +103,20 @@ class TestAxisColumns:
         assert cols.varying_axis_columns(df) == ["branches", "spacing_bytes"]
 
 
+class TestSeedColumn:
+    def test_seed_is_metadata(self):
+        # seed is run-level provenance, always emitted by the C++ binary.
+        # It must be metadata so the plotter never treats it as an axis.
+        assert "seed" in cols.METADATA_COLS
+
+    def test_seed_not_classified_as_axis(self):
+        # A frame carrying a seed column must not surface seed as an axis,
+        # which would make concatenated multi-seed CSVs grow a phantom axis.
+        df = dbf_df().assign(seed=1)
+        assert "seed" not in cols.axis_columns(df)
+        assert cols.axis_columns(df) == ["branches", "spacing_bytes"]
+
+
 class TestPlotError:
     def test_is_an_exception(self):
         assert issubclass(PlotError, Exception)


### PR DESCRIPTION
**Phase 1 refactor — Task 1 of 5 (stacked PRs).** Base: `main`.

The C++ binary always emits a `seed` column (run-level provenance), but `ferret_plot`'s `METADATA_COLS` omitted it, so the plotter classified `seed` as a plot axis. This is dormant for single runs (seed is constant → filtered by `varying_axis_columns`) but bites on **concatenated multi-seed CSVs**, where `seed` becomes a phantom axis.

This adds `seed` to `METADATA_COLS` and a `TestSeedColumn` test verifying it's metadata and excluded from `axis_columns`.

Implements decision **C2** of `docs/superpowers/specs/2026-05-29-refactor-design.md`.

Follow-up stacked PRs (Tasks 2–5) build the cross-language CSV schema drift-detection net (C1) on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)