### PR TITLE
test(schema): assert binary header matches METADATA_COLS

### DIFF
--- a/tests/python/test_schema_contract.py
+++ b/tests/python/test_schema_contract.py
@@ -9,9 +9,12 @@ failure instead of a silent plotting bug.
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
 from pathlib import Path
 
+import pytest
 from ferret_plot import columns as cols
 
 ROOT = Path(__file__).resolve().parent.parent.parent
@@ -50,3 +53,47 @@ def test_shell_validator_columns_are_metadata():
     assert names, "could not parse metric_columns from run_benchmarks.sh"
     for name in names:
         assert name in cols.METADATA_COLS, f"{name!r} in run_benchmarks.sh is not in METADATA_COLS"
+
+
+# direct_branch_footprint's swept axes and benchmark-specific options;
+# everything else in its header is metadata.
+DBF_AXES = frozenset({"branches", "spacing_bytes", "sattolo_permute"})
+
+
+def _ferret_bin() -> str:
+    """Locate the built ferret binary, or skip if it is not available."""
+    candidates = []
+    env = os.environ.get("FERRET_BIN")
+    if env:
+        candidates.append(env)
+    candidates.append(str(ROOT / "build" / "ferret"))
+    for c in candidates:
+        if Path(c).is_file() and os.access(c, os.X_OK):
+            return c
+    pytest.skip("ferret binary not found (set FERRET_BIN or build build/ferret)")
+
+
+def _header_columns(extra_args: list[str]) -> set[str]:
+    cmd = [
+        _ferret_bin(),
+        "run",
+        "direct_branch_footprint",
+        "--branches=1,2,4",
+        "--spacing_bytes=64",
+        "--reps=1",
+        "--warmup=0",
+        *extra_args,
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    header_line = proc.stdout.splitlines()[0]
+    return set(header_line.split(","))
+
+
+def test_binary_header_without_freq_matches_metadata():
+    metadata_present = _header_columns([]) - DBF_AXES
+    assert metadata_present == cols.METADATA_COLS - OPTIONAL_FREQ_COLS
+
+
+def test_binary_header_with_freq_matches_metadata():
+    metadata_present = _header_columns(["--freq=4.0GHz"]) - DBF_AXES
+    assert metadata_present == cols.METADATA_COLS


### PR DESCRIPTION
**Phase 1 refactor — Task 4 of 5 (stacked).** Base: `refactor/phase1-schema-static` (PR #51).

Appends the dynamic half of the CSV-schema contract: runs the built `ferret` binary, captures its CSV header, and asserts the metadata columns (header minus the benchmark's axis/option columns) equal `METADATA_COLS` — without `--freq` (minus the freq-only columns) and with `--freq` (full set). This is what actually catches drift between the C++ authority and the Python copy. The test auto-skips when no binary is present (`FERRET_BIN` env or `build/ferret`), so the normal Python-only test job stays green.

Note: `direct_branch_footprint` emits a `sattolo_permute` option column in its header (a `BenchOption`), so the non-metadata strip set is `{branches, spacing_bytes, sattolo_permute}`; `seed` is intentionally retained and matched as metadata.

Verified: 2 passed + 2 skipped without a binary; 4 passed with a freshly built `ferret`.

Part of decision **C1** of the Phase-1 refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)