### PR TITLE
build: add fully static build option and release workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -17,7 +17,7 @@ jobs:
   nix:
     name: nix
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
@@ -25,3 +25,5 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25  # v22
       - name: flake check
         run: nix flake check
+      - name: build static package
+        run: nix build .#static

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,18 @@ jobs:
       # actions/checkout, and Alpine has no glibc, so a container: job
       # fails before it compiles anything. Checkout and upload stay on
       # the glibc host; only the build and test happen in musl.
+      # SYS_NICE is needed because the container runs as root, so
+      # Pinning.BoostPriorityRequiresPrivilege does not take its
+      # geteuid() != 0 skip and asserts setpriority(-10) succeeds.
+      # Docker's default capability set omits SYS_NICE, so that call
+      # returns EPERM despite the process being root. Granting the
+      # capability keeps the assertion meaningful instead of weakening
+      # it. Its sibling mlockall test needs nothing extra, since
+      # mlockall succeeds within RLIMIT_MEMLOCK without a capability.
       - name: build and test static binary
         if: matrix.kind == 'musl'
         run: |
-          docker run --rm -v "$PWD:/src" -w /src "$ALPINE_IMAGE" sh -c '
+          docker run --rm --cap-add=SYS_NICE -v "$PWD:/src" -w /src "$ALPINE_IMAGE" sh -c '
           set -eu
           apk add --no-cache build-base cmake git
           cmake -S . -B build-static -DFERRET_STATIC=ON -DCMAKE_BUILD_TYPE=Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,178 @@
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build (${{ matrix.artifact }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { artifact: ferret-linux-x86_64-musl, os: ubuntu-latest, kind: musl }
+          - { artifact: ferret-linux-aarch64-musl, os: ubuntu-24.04-arm, kind: musl }
+          - { artifact: ferret-android-arm64, os: ubuntu-latest, kind: android }
+          - { artifact: ferret-macos-arm64-dynamic, os: macos-latest, kind: macos }
+    env:
+      ALPINE_IMAGE: alpine@sha256:14358309a308569c32bdc37e2e0e9694be33a9d99e68afb0f5ff33cc1f695dce  # alpine:3.22
+      ARTIFACT: ${{ matrix.artifact }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Alpine runs via `docker run`, not `container:`. The Actions
+      # runner injects a glibc-linked Node into job containers to run
+      # actions/checkout, and Alpine has no glibc, so a container: job
+      # fails before it compiles anything. Checkout and upload stay on
+      # the glibc host; only the build and test happen in musl.
+      - name: build and test static binary
+        if: matrix.kind == 'musl'
+        run: |
+          docker run --rm -v "$PWD:/src" -w /src "$ALPINE_IMAGE" sh -c '
+          set -eu
+          apk add --no-cache build-base cmake git
+          cmake -S . -B build-static -DFERRET_STATIC=ON -DCMAKE_BUILD_TYPE=Release
+          cmake --build build-static -j"$(nproc)"
+          readelf -l build-static/ferret > /tmp/phdrs.txt
+          if grep -q INTERP /tmp/phdrs.txt; then
+            echo "ERROR: ferret has an INTERP header - it is dynamically linked" >&2
+            exit 1
+          fi
+          ctest --test-dir build-static --output-on-failure
+          ./build-static/ferret run dependent_chain_throughput --reps=1 --warmup=0 --out=/tmp/smoke.csv
+          test "$(wc -l < /tmp/smoke.csv)" -ge 2
+          '
+          sudo chown -R "$(id -u):$(id -g)" build-static
+          cp build-static/ferret "$ARTIFACT"
+
+      - name: locate Android NDK
+        if: matrix.kind == 'android'
+        run: |
+          # ubuntu-latest runners ship the Android NDK at ANDROID_NDK_LATEST_HOME.
+          # Fail fast with a useful message if that assumption breaks.
+          if [ -z "${ANDROID_NDK_LATEST_HOME:-}" ] || [ ! -f "$ANDROID_NDK_LATEST_HOME/build/cmake/android.toolchain.cmake" ]; then
+            echo "ANDROID_NDK_LATEST_HOME not usable: '$ANDROID_NDK_LATEST_HOME'" >&2
+            exit 1
+          fi
+          echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> "$GITHUB_ENV"
+
+      - name: build (android)
+        if: matrix.kind == 'android'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build binutils
+          cmake -S . -B build-android -GNinja \
+            -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake" \
+            -DANDROID_ABI=arm64-v8a \
+            -DANDROID_PLATFORM=android-35 \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build-android
+          readelf -h build-android/ferret > /tmp/hdr.txt
+          if ! grep -q 'AArch64' /tmp/hdr.txt; then
+            echo "ERROR: ferret is not an aarch64 binary" >&2
+            exit 1
+          fi
+          readelf -d build-android/ferret > /tmp/dyn.txt
+          if grep -q 'libc++_shared' /tmp/dyn.txt; then
+            echo "ERROR: ferret links libc++_shared; expected a static C++ runtime" >&2
+            exit 1
+          fi
+          cp build-android/ferret "$ARTIFACT"
+
+      - name: build and test (macos)
+        if: matrix.kind == 'macos'
+        run: |
+          brew install ninja
+          cmake -S . -B build-release -GNinja -DCMAKE_BUILD_TYPE=Release
+          cmake --build build-release
+          ctest --test-dir build-release --output-on-failure
+          cp build-release/ferret "$ARTIFACT"
+
+      - name: upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+          retention-days: 7
+          if-no-files-found: error
+          archive: false
+
+  publish:
+    name: publish release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: generate checksums
+        run: |
+          cd artifacts
+          chmod +x ferret-*
+          sha256sum ferret-* > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: write release notes
+        run: |
+          cat > NOTES.md <<'EOF'
+          ## Binaries
+
+          | File | Target | Runtime dependencies |
+          | --- | --- | --- |
+          | `ferret-linux-x86_64-musl` | Linux x86_64 | none, fully static (musl) |
+          | `ferret-linux-aarch64-musl` | Linux aarch64 | none, fully static (musl) |
+          | `ferret-android-arm64` | Android arm64-v8a | on-device bionic only |
+          | `ferret-macos-arm64-dynamic` | macOS arm64 | **dynamically linked** against the macOS SDK |
+
+          macOS cannot produce a fully static executable, because Apple ships no
+          static libc and no `crt0.o`. That binary alone therefore carries no
+          no-runtime-dependencies guarantee.
+
+          Downloads are not marked executable. After downloading:
+
+          ```sh
+          chmod +x ferret-linux-x86_64-musl
+          ./ferret-linux-x86_64-musl list
+          ```
+
+          Verify with `sha256sum -c SHA256SUMS`.
+          EOF
+
+      - name: create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          case "$TAG" in
+            *-*) PRERELEASE=--prerelease ;;
+            *)   PRERELEASE= ;;
+          esac
+          gh release create "$TAG" \
+            --repo "$REPO" \
+            --title "$TAG" \
+            --notes-file NOTES.md \
+            $PRERELEASE \
+            artifacts/ferret-* artifacts/SHA256SUMS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,11 +114,23 @@ fix(plot): export surface png via chromium webgl fallback
 lint: silence ruff on intentional lazy imports and wide signatures
 ```
 
+Every commit carries two trailers, in Linux kernel style:
+
+```text
+Signed-off-by: Your Name <you@example.com>
+Assisted-by: Tool Name <noreply@example.com>
+```
+
+`Signed-off-by` comes from `git commit -s`. `Assisted-by` names any AI
+tool that helped produce the change, and is the sole place a tool name
+may appear.
+
 Forbidden in commit messages, PR titles, PR bodies, and code
 comments:
 
-- AI tool names (Codex, Claude, Grok, Gemini, …), including
-  `Co-Authored-By:` footers.
+- AI tool names (Codex, Claude, Grok, Gemini, …) in subjects, bodies,
+  and comments. The `Assisted-by:` trailer above is the only exception;
+  `Co-Authored-By:` footers remain forbidden.
 - Process narration ("FIXED", "Step 3", "Week 2", "Phase 1",
   "AC-x"). Write what the change _is_, not how the work
   progressed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ lint: silence ruff on intentional lazy imports and wide signatures
 Forbidden in commit messages, PR titles, PR bodies, and code
 comments:
 
-- AI tool names (Codex, Claude, Grok, Gemini, …) — including
+- AI tool names (Codex, Claude, Grok, Gemini, …), including
   `Co-Authored-By:` footers.
 - Process narration ("FIXED", "Step 3", "Week 2", "Phase 1",
   "AC-x"). Write what the change _is_, not how the work
@@ -138,7 +138,8 @@ PRs target `main`. CI must be green:
 | `build.yml`      | Build + ctest across gcc-13/14, clang-17/18 on linux-x86_64; gcc-14/clang-18 on linux-arm64; Apple Clang on macos-arm64 |
 | `python.yml`     | `scripts/test_py.sh` + integration tests on linux-nix, linux-pip, macos-pip                                             |
 | `sanitizers.yml` | `address+undefined` (all OS) + `thread` (Linux only) on Debug builds                                                    |
-| `nix.yml`        | `nix flake check`                                                                                                       |
+| `nix.yml`        | `nix flake check`; builds `packages.static` (`flake check` only evaluates it)                                           |
+| `release.yml`    | Static musl builds (linux x86_64 + aarch64), android + macos builds; publishes binaries on `v*` tags                    |
 | `codeql.yml`     | CodeQL c-cpp + python; weekly cron                                                                                      |
 | `zizmor.yml`     | Workflow YAML security audit; weekly cron                                                                               |
 
@@ -151,6 +152,7 @@ PRs target `main`. CI must be green:
 - **`detect_leaks` on macOS aborts startup.** Do not name it in `ASAN_OPTIONS` when running sanitizer tests on macOS — see [`docs/build.md`](docs/build.md).
 - **Apple Silicon has no per-core affinity.** `--core=N` is informational on macOS arm64; probe and benchmark land on _some_ P-core, not necessarily the same one. See the README's discipline section.
 - **`benchmark-results/` is not gitignored** while `*.csv`, `*.html`, and `*.png` are. Take care not to commit large CSV/PNG outputs into other paths.
+- **`FERRET_STATIC=ON` forces the FetchContent path.** A static configure needs network access even on a machine with all four dependencies installed, because a shared `libspdlog.so` cannot be linked into a static binary. It is also Linux-only and hard-errors when combined with `FERRET_SANITIZER`.
 
 ## Where to find things
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,29 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # turn it OFF (-DFERRET_WERROR=OFF) for a one-off local build.
 option(FERRET_WERROR "Treat warnings as errors for ferret targets" ON)
 
+# --- Static linking ---
+# Produces a binary with no runtime dependencies, for copying onto a
+# machine whose glibc / libstdc++ versions are unknown. Linux only:
+# Apple ships no static libc and no crt0.o, so -static cannot link on
+# Darwin. Off by default, so timing-sensitive workflows keep the normal
+# dynamic build. Only the option lives here, because the dependency
+# switch below reads it; the guards and link flags sit further down,
+# after FERRET_SANITIZER is declared.
+option(FERRET_STATIC "Link ferret fully statically (no runtime dependencies)" OFF)
+
+# System dependencies are bypassed for Android (nothing but the NDK
+# sysroot is on the search path) and for static builds (a shared
+# libspdlog.so cannot be linked into a -static binary; FetchContent
+# builds every dependency as a .a instead).
+#
+# Forcing CMAKE_FIND_LIBRARY_SUFFIXES to .a looks like a finer knob but
+# does not work here: spdlog and CLI11 resolve through their own
+# CONFIG-mode package files, which hardcode IMPORTED_LOCATION and the
+# library type when the dependency itself was built. No suffix setting
+# changes that after the fact, so switching the whole search off is the
+# accurate expression of the requirement.
 set(_ferret_use_system_deps ON)
-if(CMAKE_SYSTEM_NAME STREQUAL "Android")
+if(CMAKE_SYSTEM_NAME STREQUAL "Android" OR FERRET_STATIC)
   set(_ferret_use_system_deps OFF)
 endif()
 
@@ -59,6 +80,29 @@ if(FERRET_SANITIZER)
   # (Debug/RelWithDebInfo/Release) still applies.
   add_compile_options(${_ferret_san_arg} -fno-omit-frame-pointer -g)
   add_link_options(${_ferret_san_arg})
+endif()
+
+# --- Static link flags ---
+# Placed after FERRET_SANITIZER is declared so the conflict guard can
+# read it, and before the FetchContent calls below so that vendored
+# targets and everything under tests/ inherit -static. The sanitizer
+# check runs before the Darwin check on purpose: it makes the conflict
+# reportable on macOS instead of being masked by the platform error.
+if(FERRET_STATIC)
+  if(FERRET_SANITIZER)
+    message(FATAL_ERROR "ferret: FERRET_STATIC=ON cannot be combined with FERRET_SANITIZER='${FERRET_SANITIZER}'. "
+                        "Sanitizer runtimes require dynamic linking."
+    )
+  endif()
+  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    message(
+      FATAL_ERROR
+        "ferret: FERRET_STATIC=ON is not supported on Darwin. macOS ships no static libc and no "
+        "crt0.o, so a fully static executable cannot be linked. Build static binaries on Linux " "(see docs/build.md)."
+    )
+  endif()
+  message(STATUS "ferret: static linking enabled")
+  add_link_options(-static)
 endif()
 
 # --- GoogleTest: find_package first, FetchContent fallback ---

--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ resulting curves so you can spot capacity/associativity cliffs.
 
 RISC-V and LoongArch are reachable through sljit but not yet supported.
 
+## Prebuilt binaries
+
+Each release publishes binaries for four targets. The two Linux builds
+are fully static against musl. Copy one onto any machine of the right
+architecture and run it, with no toolchain, no Nix, and no matching
+glibc.
+
+```sh
+curl -LO https://github.com/eastonman/ferret/releases/latest/download/ferret-linux-x86_64-musl
+chmod +x ferret-linux-x86_64-musl
+./ferret-linux-x86_64-musl list
+```
+
+`ferret-android-arm64` depends only on on-device bionic.
+`ferret-macos-arm64-dynamic` is dynamically linked, because macOS
+cannot produce a static executable. Verify any download against the release's
+`SHA256SUMS`.
+
+Building from source instead: [`docs/build.md`](docs/build.md).
+
 ## Quickstart
 
 ```sh

--- a/docs/android.md
+++ b/docs/android.md
@@ -9,6 +9,11 @@ the host for plotting.
 Use this workflow when you want to validate ferret on a real phone —
 for example a Snapdragon 888 or Snapdragon 8 Gen 3 device.
 
+Cross-compiling is optional. Each release publishes a prebuilt
+`ferret-android-arm64`; download it, `chmod +x`, and skip straight to
+[Stage Binaries On The Device](#stage-binaries-on-the-device). Build
+from source when you need a modified ferret on the phone.
+
 ## Prerequisites
 
 Enter the Android dev shell. It pulls in the NDK, platform-tools (`adb`),

--- a/docs/build.md
+++ b/docs/build.md
@@ -55,12 +55,55 @@ output has no such requirement.
 
 ## CMake knobs
 
-| Option                               | Default | Purpose                                                                                                                                                                 |
-| ------------------------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-DFERRET_WERROR=ON\|OFF`            | `ON`    | Treat warnings as errors on ferret's own targets (vendored deps unaffected). Turn off for one-off local builds against a newer compiler. CI runs with the default `ON`. |
-| `-DFERRET_SANITIZER=<mode>`          | unset   | Enable a sanitizer build (see below).                                                                                                                                   |
-| `-DCMAKE_BUILD_TYPE=<type>`          | unset   | Debug / Release / RelWithDebInfo. CI build job leaves this unset; sanitizer jobs set `Debug`.                                                                           |
-| `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` | off     | Required for `scripts/lint.sh` (clang-tidy reads `build/compile_commands.json`).                                                                                        |
+| Option                               | Default | Purpose                                                                                                                                                                                                                       |
+| ------------------------------------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-DFERRET_WERROR=ON\|OFF`            | `ON`    | Treat warnings as errors on ferret's own targets (vendored deps unaffected). Turn off for one-off local builds against a newer compiler. CI runs with the default `ON`.                                                       |
+| `-DFERRET_SANITIZER=<mode>`          | unset   | Enable a sanitizer build (see below).                                                                                                                                                                                         |
+| `-DFERRET_STATIC=ON\|OFF`            | `OFF`   | Link fully statically, so the binary has no runtime dependencies. Linux only; errors on macOS and when combined with `FERRET_SANITIZER`. Forces the FetchContent dependency path, so a static configure needs network access. |
+| `-DCMAKE_BUILD_TYPE=<type>`          | unset   | Debug / Release / RelWithDebInfo. CI build job leaves this unset; sanitizer jobs set `Debug`.                                                                                                                                 |
+| `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` | off     | Required for `scripts/lint.sh` (clang-tidy reads `build/compile_commands.json`).                                                                                                                                              |
+
+## Static builds
+
+`-DFERRET_STATIC=ON` links `ferret` with no runtime dependencies, so
+the binary can be copied onto a machine whose glibc and libstdc++
+versions are unknown. Three constraints:
+
+- **Linux only.** macOS ships no static libc and no `crt0.o`, so the
+  option hard-errors on Darwin. This is not a limitation to work
+  around.
+- **Incompatible with `FERRET_SANITIZER`.** Sanitizer runtimes require
+  dynamic linking; combining the two hard-errors.
+- **Needs network at configure time.** `FERRET_STATIC=ON` forces the
+  FetchContent path even on a machine that has all four dependencies
+  installed, because a shared `libspdlog.so` cannot be linked into a
+  static binary.
+
+Building against musl, which is what the published release artifacts use,
+needs no toolchain setup beyond Docker:
+
+```sh
+docker run --rm -v "$PWD:/src" -w /src alpine:3.22 sh -c '
+  apk add --no-cache build-base cmake git
+  cmake -S . -B build-static -DFERRET_STATIC=ON -DCMAKE_BUILD_TYPE=Release
+  cmake --build build-static -j"$(nproc)"
+'
+```
+
+`.github/workflows/release.yml` holds the authoritative version of this
+recipe, with a digest-pinned image and the full verification sequence;
+the snippet above is a convenience copy. Confirm the result is static
+with `readelf -l build-static/ferret`. A static binary has no `INTERP`
+program header.
+
+Nix users get the same thing from the flake, built against musl from
+`pkgsStatic` and pinned by `flake.lock`:
+
+```sh
+nix build .#static
+```
+
+That output is Linux-only for the same reason the CMake option is.
 
 ## Sanitizer builds
 

--- a/docs/superpowers/plans/2026-08-28-static-build.md
+++ b/docs/superpowers/plans/2026-08-28-static-build.md
@@ -1,0 +1,833 @@
+# Static Build Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `-DFERRET_STATIC=ON` CMake option and a `packages.static` flake output that produce a fully static `ferret` binary, and publish prebuilt binaries for four targets from a new release workflow.
+
+**Architecture:** Two decoupled mechanisms. `FERRET_STATIC` forces the FetchContent dependency path and adds `-static`; it is what CI's two musl cells use inside an Alpine container. `packages.static` changes nothing about how ferret builds and instead evaluates the existing derivation under `pkgs.pkgsStatic`, which supplies musl and `-static` from its stdenv. The two must never be combined; see Global Constraints.
+
+**Tech Stack:** CMake 3.20+, Nix flakes (`pkgsStatic`), GitHub Actions, Docker (`alpine`), Android NDK.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-static-build-design.md`
+
+## Global Constraints
+
+- `FERRET_STATIC` defaults to `OFF`. Every existing build path, CI job, and timing-sensitive workflow must be byte-for-byte unaffected when the option is not set.
+- Static linking is **Linux only**. `FERRET_STATIC=ON` must hard-error on Darwin: macOS ships no static libc and no `crt0.o`.
+- `FERRET_STATIC=ON` combined with any `FERRET_SANITIZER` value must hard-error. Sanitizer runtimes require dynamic linking.
+- **Nix must never pass `-DFERRET_STATIC=ON`.** The option forces FetchContent, FetchContent needs network, and the Nix sandbox forbids it. `nix/ferret.nix` and `nix/sljit.nix` are not modified by this plan.
+- **Alpine runs via `docker run`, never `container:`.** The Actions runner injects a glibc-linked Node into job containers to execute `actions/checkout`; Alpine has no glibc and the job fails before compiling.
+- Artifact names are exact: `ferret-linux-x86_64-musl`, `ferret-linux-aarch64-musl`, `ferret-android-arm64`, `ferret-macos-arm64-dynamic`.
+- Workflow conventions, copied from the existing workflows: every action pinned to a full SHA with a trailing `  # vX.Y.Z` comment (two spaces before `#`), `persist-credentials: false` on every checkout, a `concurrency` group, `timeout-minutes` on every job, and a workflow-level `permissions: contents: read`.
+- No new files under `scripts/`. The Alpine recipe lives in `release.yml` only.
+- Commit messages: `type(scope): subject`, lowercase, imperative, no trailing period. **Forbidden:** AI tool names anywhere (including `Co-Authored-By:` footers) and process narration ("Task 3", "Phase 1", "FIXED").
+- Commit with `--no-gpg-sign`. The repository's signing key is expired and unsigned commits are authorized here.
+- `docs/superpowers/` is excluded from both prettier (`.prettierignore`) and markdownlint (`scripts/lint.sh:58`). This plan and its spec are lint-exempt; every other file this plan touches is not.
+- Never run bare `git stash`: this is a worktree sharing a stash stack with other checkouts.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+| --- | --- | --- |
+| `CMakeLists.txt` | Modify (2 sites) | Declares `FERRET_STATIC`, folds it into `_ferret_use_system_deps`, holds the guards and `-static` link flag |
+| `flake.nix` | Modify (1 site) | Adds the Linux-only `packages.static` output |
+| `.github/workflows/release.yml` | Create | Builds four artifacts; publishes on `v*` tags |
+| `docs/build.md` | Modify | CMake-knob row + "Static builds" section |
+| `README.md` | Modify | "Prebuilt binaries" pointer |
+| `AGENTS.md` | Modify | CI-gates table row + footgun entry |
+| `docs/android.md` | Modify | Note that the Android binary is downloadable |
+
+**A note on testing style.** This is build-system work; there is no unit-test harness that can assert on a linker invocation. The TDD cycle here is *write the verification command, run it, watch it fail with a specific message, implement, run it again, watch it pass*. Every task below gives the exact command and the exact expected output for both halves of that cycle. Do not skip the "watch it fail" step, because on this kind of change it is the only thing distinguishing a working guard from a guard that never fires.
+
+---
+
+### Task 1: FERRET_STATIC CMake option
+
+**Files:**
+
+- Modify: `CMakeLists.txt:14` (add option), `CMakeLists.txt:16-19` (fold into `_ferret_use_system_deps`), `CMakeLists.txt:62` (add guards + link flag after the sanitizer block)
+- Modify: `docs/build.md:58-64` (CMake knobs table)
+
+**Interfaces:**
+
+- Consumes: nothing; this is the first task.
+- Produces: the CMake option `FERRET_STATIC` (BOOL, default `OFF`). Task 3 invokes it as `cmake -S . -B build-static -DFERRET_STATIC=ON -DCMAKE_BUILD_TYPE=Release`. No other task reads it.
+
+**Prerequisite:** Docker must be running (Step 6 builds inside Alpine). On Apple Silicon this pulls the native arm64 image and produces a `linux/aarch64` static binary, which is a valid proof of the recipe.
+
+- [ ] **Step 1: Run the guard checks and watch them NOT fire**
+
+```bash
+rm -rf /tmp/ferret-guard-darwin /tmp/ferret-guard-san
+cmake -S . -B /tmp/ferret-guard-darwin -DFERRET_STATIC=ON 2>&1 | tail -5
+cmake -S . -B /tmp/ferret-guard-san -DFERRET_STATIC=ON -DFERRET_SANITIZER=address 2>&1 | tail -5
+```
+
+Expected: **both succeed**, ending in `-- Generating done` / `-- Build files have been written to: ...`. CMake may also print `Manually-specified variables were not used by this project: FERRET_STATIC`, which is precisely the bug: the option does not exist yet, so the flag is silently ignored.
+
+- [ ] **Step 2: Declare the option**
+
+Insert immediately after the `option(FERRET_WERROR ...)` line at `CMakeLists.txt:14`:
+
+```cmake
+
+# --- Static linking ---
+# Produces a binary with no runtime dependencies, for copying onto a
+# machine whose glibc / libstdc++ versions are unknown. Linux only:
+# Apple ships no static libc and no crt0.o, so -static cannot link on
+# Darwin. Off by default, so timing-sensitive workflows keep the normal
+# dynamic build. Only the option lives here, because the dependency
+# switch below reads it; the guards and link flags sit further down,
+# after FERRET_SANITIZER is declared.
+option(FERRET_STATIC "Link ferret fully statically (no runtime dependencies)" OFF)
+```
+
+- [ ] **Step 3: Fold the option into the dependency switch**
+
+Replace `CMakeLists.txt:16-19` in full:
+
+```cmake
+set(_ferret_use_system_deps ON)
+if(CMAKE_SYSTEM_NAME STREQUAL "Android")
+  set(_ferret_use_system_deps OFF)
+endif()
+```
+
+with:
+
+```cmake
+# System dependencies are bypassed for Android (nothing but the NDK
+# sysroot is on the search path) and for static builds (a shared
+# libspdlog.so cannot be linked into a -static binary; FetchContent
+# builds every dependency as a .a instead).
+set(_ferret_use_system_deps ON)
+if(CMAKE_SYSTEM_NAME STREQUAL "Android" OR FERRET_STATIC)
+  set(_ferret_use_system_deps OFF)
+endif()
+```
+
+- [ ] **Step 4: Add the guards and the link flag**
+
+Insert after the sanitizer block's closing `endif()` at `CMakeLists.txt:62`, immediately before the `# --- GoogleTest: find_package first, FetchContent fallback ---` comment:
+
+```cmake
+
+# --- Static link flags ---
+# Placed after FERRET_SANITIZER is declared so the conflict guard can
+# read it, and before the FetchContent calls below so that vendored
+# targets and everything under tests/ inherit -static. The sanitizer
+# check runs before the Darwin check on purpose: it makes the conflict
+# reportable on macOS instead of being masked by the platform error.
+if(FERRET_STATIC)
+  if(FERRET_SANITIZER)
+    message(FATAL_ERROR "ferret: FERRET_STATIC=ON cannot be combined with FERRET_SANITIZER='${FERRET_SANITIZER}'. "
+                        "Sanitizer runtimes require dynamic linking."
+    )
+  endif()
+  if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    message(FATAL_ERROR "ferret: FERRET_STATIC=ON is not supported on Darwin. macOS ships no static libc and no "
+                        "crt0.o, so a fully static executable cannot be linked. Build static binaries on Linux "
+                        "(see docs/build.md)."
+    )
+  endif()
+  message(STATUS "ferret: static linking enabled")
+  add_link_options(-static)
+endif()
+```
+
+- [ ] **Step 5: Run the guard checks again and watch them fire**
+
+```bash
+rm -rf /tmp/ferret-guard-darwin /tmp/ferret-guard-san
+cmake -S . -B /tmp/ferret-guard-san -DFERRET_STATIC=ON -DFERRET_SANITIZER=address 2>&1 | tail -6
+cmake -S . -B /tmp/ferret-guard-darwin -DFERRET_STATIC=ON 2>&1 | tail -6
+```
+
+Expected: the first exits non-zero with `CMake Error ... FERRET_STATIC=ON cannot be combined with FERRET_SANITIZER='address'`. The second exits non-zero with `CMake Error ... not supported on Darwin`.
+
+If you are executing this on Linux rather than macOS, the second command will instead configure successfully, which is correct behaviour, not a failure. Confirm the Darwin branch by reading it; only the sanitizer guard is verifiable on Linux.
+
+- [ ] **Step 6: Prove a static binary actually builds, links, tests, and runs**
+
+```bash
+docker run --rm -v "$PWD:/src" -w /src alpine:3.22 sh -c '
+set -eu
+apk add --no-cache build-base cmake git
+cmake -S . -B build-static-check -DFERRET_STATIC=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build-static-check -j"$(nproc)"
+readelf -l build-static-check/ferret > /tmp/phdrs.txt
+if grep -q INTERP /tmp/phdrs.txt; then
+  echo "ERROR: ferret has an INTERP header - it is dynamically linked" >&2
+  exit 1
+fi
+ctest --test-dir build-static-check --output-on-failure
+./build-static-check/ferret run dependent_chain_throughput --reps=1 --warmup=0 --out=/tmp/smoke.csv
+test "$(wc -l < /tmp/smoke.csv)" -ge 2
+echo "STATIC BUILD OK"
+'
+```
+
+Expected: ends with `STATIC BUILD OK`. All ctest cases pass.
+
+Four things about this command are deliberate and should not be "cleaned up":
+
+1. **No `-GNinja`.** Alpine's ninja packaging has shifted across releases (`ninja`, `ninja-build`, `samurai`); `build-base` always provides `make`. The generator has no bearing on whether the binary is static, so the default generator removes a failure mode for free.
+2. **`readelf` to a file, then `grep`.** Writing `readelf ... | grep -q INTERP && exit 1` inverts under `set -e`: in the *good* case grep exits non-zero, the `&&` chain returns non-zero, and the script dies claiming success failed. Worse, if `readelf` itself errors the pipeline still reports "static". Landing the output in a file makes `set -e` catch a broken `readelf` and leaves `grep` as a clean boolean.
+3. **The smoke run is not redundant with ctest.** ctest proves the binary starts. Only a real `ferret run` proves sljit's `mmap` of executable pages still works under static musl, which is the single most likely thing to break.
+4. **`--out=/tmp/smoke.csv`, not a path in the repo.** `.gitignore` ignores `*.csv`, but the bind mount would leave the file in your working tree regardless.
+
+If the link step fails with an error about mixing `-static` and `-pie`,
+the toolchain's specs default to PIE and `-static` needs `-no-pie`
+alongside it. Alpine is not expected to need this; a contributor's host
+distribution might. If it happens, add `-no-pie` to the
+`add_link_options` call from Step 4 and note it in the task report.
+Do not silently widen the flag set beyond that.
+
+Clean up afterwards, since the directory is bind-mounted into your checkout:
+
+```bash
+rm -rf build-static-check
+```
+
+- [ ] **Step 7: Confirm the default build is untouched**
+
+```bash
+rm -rf build
+cmake -S . -B build -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+Expected: all pass, exactly as before the change. `-- ferret: static linking enabled` must **not** appear in the configure output.
+
+- [ ] **Step 8: Format and lint the CMake changes**
+
+```bash
+cmake-format -i CMakeLists.txt
+cmake-format --check CMakeLists.txt
+cmake-lint CMakeLists.txt
+git diff CMakeLists.txt
+```
+
+Expected: `--check` and `cmake-lint` both exit zero. Review the `cmake-format -i` reflow, then accept whatever it produces; it owns wrapping, and `.cmake-format.yaml` sets `line_width: 120` with `dangle_parens: true`.
+
+- [ ] **Step 9: Document the knob**
+
+Add this row to the CMake knobs table in `docs/build.md`, after the `-DFERRET_SANITIZER=<mode>` row:
+
+```markdown
+| `-DFERRET_STATIC=ON\|OFF`            | `OFF`   | Link fully statically, so the binary has no runtime dependencies. Linux only; errors on macOS and when combined with `FERRET_SANITIZER`. Forces the FetchContent dependency path, so a static configure needs network access. |
+```
+
+Then re-align the table and verify:
+
+```bash
+prettier --write docs/build.md
+prettier --check docs/build.md
+markdownlint-cli2 docs/build.md
+```
+
+Expected: both exit zero.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add CMakeLists.txt docs/build.md
+git commit --no-gpg-sign -m "build: add FERRET_STATIC option for fully static linking"
+```
+
+---
+
+### Task 2: packages.static flake output
+
+**Files:**
+
+- Modify: `flake.nix:20-23` (the `let` block) and `flake.nix:77-80` (the `packages` attribute)
+
+**Interfaces:**
+
+- Consumes: nothing from Task 1. This task must **not** reference `FERRET_STATIC`; see Global Constraints.
+- Produces: `packages.static` on `x86_64-linux` and `aarch64-linux` only. Nothing later in this plan depends on it; CI's artifacts come from Task 3, not from Nix.
+
+- [ ] **Step 1: Confirm the output does not exist yet**
+
+```bash
+nix flake show --all-systems 2>&1 | grep -A3 'x86_64-linux'
+```
+
+Expected: under `packages.x86_64-linux` only `default` is listed. No `static`.
+
+- [ ] **Step 2: Determine whether `nix flake check` builds packages**
+
+This answers the spec's one open risk before you write any code, and the answer decides nothing in this task; it decides whether Task 6 needs to raise a timeout.
+
+```bash
+nix flake check -v 2>&1 | tail -30
+```
+
+Watch whether `packages.<system>.default` (the ferret derivation) is built or merely evaluated. Record the answer in your report for this task. If packages **are** built, the `nix.yml` job will start building `packages.static` on Linux once Step 3 lands, and you must check its runtime against the existing `timeout-minutes: 60` when CI first runs.
+
+- [ ] **Step 3: Add the static package**
+
+In `flake.nix`, extend the `let` block at lines 20-23 to:
+
+```nix
+      system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+        sljit = pkgs.callPackage ./nix/sljit.nix {src = sljit-src;};
+        sljitStatic = pkgs.pkgsStatic.callPackage ./nix/sljit.nix {src = sljit-src;};
+      in {
+```
+
+and replace the `packages.default` attribute at lines 77-80 with:
+
+```nix
+        packages =
+          {
+            default = pkgs.callPackage ./nix/ferret.nix {
+              inherit sljit;
+              src = self;
+            };
+          }
+          # pkgsStatic is musl + -static on Linux. On Darwin it cannot
+          # produce a fully static executable (no static libc, no
+          # crt0.o), so the output is Linux-only. Note this deliberately
+          # does NOT pass -DFERRET_STATIC=ON: that option forces the
+          # FetchContent path, which needs network access the Nix
+          # sandbox does not grant. pkgsStatic's stdenv supplies the
+          # static linking, and its spdlog/gtest/cli11 are .a archives
+          # the existing find_package path resolves unchanged.
+          // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+            static = pkgs.pkgsStatic.callPackage ./nix/ferret.nix {
+              sljit = sljitStatic;
+              src = self;
+            };
+          };
+```
+
+Match the surrounding formatting: this file uses compact braces (`{src = sljit-src;}`) rather than the `nixfmt-rfc-style` the `formatter` attribute names. Nothing in `scripts/lint.sh` or `nix flake check` gates Nix formatting, so follow the file, not the formatter.
+
+- [ ] **Step 4: Verify the output appears for Linux and not for Darwin**
+
+```bash
+nix flake show --all-systems 2>&1 | grep -B1 -A4 'packages'
+```
+
+Expected: `static` and `default` listed under both `packages.x86_64-linux` and `packages.aarch64-linux`; only `default` under `packages.x86_64-darwin` and `packages.aarch64-darwin`.
+
+- [ ] **Step 5: Verify the Linux derivation evaluates**
+
+```bash
+nix eval --raw .#packages.x86_64-linux.static.drvPath
+nix eval --raw .#packages.aarch64-linux.static.drvPath
+```
+
+Expected: each prints a `/nix/store/....drv` path. This proves the expression is well-formed without building it.
+
+- [ ] **Step 6: Verify nothing on the current system regressed**
+
+```bash
+nix flake check
+nix build .#default && ./result/bin/ferret list
+```
+
+Expected: `nix flake check` exits zero; `ferret list` prints the four registered benchmark names.
+
+**Honest limitation to report:** on macOS you cannot build `packages.static`, because there is no Linux builder configured. Its first real build happens in CI. Say so explicitly in your task report rather than implying it was verified.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add flake.nix
+git commit --no-gpg-sign -m "build: add static flake package built from pkgsStatic"
+```
+
+---
+
+### Task 3: Release workflow, musl static Linux cells
+
+**Files:**
+
+- Create: `.github/workflows/release.yml`
+
+**Interfaces:**
+
+- Consumes: `-DFERRET_STATIC=ON` from Task 1.
+- Produces: a `build` job with a `matrix.include` list whose entries carry `artifact`, `os`, and `kind` keys, and a job-level `ALPINE_IMAGE` env var. Task 4 appends two entries with `kind: android` and `kind: macos` to that same matrix. Task 5 adds a `publish` job with `needs: build` that consumes the uploaded artifact names.
+
+- [ ] **Step 1: Resolve the Alpine image digest**
+
+Never pin by tag: the repository pins every GitHub Action by SHA and the container image gets the same treatment.
+
+```bash
+docker pull alpine:3.22
+docker inspect --format='{{index .RepoDigests 0}}' alpine:3.22
+```
+
+Expected: a line like `alpine@sha256:<64 hex chars>`. Use that exact string as `ALPINE_IMAGE` below.
+
+- [ ] **Step 2: Create the workflow with the two musl cells**
+
+Create `.github/workflows/release.yml`. Substitute the digest from Step 1 for `<DIGEST>`:
+
+```yaml
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build (${{ matrix.artifact }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { artifact: ferret-linux-x86_64-musl, os: ubuntu-latest, kind: musl }
+          - { artifact: ferret-linux-aarch64-musl, os: ubuntu-24.04-arm, kind: musl }
+    env:
+      # alpine:3.22
+      ALPINE_IMAGE: alpine@sha256:<DIGEST>
+      ARTIFACT: ${{ matrix.artifact }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Alpine runs via `docker run`, not `container:`. The Actions
+      # runner injects a glibc-linked Node into job containers to run
+      # actions/checkout, and Alpine has no glibc, so a container: job
+      # fails before it compiles anything. Checkout and upload stay on
+      # the glibc host; only the build and test happen in musl.
+      - name: build and test static binary
+        if: matrix.kind == 'musl'
+        run: |
+          docker run --rm -v "$PWD:/src" -w /src "$ALPINE_IMAGE" sh -c '
+          set -eu
+          apk add --no-cache build-base cmake git
+          cmake -S . -B build-static -DFERRET_STATIC=ON -DCMAKE_BUILD_TYPE=Release
+          cmake --build build-static -j"$(nproc)"
+          readelf -l build-static/ferret > /tmp/phdrs.txt
+          if grep -q INTERP /tmp/phdrs.txt; then
+            echo "ERROR: ferret has an INTERP header - it is dynamically linked" >&2
+            exit 1
+          fi
+          ctest --test-dir build-static --output-on-failure
+          ./build-static/ferret run dependent_chain_throughput --reps=1 --warmup=0 --out=/tmp/smoke.csv
+          test "$(wc -l < /tmp/smoke.csv)" -ge 2
+          '
+          sudo chown -R "$(id -u):$(id -g)" build-static
+          cp build-static/ferret "$ARTIFACT"
+
+      - name: upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+          retention-days: 7
+          if-no-files-found: error
+```
+
+Three details that are load-bearing:
+
+- The `sh -c '...'` body is **single-quoted**, so `$(nproc)` and `$(wc -l ...)` reach the container shell unexpanded. `"$ALPINE_IMAGE"` sits outside the quotes and is expanded by the host. Do not convert the outer quotes to double quotes.
+- `matrix.artifact` is passed through the `ARTIFACT` env var rather than interpolated directly into `run:`. `zizmor.yml` flags `${{ }}` expressions inside `run:` blocks as template-injection risks; the env indirection is the standard fix.
+- Files the container writes are root-owned on a Linux runner, hence the `chown` before `cp`. This is not needed locally on Docker Desktop, which maps the host user, but it is required in CI.
+
+- [ ] **Step 3: Validate the YAML parses**
+
+```bash
+prettier --check .github/workflows/release.yml
+```
+
+Expected: exit zero. If it reports a difference, run `prettier --write .github/workflows/release.yml` and re-check.
+
+- [ ] **Step 4: Commit and push, then watch the workflow**
+
+```bash
+git add .github/workflows/release.yml
+git commit --no-gpg-sign -m "ci: add release workflow with musl static linux builds"
+git push
+```
+
+Then open the PR (or push to the existing one) and watch the `release` workflow. Expected: two green cells, `build (ferret-linux-x86_64-musl)` and `build (ferret-linux-aarch64-musl)`, each with an uploaded artifact.
+
+If a cell fails, read the log before changing anything. The three failures worth anticipating: an `apk` package name change, the `chown` step failing because `sudo` is unavailable on the arm64 runner image, and the smoke run failing on `mlockall`. Note that ferret is expected to *warn and continue* there, so an actual failure means something else.
+
+---
+
+### Task 4: Release workflow, Android and macOS cells
+
+**Files:**
+
+- Modify: `.github/workflows/release.yml` (matrix `include` list, plus three new steps)
+
+**Interfaces:**
+
+- Consumes: the `build` job matrix and the `ARTIFACT` env var from Task 3.
+- Produces: two more uploaded artifacts, `ferret-android-arm64` and `ferret-macos-arm64-dynamic`. Task 5 attaches all four to the release.
+
+Neither cell sets `FERRET_STATIC`. Android gets portability from the NDK's default `c++_static` plus on-device bionic; macOS cannot be static at all.
+
+- [ ] **Step 1: Extend the matrix**
+
+Add two entries to the `matrix.include` list:
+
+```yaml
+          - { artifact: ferret-android-arm64, os: ubuntu-latest, kind: android }
+          - { artifact: ferret-macos-arm64-dynamic, os: macos-latest, kind: macos }
+```
+
+- [ ] **Step 2: Add the Android steps**
+
+Insert after the `build and test static binary` step and before `upload artifact`. This mirrors `.github/workflows/build.yml:90-109`:
+
+```yaml
+      - name: locate Android NDK
+        if: matrix.kind == 'android'
+        run: |
+          # ubuntu-latest runners ship the Android NDK at ANDROID_NDK_LATEST_HOME.
+          # Fail fast with a useful message if that assumption breaks.
+          if [ -z "${ANDROID_NDK_LATEST_HOME:-}" ] || [ ! -f "$ANDROID_NDK_LATEST_HOME/build/cmake/android.toolchain.cmake" ]; then
+            echo "ANDROID_NDK_LATEST_HOME not usable: '$ANDROID_NDK_LATEST_HOME'" >&2
+            exit 1
+          fi
+          echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> "$GITHUB_ENV"
+
+      - name: build (android)
+        if: matrix.kind == 'android'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ninja-build
+          cmake -S . -B build-android -GNinja \
+            -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake" \
+            -DANDROID_ABI=arm64-v8a \
+            -DANDROID_PLATFORM=android-35 \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build-android
+          cp build-android/ferret "$ARTIFACT"
+```
+
+There is no test step. Android binaries cannot execute on the host, matching what `android-cross-build` already does in `build.yml`.
+
+- [ ] **Step 3: Add the macOS step**
+
+Insert after the Android steps:
+
+```yaml
+      - name: build and test (macos)
+        if: matrix.kind == 'macos'
+        run: |
+          brew install ninja
+          cmake -S . -B build-release -GNinja -DCMAKE_BUILD_TYPE=Release
+          cmake --build build-release
+          ctest --test-dir build-release --output-on-failure
+          cp build-release/ferret "$ARTIFACT"
+```
+
+- [ ] **Step 4: Validate and commit**
+
+```bash
+prettier --check .github/workflows/release.yml
+git add .github/workflows/release.yml
+git commit --no-gpg-sign -m "ci: add android and macos cells to release workflow"
+git push
+```
+
+Expected on CI: four green cells, four uploaded artifacts.
+
+---
+
+### Task 5: Publish job
+
+**Files:**
+
+- Modify: `.github/workflows/release.yml` (append a `publish` job)
+
+**Interfaces:**
+
+- Consumes: the four artifacts uploaded by the `build` job in Tasks 3 and 4.
+- Produces: a GitHub Release on `v*` tags carrying five assets: the four binaries plus `SHA256SUMS`.
+
+- [ ] **Step 1: Resolve the download-artifact SHA**
+
+`actions/download-artifact` is not yet used in this repository, so there is no existing pin to copy.
+
+```bash
+gh api repos/actions/download-artifact/commits/v6 --jq '.sha'
+gh api repos/actions/download-artifact/releases/latest --jq '.tag_name'
+```
+
+Expected: a 40-character SHA and a tag like `v6.0.0`. If `v6` 404s, try `v5`, and use whatever tag the second command reports for the trailing comment.
+
+- [ ] **Step 2: Append the publish job**
+
+Add at the end of `release.yml`, substituting the SHA and tag from Step 1:
+
+```yaml
+  publish:
+    name: publish release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: download artifacts
+        uses: actions/download-artifact@<SHA>  # <TAG>
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: generate checksums
+        run: |
+          cd artifacts
+          chmod +x ferret-*
+          sha256sum ferret-* > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: write release notes
+        run: |
+          cat > NOTES.md <<'EOF'
+          ## Binaries
+
+          | File | Target | Runtime dependencies |
+          | --- | --- | --- |
+          | `ferret-linux-x86_64-musl` | Linux x86_64 | none, fully static (musl) |
+          | `ferret-linux-aarch64-musl` | Linux aarch64 | none, fully static (musl) |
+          | `ferret-android-arm64` | Android arm64-v8a | on-device bionic only |
+          | `ferret-macos-arm64-dynamic` | macOS arm64 | **dynamically linked** against the macOS SDK |
+
+          macOS cannot produce a fully static executable, because Apple ships no
+          static libc and no `crt0.o`. That binary alone therefore carries no
+          no-runtime-dependencies guarantee.
+
+          Downloads are not marked executable. After downloading:
+
+          ```sh
+          chmod +x ferret-linux-x86_64-musl
+          ./ferret-linux-x86_64-musl list
+          ```
+
+          Verify with `sha256sum -c SHA256SUMS`.
+          EOF
+
+      - name: create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh release create "$TAG" \
+            --repo "$REPO" \
+            --title "$TAG" \
+            --notes-file NOTES.md \
+            artifacts/ferret-* artifacts/SHA256SUMS
+```
+
+Notes on the choices here:
+
+- `gh` rather than a third-party release action: nothing new to pin and audit, and less for `zizmor.yml` to object to. `gh release create --repo` needs no checkout, which is why this job has no `actions/checkout` step, a genuine least-privilege win.
+- `contents: write` is scoped to this job alone; the workflow-level default stays `contents: read`.
+- The heredoc body must keep uniform indentation. YAML strips the common leading whitespace from a `|` block, so the shell sees `cat`, the body, and `EOF` all at column 0. Do not re-indent `EOF` to column 0 inside the YAML; that breaks the block scalar.
+- `sha256sum ferret-*` cannot match `SHA256SUMS`, because the glob is prefixed, so there is no ordering hazard between the two steps.
+- The `chmod +x` is cosmetic for release assets, which carry no permission bits over HTTP. It matters for anyone pulling the PR-run zip, and the release notes tell downloaders to `chmod +x` regardless.
+
+- [ ] **Step 3: Validate and commit**
+
+```bash
+prettier --check .github/workflows/release.yml
+git add .github/workflows/release.yml
+git commit --no-gpg-sign -m "ci: publish release artifacts on version tags"
+git push
+```
+
+- [ ] **Step 4: Confirm the publish job is correctly skipped on the PR**
+
+On the pull request run, the `publish` job must show as skipped while all four `build` cells run. Expected: `publish` greyed out with "This job was skipped".
+
+Do **not** push a `v*` tag to test the publish path unless the user asks for it. Cutting a release is theirs to decide.
+
+---
+
+### Task 6: Documentation
+
+**Files:**
+
+- Modify: `docs/build.md` (new "Static builds" section), `README.md` (prebuilt binaries), `AGENTS.md` (CI table + footgun), `docs/android.md` (prebuilt note)
+
+**Interfaces:**
+
+- Consumes: the `FERRET_STATIC` option from Task 1, `packages.static` from Task 2, and the artifact names from Tasks 3-5.
+- Produces: nothing consumed by other tasks.
+
+The knob-table row in `docs/build.md` already landed in Task 1. This task adds the prose.
+
+- [ ] **Step 1: Add the "Static builds" section to `docs/build.md`**
+
+Insert after the "CMake knobs" table and before the "Sanitizer builds" section:
+
+````markdown
+## Static builds
+
+`-DFERRET_STATIC=ON` links `ferret` with no runtime dependencies, so
+the binary can be copied onto a machine whose glibc and libstdc++
+versions are unknown. Three constraints:
+
+- **Linux only.** macOS ships no static libc and no `crt0.o`, so the
+  option hard-errors on Darwin. This is not a limitation to work
+  around.
+- **Incompatible with `FERRET_SANITIZER`.** Sanitizer runtimes require
+  dynamic linking; combining the two hard-errors.
+- **Needs network at configure time.** `FERRET_STATIC=ON` forces the
+  FetchContent path even on a machine that has all four dependencies
+  installed, because a shared `libspdlog.so` cannot be linked into a
+  static binary.
+
+Building against musl, which is what the published release artifacts use,
+needs no toolchain setup beyond Docker:
+
+```sh
+docker run --rm -v "$PWD:/src" -w /src alpine:3.22 sh -c '
+  apk add --no-cache build-base cmake git
+  cmake -S . -B build-static -DFERRET_STATIC=ON -DCMAKE_BUILD_TYPE=Release
+  cmake --build build-static -j"$(nproc)"
+'
+```
+
+`.github/workflows/release.yml` holds the authoritative version of this
+recipe, with a digest-pinned image and the full verification sequence;
+the snippet above is a convenience copy. Confirm the result is static
+with `readelf -l build-static/ferret`. A static binary has no `INTERP`
+program header.
+
+Nix users get the same thing from the flake, built against musl from
+`pkgsStatic` and pinned by `flake.lock`:
+
+```sh
+nix build .#static
+```
+
+That output is Linux-only for the same reason the CMake option is.
+````
+
+- [ ] **Step 2: Add "Prebuilt binaries" to `README.md`**
+
+Insert immediately before the `## Quickstart` heading:
+
+````markdown
+## Prebuilt binaries
+
+Each release publishes binaries for four targets. The two Linux builds
+are fully static against musl. Copy one onto any machine of the right
+architecture and run it, with no toolchain, no Nix, and no matching
+glibc.
+
+```sh
+curl -LO https://github.com/<owner>/ferret/releases/latest/download/ferret-linux-x86_64-musl
+chmod +x ferret-linux-x86_64-musl
+./ferret-linux-x86_64-musl list
+```
+
+`ferret-android-arm64` depends only on on-device bionic.
+`ferret-macos-arm64-dynamic` is dynamically linked, because macOS
+cannot produce a static executable. Verify any download against the release's
+`SHA256SUMS`.
+
+Building from source instead: [`docs/build.md`](docs/build.md).
+````
+
+Replace `<owner>` with the actual GitHub owner, read from `git remote get-url origin`.
+
+- [ ] **Step 3: Update `AGENTS.md`**
+
+Add to the CI workflow table, after the `nix.yml` row:
+
+```markdown
+| `release.yml`    | Static musl builds (linux x86_64 + aarch64), android + macos builds; publishes binaries on `v*` tags |
+```
+
+Add to the Footguns list:
+
+```markdown
+- **`FERRET_STATIC=ON` forces the FetchContent path.** A static configure needs network access even on a machine with all four dependencies installed, because a shared `libspdlog.so` cannot be linked into a static binary. It is also Linux-only and hard-errors when combined with `FERRET_SANITIZER`.
+```
+
+- [ ] **Step 4: Update `docs/android.md`**
+
+Insert after the opening paragraph, before "## Prerequisites":
+
+```markdown
+Cross-compiling is optional. Each release publishes a prebuilt
+`ferret-android-arm64`; download it, `chmod +x`, and skip straight to
+[Stage Binaries On The Device](#stage-binaries-on-the-device). Build
+from source when you need a modified ferret on the phone.
+```
+
+- [ ] **Step 5: Format and lint every touched doc**
+
+```bash
+prettier --write README.md AGENTS.md docs/build.md docs/android.md
+prettier --check '**/*.md'
+markdownlint-cli2 '**/*.md' '#build' '#_deps' '#node_modules' '#docs/superpowers'
+```
+
+Expected: both exit zero. Note that `docs/build.md` now contains a fenced code block inside a section that itself uses fences, so check the nesting rendered correctly by reading the file after prettier runs.
+
+- [ ] **Step 6: Run the full pre-PR gate**
+
+```bash
+./scripts/format.sh
+cmake -S . -B build -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+cmake --build build
+ctest --test-dir build --output-on-failure
+./scripts/test_py.sh
+./scripts/lint.sh
+```
+
+Expected: all six exit zero. This is the gate from `AGENTS.md`; nothing merges without it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add README.md AGENTS.md docs/build.md docs/android.md
+git commit --no-gpg-sign -m "docs: document static builds and prebuilt binaries"
+git push
+```
+
+---
+
+## Verification Summary
+
+What proves this works, and where:
+
+| Claim | Proven by | Where it runs |
+| --- | --- | --- |
+| The Darwin guard fires | Task 1 Step 5 | Locally, macOS only |
+| The sanitizer guard fires | Task 1 Step 5 | Locally, any platform |
+| A static binary links | Task 1 Step 6, `readelf` has no `INTERP` | Local Docker + both CI musl cells |
+| The static binary's tests pass | `ctest` inside Alpine | Local Docker + both CI musl cells |
+| JIT works under static musl | The `ferret run` smoke step | Local Docker + both CI musl cells |
+| The default build is unaffected | Task 1 Step 7 + the untouched `build.yml` matrix | Local + CI |
+| `packages.static` evaluates | Task 2 Steps 4-5 | Locally |
+| `packages.static` **builds** | `nix.yml`, if `nix flake check` builds packages | CI only, unverifiable on macOS |
+| The publish job skips on PRs | Task 5 Step 4 | CI |
+| The publish job **works** | Nothing in this plan | Unverified until a real `v*` tag is cut |
+
+The last two rows are the honest gaps. Publishing is verified only by cutting a release, which is the user's call, not the implementer's.

--- a/docs/superpowers/specs/2026-08-28-static-build-design.md
+++ b/docs/superpowers/specs/2026-08-28-static-build-design.md
@@ -1,0 +1,247 @@
+# Static Build Design
+
+## Goal
+
+Produce a `ferret` binary that can be copied onto a machine you do not
+control, such as a colleague's server, a lab box, or a phone, and run with no
+runtime dependencies and no glibc or libstdc++ version matching. Ship
+those binaries as published release artifacts so the common case is
+downloading one rather than building it.
+
+Two mechanisms serve this, deliberately decoupled:
+
+- `-DFERRET_STATIC=ON`, a CMake option any contributor can use on any
+  Linux, with no Nix and no container required.
+- `packages.static`, a flake output built from `pkgs.pkgsStatic` for
+  Nix users who want a store-pinned static build.
+
+CI's two static cells build with the first; the Android and macOS
+cells set no static flag at all. The second exists for Nix users and
+is validated by `nix flake check`.
+
+## Scope
+
+In scope: a CMake static option, a static flake package, a release
+workflow publishing four artifacts, and the documentation for all
+three.
+
+Out of scope: `-static-pie`, cross-compilation of any kind, a
+`scripts/build_static.sh` wrapper, and any change to the default
+(dynamic) build. `FERRET_STATIC` defaults to OFF; every existing build
+path, CI job, and timing-sensitive workflow is unchanged.
+
+## Platform Reality
+
+The design is shaped by three facts established before it was written.
+
+**Ferret has none of the usual static-linking hazards.** `src/`,
+`include/`, and `benchmarks/` contain no `dlopen`, no `dlsym`, no
+`getaddrinfo`, no `getpwnam`, and no other NSS entry point. The
+failure modes that make static glibc a bad default do not apply here.
+musl is still preferred for the published artifacts, but the choice is
+about binary size and kernel-floor cleanliness, not correctness.
+
+**macOS cannot produce a fully static executable.** Apple ships no
+static libc and no `crt0.o`; both `-static` and `-static-libstdc++`
+fail on Apple Clang. This is not a limitation to engineer around.
+Darwin is excluded from the static path entirely, and its release
+artifact is an ordinary dynamically-linked binary, named so that this
+is obvious to anyone downloading it.
+
+**Android is already close to portable.** The NDK defaults to
+`c++_static`, and bionic is guaranteed present on-device. The Android
+artifact is built with the existing cross-build recipe and does not
+set `FERRET_STATIC`; adding `-static` there would buy almost nothing.
+
+## CMake: FERRET_STATIC
+
+```cmake
+option(FERRET_STATIC "Link ferret fully statically (no runtime dependencies)" OFF)
+```
+
+Declared near the top of `CMakeLists.txt`, before dependency
+resolution. When ON it has four effects.
+
+**Forces the vendored-dependency path.** `_ferret_use_system_deps`
+becomes OFF. A system shared `libspdlog.so` cannot be linked into a
+`-static` binary; FetchContent builds all four dependencies as static
+archives, since `BUILD_SHARED_LIBS` is off by default and
+`gtest_force_shared_crt` is MSVC-only. Android already flips this same
+switch, so `_ferret_use_system_deps` should be computed once from
+`Android OR static` rather than assigned in two places.
+
+**Adds `add_link_options(-static)`.** Directory-scoped, so vendored
+targets and everything under `add_subdirectory(tests)` inherit it.
+This is the same mechanism the sanitizer block already uses, and for
+the same reason. It must appear above the `FetchContent_MakeAvailable`
+calls for that inheritance to hold.
+
+**Hard-errors on Darwin.** The message names the reason, no static
+libc and no `crt0.o`, then points at the Linux path, so the failure is
+self-explanatory rather than a link error.
+
+**Hard-errors when `FERRET_SANITIZER` is also set.** ASan and TSan
+runtimes require dynamic linking. Producing a static binary with
+silently absent instrumentation would be worse than refusing.
+
+`sljit_static` keeps its `-fPIC`; PIC objects link into a non-PIE
+static executable without issue.
+
+## Nix: packages.static
+
+The CMake option and the Nix package must stay decoupled.
+`FERRET_STATIC=ON` forces the FetchContent path, FetchContent needs
+network access, and the Nix sandbox forbids it. Passing the flag from
+a derivation would break the build.
+
+The correct approach changes nothing about how ferret is built and
+instead evaluates the existing derivation in a different package set:
+
+```nix
+sljitStatic = pkgs.pkgsStatic.callPackage ./nix/sljit.nix { src = sljit-src; };
+packages.static = pkgs.pkgsStatic.callPackage ./nix/ferret.nix {
+  sljit = sljitStatic;
+  src = self;
+};
+```
+
+`pkgsStatic`'s stdenv supplies musl and `-static`. Its `spdlog`,
+`gtest`, and `cli11` are static archives that the existing
+`find_package`-first logic in `CMakeLists.txt` resolves without
+modification. `nix/sljit.nix` works unchanged: `$CC` and `$AR` become
+the musl-static wrappers. `doCheck = true` is inherited, so ctest runs
+against the static binary as part of the build.
+
+Guarded with `lib.optionalAttrs pkgs.stdenv.isLinux`, since
+`eachDefaultSystem` also covers `x86_64-darwin` and `aarch64-darwin`
+where `pkgsStatic` cannot deliver a fully static executable.
+
+Expected outcome: `nix/ferret.nix` and `nix/sljit.nix` are untouched;
+the change is confined to `flake.nix`.
+
+## CI: release.yml
+
+A new workflow with four build cells and one publish job.
+
+| Artifact                      | Runner             | Method                       |
+| ----------------------------- | ------------------ | ---------------------------- |
+| `ferret-linux-x86_64-musl`    | `ubuntu-latest`    | Alpine, `-DFERRET_STATIC=ON` |
+| `ferret-linux-aarch64-musl`   | `ubuntu-24.04-arm` | Alpine, `-DFERRET_STATIC=ON` |
+| `ferret-android-arm64`        | `ubuntu-latest`    | existing NDK recipe          |
+| `ferret-macos-arm64-dynamic`  | `macos-latest`     | native Release build         |
+
+The macOS artifact carries `-dynamic` in its name deliberately, and
+the release body states that it is the one artifact without the
+no-runtime-dependencies guarantee.
+
+### Alpine runs under docker run, not container:
+
+A job-level `container: alpine` does not work. The Actions runner
+injects its own glibc-linked Node into job containers to execute
+`actions/checkout`, and Alpine has no glibc, so the job fails before
+compiling anything. Installing `nodejs` inside the image does not
+address this.
+
+Alpine is therefore invoked as an ordinary step. Checkout, artifact
+upload, and every other action run on the glibc host; only the compile
+and test run in the container:
+
+```sh
+docker run --rm -v "$PWD:/src" -w /src alpine:3.22 sh -c '
+  apk add --no-cache build-base cmake ninja git
+  cmake -S . -B build-static -GNinja -DFERRET_STATIC=ON -DCMAKE_BUILD_TYPE=Release
+  cmake --build build-static
+  ...'
+```
+
+The tag above is illustrative. The workflow pins the image by digest
+with a trailing version comment, mirroring how the repository pins
+GitHub Actions.
+
+This also keeps the arm64 cell honest: `alpine` resolves to the native
+arm64 image on `ubuntu-24.04-arm`, so there is no qemu emulation and
+no cross-compilation anywhere in the design.
+
+Files written inside the container are root-owned. The host needs a
+`chown` before `upload-artifact`.
+
+### Verification and testing per cell
+
+Assert the absence of a dynamic-loader program header rather than
+parsing `file` or `ldd` output:
+
+```sh
+readelf -l build-static/ferret | grep -q INTERP && { echo "not static"; exit 1; }
+```
+
+`readelf` is already present in `build-base`.
+
+`ctest` runs inside the container for both Linux cells and natively on
+macOS. The Android cell builds only; its binaries cannot execute on
+the host, matching the existing `android-cross-build` job.
+
+Both static cells additionally perform one real benchmark run, a
+minimal-reps `ferret run dependent_chain_throughput`. ctest proves the
+binary starts; only a real run proves sljit's `mmap` of executable
+pages still works under static musl. This is the highest-value single
+check in the workflow.
+
+### Triggers and publishing
+
+- `pull_request` against `main`: all four cells build, verify, and
+  test, uploading with `retention-days: 7`. No release. This is what
+  keeps the static path from rotting between releases.
+- `push` of a `v*` tag: the same four cells, then publish.
+- `workflow_dispatch`: build on demand.
+
+The publish job is gated on `needs: build` and
+`if: startsWith(github.ref, 'refs/tags/v')`. It downloads all four
+artifacts, generates `SHA256SUMS`, and creates the release with `gh`
+rather than a third-party action: no new dependency to pin and audit,
+and less for `zizmor.yml` to object to. `contents: write` is scoped to
+that job alone; the workflow default remains `contents: read`.
+
+Repository conventions apply throughout: actions pinned to a SHA with
+a trailing version comment, `persist-credentials: false` on checkout,
+a `concurrency` group, and `timeout-minutes` on every job.
+
+## Documentation
+
+- `docs/build.md`: a `-DFERRET_STATIC=ON|OFF` row in the CMake-knobs
+  table, and a "Static builds" section covering the Linux-only
+  constraint, the sanitizer mutual-exclusion, the Alpine recipe, and
+  `nix build .#static`. The section names `release.yml` as the
+  authoritative copy of the recipe.
+- `README.md`: a "Prebuilt binaries" pointer to Releases. Downloading
+  a binary is now the common path and belongs on the front page.
+- `AGENTS.md`: `release.yml` added to the CI-gates table, plus a
+  footgun entry: `FERRET_STATIC=ON` forces the FetchContent path, so a
+  static configure requires network access even on a machine that has
+  all four dependencies installed.
+- `docs/android.md`: note that `ferret-android-arm64` is downloadable,
+  making the cross-build section optional rather than mandatory.
+
+No `scripts/build_static.sh`. The recipe lives in `release.yml` and is
+quoted in `docs/build.md`, which points back at the workflow as
+authoritative.
+
+## Risks
+
+**`nix flake check` may build `packages.static`.** If it does, every
+PR pays the `pkgsStatic` build cost in `nix.yml`. Binary-cache
+coverage for `x86_64-linux` `pkgsStatic` is expected to make this
+tolerable, but the behaviour and the cost must be measured during
+implementation rather than assumed. If it is slow, the response is to
+raise `timeout-minutes`, not to hide the package from the check. An
+unchecked flake output is the failure mode this design is trying to
+avoid elsewhere.
+
+**Default-PIE toolchains.** On distributions whose GCC specs force
+`-pie`, `-static` can require an explicit `-no-pie` alongside it.
+Alpine is not expected to need this; a contributor's host distribution
+might.
+
+**Recipe drift.** With no wrapper script, the Alpine recipe exists in
+`release.yml` and is quoted in `docs/build.md`. The documentation
+names the workflow as authoritative to contain this, but the two can
+still fall out of sync.

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
       system: let
         pkgs = nixpkgs.legacyPackages.${system};
         sljit = pkgs.callPackage ./nix/sljit.nix {src = sljit-src;};
+        sljitStatic = pkgs.pkgsStatic.callPackage ./nix/sljit.nix {src = sljit-src;};
       in {
         formatter = pkgs.nixfmt-rfc-style;
 
@@ -74,10 +75,27 @@
             '';
           };
 
-        packages.default = pkgs.callPackage ./nix/ferret.nix {
-          inherit sljit;
-          src = self;
-        };
+        packages =
+          {
+            default = pkgs.callPackage ./nix/ferret.nix {
+              inherit sljit;
+              src = self;
+            };
+          }
+          # pkgsStatic is musl + -static on Linux. On Darwin it cannot
+          # produce a fully static executable (no static libc, no
+          # crt0.o), so the output is Linux-only. Note this deliberately
+          # does NOT pass -DFERRET_STATIC=ON: that option forces the
+          # FetchContent path, which needs network access the Nix
+          # sandbox does not grant. pkgsStatic's stdenv supplies the
+          # static linking, and its spdlog/gtest/cli11 are .a archives
+          # the existing find_package path resolves unchanged.
+          // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+            static = pkgs.pkgsStatic.callPackage ./nix/ferret.nix {
+              sljit = sljitStatic;
+              src = self;
+            };
+          };
       }
     );
 }

