### PR TITLE
test(csv): pin exact metadata header; document sites_per_iter column

### DIFF
--- a/include/ferret/runner.hpp
+++ b/include/ferret/runner.hpp
@@ -9,7 +9,7 @@ struct MeasurementRow {
   uint64_t ticks_min = 0;
   uint64_t ticks_median = 0;
   size_t iters = 0;
-  size_t sites = 0;
+  size_t sites = 0;  // emitted in CSV as the `sites_per_iter` column (see CsvWriter::write_header)
   size_t reps = 0;
   bool jit_failed = false;
 };

--- a/tests/test_csv.cpp
+++ b/tests/test_csv.cpp
@@ -27,6 +27,28 @@ TEST(Csv, HeaderWithFreqIncludesCycleColumns) {
   EXPECT_NE(out.find("freq_hz"), std::string::npos);
 }
 
+// Authoritative pin of the metadata column names and order emitted by
+// CsvWriter. The Python plotter's METADATA_COLS and the run_benchmarks.sh
+// validator mirror this; the schema-contract tests enforce the match.
+TEST(Csv, MetadataHeaderExactNoFreq) {
+  std::ostringstream os;
+  CsvWriter w(os, "b", {}, std::nullopt);
+  w.write_header();
+  EXPECT_EQ(os.str(),
+            "benchmark,ticks_min,ticks_median,iters,sites_per_iter,reps,"
+            "ns_per_site_min,ns_per_site_median\n");
+}
+
+TEST(Csv, MetadataHeaderExactWithFreq) {
+  std::ostringstream os;
+  CsvWriter w(os, "b", {}, 4.0e9);
+  w.write_header();
+  EXPECT_EQ(os.str(),
+            "benchmark,ticks_min,ticks_median,iters,sites_per_iter,reps,"
+            "ns_per_site_min,ns_per_site_median,"
+            "cycles_per_site_min,cycles_per_site_median,freq_hz\n");
+}
+
 TEST(Csv, RowFormatNoFreq) {
   std::ostringstream os;
   CsvWriter w(os, "bench", {"x"}, std::nullopt);


### PR DESCRIPTION
**Phase 1 refactor — Task 2 of 5 (stacked).** Base: `refactor/phase1-seed-metadata` (PR #49).

Pins the exact metadata header emitted by `CsvWriter::write_header` (no-freq and with-freq variants) so any future column rename/reorder is caught by a C++ test. Also documents that the `MeasurementRow::sites` struct field is emitted as the `sites_per_iter` CSV column — resolving the hidden rename.

`seed` is intentionally absent from these expected strings: it is a passthrough axis column injected by `run_command`, not part of `CsvWriter`'s own output.

Part of decision **C1** (CSV schema source-of-truth) of the Phase-1 refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)