### PR TITLE
ci(python): build ferret and run CSV schema contract test

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -17,15 +17,18 @@ jobs:
   pytest:
     name: pytest
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           persist-credentials: false
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25  # v22
 
+      - name: build ferret binary (for schema contract test)
+        run: nix develop --command bash -c "cmake -S . -B build -GNinja && cmake --build build --target ferret"
+
       - name: run ferret_plot pytest suite (in devshell)
-        run: nix develop --command ./scripts/test_py.sh
+        run: nix develop --command bash -c 'FERRET_BIN="$PWD/build/ferret" ./scripts/test_py.sh'
 
   png-integration:
     # Exercise the kaleido PNG path end-to-end on three environments:


### PR DESCRIPTION
**Phase 1 refactor — Task 5 of 5 (stacked).** Base: `refactor/phase1-schema-binary` (PR #52).

The schema-contract test's binary-header checks auto-skip without a `ferret` binary, and no CI job previously had both the binary and Python — so the cross-language drift check never ran in CI. This makes the `python.yml` `pytest` job build `ferret` and pass `FERRET_BIN="$PWD/build/ferret"` to `test_py.sh`, so the contract test runs for real. `timeout-minutes` bumped 15→25 to absorb the C++ build. The `png-integration` job is untouched.

Completes the CI wiring for decision **C1** of the Phase-1 refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)