--- a/include/ferret/bench_helpers.hpp
+++ b/include/ferret/bench_helpers.hpp
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <vector>


### PR DESCRIPTION
## What

Adds a fully static build of `ferret` and a workflow that publishes prebuilt binaries, so the tool can be dropped onto a machine you do not control (a lab box, a colleague's server, a phone) and run without a toolchain, without Nix, and without matching glibc or libstdc++ versions.

Two deliberately decoupled mechanisms:

- **`-DFERRET_STATIC=ON`**, a CMake option any contributor can use on any Linux. It forces the FetchContent dependency path, because a shared `libspdlog.so` cannot be linked into a `-static` binary, adds `-static`, and hard-errors on Darwin and against `FERRET_SANITIZER`.
- **`packages.static`**, a Linux-only flake output built under `pkgsStatic`, which supplies musl and `-static` from its own stdenv. It pointedly does **not** set `FERRET_STATIC`: that option needs network for FetchContent, and the Nix sandbox forbids it. Keeping the two mechanisms separate is load-bearing, not an oversight.

`release.yml` builds four targets and, on a `v*` tag, attaches them plus `SHA256SUMS` to a GitHub Release.

| Artifact | Runtime dependencies |
| --- | --- |
| `ferret-linux-x86_64-musl` | none, fully static |
| `ferret-linux-aarch64-musl` | none, fully static |
| `ferret-android-arm64` | on-device bionic only |
| `ferret-macos-arm64-dynamic` | dynamically linked against the macOS SDK |

macOS is the exception on purpose. Apple ships no static libc and no `crt0.o`, so a fully static executable cannot be linked there. The artifact name says so, and the release notes repeat it.

## Why some things look the way they do

**`readelf` output goes to a file before `grep` reads it.** This is not an accident and should not be "simplified" into a pipeline. Without `pipefail`, `readelf … | grep -q INTERP` hides a `readelf` failure: `grep` finds nothing and the binary is reported as *static*, a false pass. Writing to a file first lets `set -e` catch the real failure.

**Alpine runs via `docker run`, not `container:`.** The Actions runner injects a glibc-linked Node into job containers to execute `actions/checkout`, and Alpine has no glibc, so a `container:` job dies before compiling anything. Checkout and upload stay on the host; only the compile and test run in musl.

**The Alpine image is digest-pinned to a multi-arch index**, so the same pin resolves natively on both the x86_64 and arm64 runners with no qemu and no cross-compilation anywhere in the design.

**Each Linux cell runs a real benchmark, not just `ctest`.** `ctest` proves the binary starts. Only a real `ferret run` proves sljit's `mmap` of executable pages still works under static musl, which is the most likely thing to break.

**`nix flake check` only evaluates packages, it never builds them.** Without the added `nix build .#static` step, `packages.static` would ship built by nothing. The `nix` job's timeout rises to 120 minutes because `pkgsStatic` binary-cache coverage is patchy.

## What is verified, and what is not

Verified locally: the CMake guards fire correctly, the default dynamic build is untouched (203/203 ctest, 139/139 pytest, `lint.sh` clean), the flake's Linux outputs evaluate, and both workflows parse.

**Not verified anywhere, and this is the main thing to watch on the first CI run.** `FERRET_STATIC=ON` hard-errors on Darwin by design, and the development machine had no container runtime and no Nix Linux builder. So the musl link itself, `-static` under Alpine's default-PIE GCC, sljit's `mmap(PROT_EXEC)` under static musl, the `pkgsStatic` build, and the entire publish path have **never executed**. This PR's own `pull_request` trigger is the first time any of it runs.

Two specific predictions:

1. All three release cells compile at `Release` with `-Werror`, which no existing job does. `build.yml` uses an empty build type, and `benchmarks.yml` builds Release but only `--target ferret`. GCC's `-Wmaybe-uninitialized`, `-Wstringop-overflow` and friends only activate under optimization. A red musl cell here is a real warning, not flakiness.
2. `nix build .#static` on a cold `pkgsStatic` cache could be slow. If it exceeds 120 minutes, raise the timeout rather than dropping the step.

Also unconfirmed: the design assumes `doCheck` runs ctest under `pkgsStatic`. That depends on how nixpkgs gates `doCheck` for a same-arch cross build. If it is silently skipped, `nix build .#static` is a compile check only, which is worth confirming from the first log.

## CI cost

This adds four build cells per pull request. The Android and macOS cells substantially duplicate work `build.yml` already does on the same trigger, at roughly 10 to 25 runner-minutes per PR, and none of the new cells use ccache. That was an accepted trade for keeping the release path continuously exercised rather than discovering it broken at tag time. Gating those two cells to tags only would recover most of it if the cost proves annoying.

## Commit convention change

One commit in this branch amends `AGENTS.md`. The file previously banned AI tool names everywhere including footers, which now conflicts with the `Assisted-by:` trailer every commit here carries. The rule is narrowed so that trailer is the single permitted place for a tool name; `Co-Authored-By:` footers stay forbidden. Every commit also carries `Signed-off-by:` via `git commit -s`.

## Deferred

- Uploaded artifact filenames (`ferret-linux-*`) are written to the repo root and are not covered by `.gitignore`.
- `gh release create` errors if a release already exists for the tag. Loud, no data loss.
- The `locate Android NDK` step is byte-identical to the one in `build.yml`. A composite action would deduplicate it, but that means editing a currently-green workflow and was left out of this change.
- There is no runnable local equivalent of the binary verification. `docs/build.md` describes the `readelf` check in prose only.