### PR TITLE
feat(bench): add store-to-load elimination benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -89,3 +89,23 @@ jobs:
           name: ${{ matrix.label }}-branch_history_footprint.html
           path: benchmark-results/${{ matrix.label }}/${{ matrix.label }}-branch_history_footprint.html
           archive: false
+
+      - name: upload store_load_footprint html
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ matrix.label }}-store_load_footprint.html
+          path: benchmark-results/${{ matrix.label }}/${{ matrix.label }}-store_load_footprint.html
+          archive: false
+      - name: upload store_load_distance html
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ matrix.label }}-store_load_distance.html
+          path: benchmark-results/${{ matrix.label }}/${{ matrix.label }}-store_load_distance.html
+          archive: false
+
+      - name: upload store_load_overlap html
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ matrix.label }}-store_load_overlap.html
+          path: benchmark-results/${{ matrix.label }}/${{ matrix.label }}-store_load_overlap.html
+          archive: false

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 build/
+build-*/
 _deps/
 node_modules/
 # Frozen agent-generated plan/spec artifacts — preserve verbatim.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,8 +251,10 @@ target_compile_features(ferret_core PUBLIC cxx_std_20)
 # Benchmark TUs compiled once; both the ferret executable and benchmark-
 # specific tests reuse the resulting object files.
 add_library(
-  ferret_benchmarks OBJECT benchmarks/branch_history_footprint.cpp benchmarks/direct_branch_footprint.cpp
-                           benchmarks/nested_call_depth.cpp benchmarks/dependent_chain_throughput.cpp
+  ferret_benchmarks OBJECT
+  benchmarks/branch_history_footprint.cpp benchmarks/direct_branch_footprint.cpp benchmarks/nested_call_depth.cpp
+  benchmarks/dependent_chain_throughput.cpp benchmarks/store_load_footprint.cpp benchmarks/store_load_distance.cpp
+  benchmarks/store_load_overlap.cpp
 )
 target_link_libraries(ferret_benchmarks PRIVATE ferret_core sljit::sljit ferret_warnings)
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ CLI flags and axis syntax: [`docs/cli.md`](docs/cli.md).
 | [`direct_branch_footprint`](docs/benchmarks/direct_branch_footprint.md)       | direct-jump BTB capacity                        |
 | [`nested_call_depth`](docs/benchmarks/nested_call_depth.md)                   | Return Address Stack (RAS) depth                |
 | [`branch_history_footprint`](docs/benchmarks/branch_history_footprint.md)     | conditional-branch direction-predictor capacity |
+| [`store_load_footprint`](docs/benchmarks/store_load_footprint.md)             | store-to-load forward latency                   |
+| [`store_load_distance`](docs/benchmarks/store_load_distance.md)               | store-to-load separation window                 |
+| [`store_load_overlap`](docs/benchmarks/store_load_overlap.md)                 | store-to-load address/width match conditions    |
 
 Each benchmark page has the kernel structure, CLI surface, and reading-the-curves guide.
 

--- a/benchmarks/store_load_distance.cpp
+++ b/benchmarks/store_load_distance.cpp
@@ -1,0 +1,256 @@
+extern "C" {
+#include <sljitLir.h>
+}
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "ferret/bench_helpers.hpp"
+#include "ferret/benchmark.hpp"
+
+namespace ferret {
+
+namespace {
+
+constexpr size_t kOpBudget = 20'000'000;
+
+// The emitted loop body is held to a roughly constant *instruction*
+// count rather than a constant link count, so sweeping `separation` or
+// `alu_ops` does not also sweep the L1I footprint. Getting this wrong
+// makes instruction-cache pressure masquerade as a distance effect.
+constexpr size_t kBodyInsns = 4096;
+
+// Chain slot, placed mid-cache-line so nothing here straddles a line.
+constexpr sljit_sw kSlot = 576;
+// Filler stores and loads live well clear of the chain slot, one per
+// 128-byte line, so they cannot contend with the line under test.
+constexpr sljit_sw kFillerMem = 8192;
+constexpr sljit_sw kFillerStride = 128;
+
+// See kMaxLocalOffset in store_load_footprint.cpp: an 8-byte-aligned
+// AArch64 LDR/STR immediate reaches 32760, less the 16-byte
+// SLJIT_LOCALS_OFFSET_BASE. Filler memory ops must stay inside it too.
+constexpr sljit_sw kMaxLocalOffset = 32744;
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+constexpr bool kUniformInsnWidth = true;
+constexpr size_t kInsnBytes = 4;
+#elif defined(__x86_64__) || defined(_M_X64)
+constexpr bool kUniformInsnWidth = false;
+constexpr size_t kInsnBytes = 0;
+#else
+#error "ferret supports only x86_64 and aarch64"
+#endif
+
+// What sits between the store and the load. Every kind occupies exactly
+// one instruction, so `separation` is both an instruction count and the
+// emitted byte stride divided by kInsnBytes.
+enum class Filler : uint8_t {
+  Alu = 0,       // independent ADD, rotating destinations
+  Nop = 1,       // occupies a slot and nothing else
+  Store = 2,     // independent store, distinct address per position
+  Load = 3,      // independent load from a never-stored region
+  Branch = 4,    // taken branch to the next instruction: ends a fetch block
+  BaseWrite = 5  // rewrites the address base register with its own value
+};
+
+constexpr int64_t kFillerMin = 0;
+constexpr int64_t kFillerMax = 5;
+
+// Rotating destinations for the filler ops. A single shared destination
+// makes loads look artificially cheap and skews the whole curve.
+constexpr sljit_s32 kAcc = SLJIT_R0;
+constexpr sljit_s32 kTmp = SLJIT_R1;
+constexpr sljit_s32 kCounter = SLJIT_R2;
+constexpr sljit_s32 kConst = SLJIT_R3;
+constexpr sljit_s32 kBase = SLJIT_R4;
+constexpr sljit_s32 kFillFirst = SLJIT_R5;
+constexpr size_t kFillRegs = 8;
+constexpr sljit_s32 kScratches = 5 + static_cast<sljit_s32>(kFillRegs);
+
+struct KernelParams {
+  size_t separation;
+  size_t alu_ops;
+  Filler filler;
+};
+
+// A BaseWrite filler has to have a base register it may legally write,
+// so those rows address the chain slot through a general register.
+bool needs_gpr_base(Filler f) { return f == Filler::BaseWrite; }
+
+KernelParams validated_params(const Params& p) {
+  auto separation = p.get<int64_t>("separation");
+  auto filler = p.get<int64_t>("filler");
+  auto alu_ops = p.get<int64_t>("alu_ops");
+
+  if (separation < 0) {
+    throw std::invalid_argument("separation=" + std::to_string(separation) + " must be >= 0");
+  }
+  if (filler < kFillerMin || filler > kFillerMax) {
+    throw std::invalid_argument("filler=" + std::to_string(filler) +
+                                " must be 0 (alu), 1 (nop), 2 (store), 3 (load), 4 (branch) or 5 (base_write)");
+  }
+  if (alu_ops < 1) {
+    throw std::invalid_argument("alu_ops=" + std::to_string(alu_ops) +
+                                ": the chain needs at least one ALU op to carry the loaded value back to the "
+                                "store's source register without the two registers coinciding");
+  }
+  sljit_sw max_filler_off = kFillerMem + (static_cast<sljit_sw>(separation) * kFillerStride);
+  if (max_filler_off > kMaxLocalOffset) {
+    throw std::invalid_argument("separation=" + std::to_string(separation) + " needs a filler offset of " +
+                                std::to_string(max_filler_off) + ", past the " + std::to_string(kMaxLocalOffset) +
+                                "-byte single-instruction addressing window; lower separation");
+  }
+  return {.separation = static_cast<size_t>(separation),
+          .alu_ops = static_cast<size_t>(alu_ops),
+          .filler = static_cast<Filler>(filler)};
+}
+
+size_t insns_per_link(const KernelParams& k) { return 1 + k.separation + 1 + k.alu_ops; }
+
+size_t link_repeats(const KernelParams& k) { return compute_iterations(kBodyInsns, insns_per_link(k)); }
+
+}  // namespace
+
+// A serial dependent chain whose store and load are pushed `separation`
+// instructions apart:
+//
+//   str  x0, [base, #slot]
+//   <separation filler instructions>
+//   ldr  x3, [base, #slot]
+//   add  x0, x3, #1
+//   <alu_ops-1 further adds>
+//
+// The chain is store-data -> load-result -> ALU -> next store-data, so
+// the per-link cost is the forward latency plus `alu_ops`. Subtracting
+// alu_ops leaves the forward cost on its own.
+//
+// A core that resolves the load when the two are adjacent, but not when
+// they are a few instructions apart, produces a curve that is fast at
+// separation 0, worst at 1, and recovers as separation grows. Where it
+// returns to zero measures the width of whatever window the mechanism
+// needs the pair to fall outside of.
+//
+// `filler` asks whether the *kind* of intervening instruction matters or
+// only the count. Instructions that end a fetch block (taken branches)
+// can behave differently from ones that merely occupy a slot, and
+// `base_write` tests whether rewriting the address base register — with
+// its own value, so the address is unchanged — invalidates the match.
+//
+// This benchmark deliberately does not vary how many store/load pairs
+// are in flight at once; the chain is serial, so exactly one is. Probing
+// the capacity of the tracking structure needs a different kernel.
+struct StoreLoadDistance : Benchmark {
+  std::vector<sljit_label*> link_labels_;
+  size_t link_bytes_ = 0;
+
+  [[nodiscard]] std::string name() const override { return "store_load_distance"; }
+
+  // `separation` is linear, not geometric: the interesting structure is
+  // a handful of instructions wide, so every integer step matters and a
+  // log2 sweep would step straight over it.
+  [[nodiscard]] SweepAxes axes() const override {
+    return {
+        Axis::range("separation", 0, 16),
+        Axis::values("filler", {0, 1, 2, 3, 4, 5}),
+    };
+  }
+
+  // alu_ops buys a latency shadow for the filler work to hide in, so the
+  // measurement stays latency-bound rather than issue-bound. It is also
+  // the calibration knob: cost must move by exactly one cycle per added
+  // op, and a slope that is not 1.0 means the chain is not serial.
+  [[nodiscard]] BenchOptions options() const override { return {BenchOption{.name = "alu_ops", .default_value = 16}}; }
+
+  [[nodiscard]] size_t sites_per_kernel(const Params& p) const override { return link_repeats(validated_params(p)); }
+
+  [[nodiscard]] size_t iterations(const Params& p) const override {
+    return compute_iterations(kOpBudget, sites_per_kernel(p) * insns_per_link(validated_params(p)));
+  }
+
+  void emit_kernel(sljit_compiler* c, const Params& p) override {
+    auto k = validated_params(p);
+    size_t repeats = link_repeats(k);
+    size_t iters = iterations(p);
+    auto local_size = static_cast<sljit_s32>(kFillerMem + (static_cast<sljit_sw>(k.separation + 1) * kFillerStride));
+
+    sljit_emit_enter(c, 0, SLJIT_ARGS0V(), kScratches, 0, local_size);
+    sljit_emit_op1(c, SLJIT_MOV, kAcc, 0, SLJIT_IMM, 1);
+    sljit_emit_op1(c, SLJIT_MOV, kConst, 0, SLJIT_IMM, 7);
+    // SLJIT_SP is only legal as MEM1(SLJIT_SP), so a filler that writes
+    // the base needs an addressable copy of it.
+    sljit_get_local_base(c, kBase, 0, 0);
+    const sljit_s32 base = needs_gpr_base(k.filler) ? kBase : SLJIT_SP;
+
+    link_labels_.clear();
+    link_bytes_ = (2 + k.separation + k.alu_ops) * kInsnBytes;
+
+    emit_outer_loop(c, kCounter, iters, [&] {
+      for (size_t r = 0; r < repeats; ++r) {
+        if constexpr (kUniformInsnWidth) {
+          link_labels_.push_back(sljit_emit_label(c));
+        }
+        sljit_emit_op1(c, SLJIT_MOV, SLJIT_MEM1(base), kSlot, kAcc, 0);
+        for (size_t i = 0; i < k.separation; ++i) {
+          emit_filler(c, k.filler, i);
+        }
+        sljit_emit_op1(c, SLJIT_MOV, kTmp, 0, SLJIT_MEM1(base), kSlot);
+        sljit_emit_op2(c, SLJIT_ADD, kAcc, 0, kTmp, 0, SLJIT_IMM, kChainCarryImm);
+        for (size_t a = 1; a < k.alu_ops; ++a) {
+          sljit_emit_op2(c, SLJIT_ADD, kAcc, 0, kAcc, 0, SLJIT_IMM, kChainCarryImm);
+        }
+      }
+    });
+
+    sljit_emit_return_void(c);
+  }
+
+  // Every filler kind is one instruction, so a link is exactly
+  // (2 + separation + alu_ops) instructions. sljit silently re-bases with
+  // an extra ADDI once an offset leaves the single-instruction window,
+  // and a taken branch could in principle be encoded differently; this
+  // turns either into a failed row rather than a quietly inflated one.
+  void verify_layout(sljit_compiler* c) override {
+    (void)c;
+    if constexpr (kUniformInsnWidth) {
+      verify_uniform_spacing(link_labels_, link_bytes_, /*strict=*/true, "store_load_distance");
+    }
+  }
+
+ private:
+  static void emit_filler(sljit_compiler* c, Filler f, size_t i) {
+    auto dst = static_cast<sljit_s32>(kFillFirst + (i % kFillRegs));
+    auto off = static_cast<sljit_sw>(kFillerMem + (static_cast<sljit_sw>(i) * kFillerStride));
+    switch (f) {
+      case Filler::Alu:
+        sljit_emit_op2(c, SLJIT_ADD, dst, 0, kConst, 0, SLJIT_IMM, 1);
+        break;
+      case Filler::Nop:
+        sljit_emit_op0(c, SLJIT_NOP);
+        break;
+      case Filler::Store:
+        sljit_emit_op1(c, SLJIT_MOV, SLJIT_MEM1(SLJIT_SP), off, kConst, 0);
+        break;
+      case Filler::Load:
+        sljit_emit_op1(c, SLJIT_MOV, dst, 0, SLJIT_MEM1(SLJIT_SP), off);
+        break;
+      case Filler::Branch: {
+        sljit_jump* j = sljit_emit_jump(c, SLJIT_JUMP);
+        sljit_set_label(j, sljit_emit_label(c));
+        break;
+      }
+      case Filler::BaseWrite:
+        // Adding zero leaves the address untouched but still writes the
+        // architectural register the store and load are addressing through.
+        sljit_emit_op2(c, SLJIT_ADD, kBase, 0, kBase, 0, SLJIT_IMM, 0);
+        break;
+    }
+  }
+};
+
+FERRET_BENCHMARK("store_load_distance", StoreLoadDistance);
+
+}  // namespace ferret

--- a/benchmarks/store_load_footprint.cpp
+++ b/benchmarks/store_load_footprint.cpp
@@ -1,0 +1,279 @@
+extern "C" {
+#include <sljitLir.h>
+}
+
+#include <algorithm>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "ferret/bench_helpers.hpp"
+#include "ferret/benchmark.hpp"
+
+namespace ferret {
+
+namespace {
+
+constexpr size_t kOpBudget = 20'000'000;
+
+// Links emitted per outer-loop iteration, held constant across the
+// `addresses` axis by repeating the address rotation. Without this,
+// addresses=1 would be three instructions inside a loop and the loop
+// overhead would swamp the per-link measurement.
+constexpr size_t kUnrollLinks = 512;
+
+// Ceiling on the emitted loop body, in instructions. kUnrollLinks alone
+// fixes the *link* count, so the body would grow without bound as
+// alu_ops rises -- at alu_ops=64 that is 33 792 instructions, 132 KB,
+// closing on the 192 KB L1I of an M4 P-core. Capping the repeat count
+// keeps instruction-cache pressure out of the measurement. The cap only
+// binds for alu_ops above ~5, so the default sweep is unaffected.
+constexpr size_t kMaxBodyInsns = 8192;
+
+// Every store and load moves one machine word.
+constexpr size_t kWordBytes = 8;
+
+// AArch64 encodes an 8-byte-aligned LDR/STR immediate offset in 12 bits
+// scaled by 8, so a single instruction reaches offset <= 32760 (see
+// emit_op_mem in sljit's sljitNativeARM_64.c). Past that sljit silently
+// prepends an ADDI to re-base, which inflates the per-link instruction
+// count and therefore the measured latency. SLJIT_SP-relative offsets
+// additionally carry SLJIT_LOCALS_OFFSET_BASE (16 bytes on AArch64), so
+// the usable window for the offsets we choose is 32744.
+//
+// Applied on x86_64 too, where disp32 imposes no comparable limit. Both
+// architectures then sweep an identical parameter space and their CSVs
+// stay directly comparable.
+constexpr size_t kMaxLocalOffset = 32744;
+
+// Whether every instruction in a link occupies the same number of bytes.
+// True on AArch64 (fixed 4-byte encoding), which lets verify_layout
+// assert an exact per-link byte stride and so catch any extra
+// instruction sljit slipped in. False on x86_64, where LDR/STR
+// displacement width varies with the offset (disp8 vs disp32) and a
+// uniform stride does not hold by construction.
+#if defined(__aarch64__) || defined(_M_ARM64)
+constexpr bool kUniformInsnWidth = true;
+constexpr size_t kInsnBytes = 4;
+#elif defined(__x86_64__) || defined(_M_X64)
+constexpr bool kUniformInsnWidth = false;
+constexpr size_t kInsnBytes = 0;
+#else
+#error "ferret supports only x86_64 and aarch64"
+#endif
+
+// Instructions in one link: the store, the load, and the carry ops.
+size_t insns_per_link(size_t alu_ops) { return 2 + alu_ops; }
+
+// Address rotation repeats: enough to fill kUnrollLinks links, but never
+// so many that the loop body outgrows kMaxBodyInsns.
+size_t link_repeats(size_t addresses, size_t alu_ops) {
+  size_t by_links = compute_iterations(kUnrollLinks, addresses);
+  size_t by_insns = compute_iterations(kMaxBodyInsns, addresses * insns_per_link(alu_ops));
+  return std::max<size_t>(1, std::min(by_links, by_insns));
+}
+
+// One validated parameter point.
+struct KernelParams {
+  size_t addresses;
+  size_t stride;
+  size_t alu_ops;
+  int64_t base_sel;
+};
+
+// Reads and validates a parameter point. Kept out of emit_kernel so
+// every rejection happens before the caller touches the compiler and no
+// partial sljit state can survive a bad point.
+KernelParams validated_params(const Params& p) {
+  auto addresses = p.get<size_t>("addresses");
+  auto stride = p.get<size_t>("stride_bytes");
+  // Read as signed so a negative override is rejected here with a
+  // benchmark-specific message rather than by Params::get<size_t>.
+  auto alu_ops = p.get<int64_t>("alu_ops");
+  auto base_sel = p.get<int64_t>("base_reg");
+
+  if (addresses == 0) {
+    throw std::invalid_argument("addresses=0: the chain needs at least one address");
+  }
+  if (stride < kWordBytes || stride % kWordBytes != 0) {
+    throw std::invalid_argument("stride_bytes=" + std::to_string(stride) + " must be a positive multiple of " +
+                                std::to_string(kWordBytes));
+  }
+  if (base_sel < 0 || base_sel > 3) {
+    throw std::invalid_argument("base_reg=" + std::to_string(base_sel) +
+                                " must be 0 (sp/sp), 1 (gpr/gpr), 2 (sp store, gpr load) or 3 (gpr store, sp load)");
+  }
+  // With no ALU op there is nothing to carry the loaded value back into
+  // the store's source register, so the link would have to load straight
+  // into that register. That is a structurally different kernel — the
+  // stored value then never changes, and the store's data register and
+  // the load's destination register coincide — so it cannot serve as the
+  // alu_ops=0 point of this benchmark's line. Measured on an M4 Pro that
+  // variant runs ~4.8 cycles per link against ~2.0 for alu_ops=1, which
+  // is exactly the confusion this rejection exists to prevent.
+  if (alu_ops < 1) {
+    throw std::invalid_argument("alu_ops=" + std::to_string(alu_ops) +
+                                ": the chain needs at least one ALU op to carry the loaded value back to the "
+                                "store's source register without the two registers coinciding");
+  }
+  size_t max_offset = (addresses - 1) * stride;
+  if (max_offset > kMaxLocalOffset) {
+    throw std::invalid_argument("addresses=" + std::to_string(addresses) + " x stride_bytes=" + std::to_string(stride) +
+                                " needs offset " + std::to_string(max_offset) + ", past the " +
+                                std::to_string(kMaxLocalOffset) +
+                                "-byte single-instruction addressing window; lower either axis");
+  }
+  return {.addresses = addresses, .stride = stride, .alu_ops = static_cast<size_t>(alu_ops), .base_sel = base_sel};
+}
+
+}  // namespace
+
+// A strictly serial dependent chain threaded through memory, rotating
+// over `addresses` distinct stack slots:
+//
+//   str  x0, [base, #i*stride]     ; store the chain value
+//   ldr  x3, [base, #i*stride]     ; read it back
+//   add  x0, x3, #1                ; carry it to the next link
+//
+// Every link is store-data -> load-result -> ALU -> next store-data, so
+// the per-link cost is the machine's store-to-load forward latency plus
+// `alu_ops`. A core that resolves the load at rename time (memory
+// renaming) pays only the ALU op; a core that forwards through the
+// store queue pays its full forwarding latency.
+//
+// Sweeping `addresses` separates "the mechanism only recognizes a
+// repeat of the immediately preceding store" from "it handles an
+// arbitrary rotating set of slots", and `stride_bytes` separates
+// per-address handling from line- or page-granular handling. The whole
+// default sweep stays L1D-resident by construction (max footprint
+// 32 KB, see kMaxLocalOffset), so no feature of the curve can be a
+// cache-capacity effect.
+//
+// Neither axis probes the *capacity* of whatever tracks store/load
+// pairs. The chain is serial, so exactly one pair is ever in flight and
+// there is nothing to exhaust; rotating the address changes which slot
+// is used, not how many pairs are tracked at once. A capacity probe
+// needs concurrently live pairs — independent interleaved chains, one
+// register per chain — which is a different kernel.
+//
+// `base_reg` selects which register name the store and the load each use
+// to reach the one address:
+//
+//   0  str [sp,#i]  / ldr [sp,#i]
+//   1  str [xN,#i]  / ldr [xN,#i]    xN copied from SP via sljit_get_local_base
+//   2  str [sp,#i]  / ldr [xN,#i]    same bytes, different register NAME
+//   3  str [xN,#i]  / ldr [sp,#i]
+//
+// All four address identical bytes with identical offsets and an
+// identical instruction count. Forms 0 and 1 say whether the stack
+// pointer is special. Forms 2 and 3 are the sharper test: xN provably
+// holds exactly SP, so if they behave differently from 0 and 1 the
+// hardware is matching on the register NAME rather than on the computed
+// address — i.e. the comparison happens before any address exists.
+struct StoreLoadFootprint : Benchmark {
+  // Captured at emit time, consumed by verify_layout() once
+  // sljit_generate_code has populated label addresses. Only populated
+  // when kUniformInsnWidth.
+  std::vector<sljit_label*> link_labels_;
+  size_t link_bytes_ = 0;
+
+  [[nodiscard]] std::string name() const override { return "store_load_footprint"; }
+
+  [[nodiscard]] SweepAxes axes() const override {
+    return {
+        Axis::geom_range("addresses", 1, 1 << 8, /*samples_per_octave=*/1),
+        Axis::log2_range("stride_bytes", 8, 128),
+        Axis::values("base_reg", {0, 1, 2, 3}),
+    };
+  }
+
+  // alu_ops is a calibration knob: each additional ALU op must lengthen
+  // the chain by exactly one cycle. Fitting cycles-per-link against
+  // alu_ops recovers the forward latency as the intercept, and a slope
+  // that is not 1.0 means the chain is not serial and the rest of the
+  // row means nothing. One op is the floor — see the rejection in
+  // validated_params.
+  [[nodiscard]] BenchOptions options() const override { return {BenchOption{.name = "alu_ops", .default_value = 1}}; }
+
+  [[nodiscard]] size_t sites_per_kernel(const Params& p) const override {
+    auto k = validated_params(p);
+    return k.addresses * link_repeats(k.addresses, k.alu_ops);
+  }
+
+  [[nodiscard]] size_t iterations(const Params& p) const override {
+    return compute_iterations(kOpBudget, sites_per_kernel(p));
+  }
+
+  void emit_kernel(sljit_compiler* c, const Params& p) override {
+    // Validate before any sljit state changes — a bad point must leave
+    // no partial compiler state behind.
+    auto [addresses, stride, alu_ops, base_sel] = validated_params(p);
+
+    size_t repeats = link_repeats(addresses, alu_ops);
+    size_t iters = iterations(p);
+    auto local_size = static_cast<sljit_s32>(addresses * stride);
+
+    // R0 chain value, R1 outer-loop counter, R2 general base register,
+    // R3 load destination.
+    sljit_emit_enter(c, 0, SLJIT_ARGS0V(), 4, 0, local_size);
+    sljit_emit_op1(c, SLJIT_MOV, SLJIT_R0, 0, SLJIT_IMM, 1);
+
+    // R2 holds exactly what SLJIT_SP holds. Hoisted out of the loop so
+    // every base_reg form emits an instruction-for-instruction identical
+    // link and only the register *name* in the encoding differs.
+    const bool store_gpr = base_sel == 1 || base_sel == 3;
+    const bool load_gpr = base_sel == 1 || base_sel == 2;
+    if (store_gpr || load_gpr) {
+      sljit_get_local_base(c, SLJIT_R2, 0, 0);
+    }
+    const sljit_s32 st_base = store_gpr ? SLJIT_R2 : SLJIT_SP;
+    const sljit_s32 ld_base = load_gpr ? SLJIT_R2 : SLJIT_SP;
+
+    link_labels_.clear();
+    link_bytes_ = (2 + alu_ops) * kInsnBytes;
+
+    emit_outer_loop(c, SLJIT_R1, iters, [&] {
+      for (size_t r = 0; r < repeats; ++r) {
+        for (size_t i = 0; i < addresses; ++i) {
+          auto off = static_cast<sljit_sw>(i * stride);
+          // Only the first rotation is labelled: later rotations reuse
+          // the same offsets, so they cannot encode differently.
+          if constexpr (kUniformInsnWidth) {
+            if (r == 0) {
+              link_labels_.push_back(sljit_emit_label(c));
+            }
+          }
+          sljit_emit_op1(c, SLJIT_MOV, SLJIT_MEM1(st_base), off, SLJIT_R0, 0);
+          // Load into R3 rather than R0 so the store's data register and
+          // the load's destination register differ. Sharing one register
+          // would leave the chain value unchanged for the whole run and
+          // make a same-register peephole indistinguishable from a
+          // genuinely fast forward.
+          sljit_emit_op1(c, SLJIT_MOV, SLJIT_R3, 0, SLJIT_MEM1(ld_base), off);
+          sljit_emit_op2(c, SLJIT_ADD, SLJIT_R0, 0, SLJIT_R3, 0, SLJIT_IMM, kChainCarryImm);
+          for (size_t a = 1; a < alu_ops; ++a) {
+            sljit_emit_op2(c, SLJIT_ADD, SLJIT_R0, 0, SLJIT_R0, 0, SLJIT_IMM, kChainCarryImm);
+          }
+        }
+      }
+    });
+
+    sljit_emit_return_void(c);
+  }
+
+  // Asserts every link occupies exactly link_bytes_. sljit re-bases with
+  // an extra ADDI once an offset leaves the single-instruction window,
+  // which would inflate per-link latency by a whole instruction without
+  // any other visible symptom; this turns that into a failed row.
+  void verify_layout(sljit_compiler* c) override {
+    (void)c;
+    if constexpr (kUniformInsnWidth) {
+      verify_uniform_spacing(link_labels_, link_bytes_, /*strict=*/true, "store_load_footprint");
+    }
+  }
+};
+
+FERRET_BENCHMARK("store_load_footprint", StoreLoadFootprint);
+
+}  // namespace ferret

--- a/benchmarks/store_load_overlap.cpp
+++ b/benchmarks/store_load_overlap.cpp
@@ -1,0 +1,194 @@
+extern "C" {
+#include <sljitLir.h>
+}
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "ferret/bench_helpers.hpp"
+#include "ferret/benchmark.hpp"
+
+namespace ferret {
+
+namespace {
+
+constexpr size_t kOpBudget = 20'000'000;
+constexpr size_t kBodyInsns = 4096;
+
+// Mid-cache-line, so a small negative load offset does not cross a
+// 128-byte boundary. A line split costs several times the forwarding
+// penalty and would swamp the effect under test.
+constexpr sljit_sw kSlot = 576;
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+constexpr bool kUniformInsnWidth = true;
+constexpr size_t kInsnBytes = 4;
+#elif defined(__x86_64__) || defined(_M_X64)
+constexpr bool kUniformInsnWidth = false;
+constexpr size_t kInsnBytes = 0;
+#else
+#error "ferret supports only x86_64 and aarch64"
+#endif
+
+constexpr sljit_s32 kAcc = SLJIT_R0;
+constexpr sljit_s32 kTmp = SLJIT_R1;
+constexpr sljit_s32 kCounter = SLJIT_R2;
+// Points AT the slot, so the store's offset is 0 and the load's is just
+// load_offset. Addressing from SLJIT_SP instead would make the load's
+// offset 576+delta: unaligned, past the 256-byte unscaled LDUR/STUR
+// window, so sljit would prepend an address computation and the link
+// would no longer be a fixed instruction count.
+constexpr sljit_s32 kBase = SLJIT_R3;
+
+struct KernelParams {
+  int64_t load_offset;
+  size_t store_width;
+  size_t load_width;
+  size_t alu_ops;
+};
+
+bool is_width(int64_t w) { return w == 4 || w == 8; }
+
+KernelParams validated_params(const Params& p) {
+  auto load_offset = p.get<int64_t>("load_offset_bytes");
+  auto store_width = p.get<int64_t>("store_width");
+  auto load_width = p.get<int64_t>("load_width");
+  auto alu_ops = p.get<int64_t>("alu_ops");
+
+  if (!is_width(store_width) || !is_width(load_width)) {
+    throw std::invalid_argument("store_width=" + std::to_string(store_width) +
+                                " load_width=" + std::to_string(load_width) + ": each must be 4 or 8");
+  }
+  if (alu_ops < 1) {
+    throw std::invalid_argument("alu_ops=" + std::to_string(alu_ops) + " must be >= 1 to carry the chain value");
+  }
+  // The load must read some of the bytes the store wrote, or there is no
+  // dependency at all and the "chain" silently stops being a chain.
+  if (load_offset >= store_width || load_offset + load_width <= 0) {
+    throw std::invalid_argument("load_offset_bytes=" + std::to_string(load_offset) + " with store_width=" +
+                                std::to_string(store_width) + " load_width=" + std::to_string(load_width) +
+                                ": the load reads none of the stored bytes, which breaks the dependent chain");
+  }
+  // Stronger: the load must cover byte 0 of the store. The chain value is
+  // carried by adding 1, so only the low byte is guaranteed to change on
+  // every link. A load that misses it sees an effectively constant value,
+  // the chain goes dead, and the row reports issue throughput rather than
+  // forwarding latency — fast, and completely wrong.
+  if (load_offset > 0 || load_offset + load_width <= 0) {
+    throw std::invalid_argument(
+        "load_offset_bytes=" + std::to_string(load_offset) + " with load_width=" + std::to_string(load_width) +
+        ": the load must cover byte 0 of the store (require -load_width < offset <= 0), otherwise the "
+        "loaded value is constant and the dependent chain dies");
+  }
+  return {.load_offset = load_offset,
+          .store_width = static_cast<size_t>(store_width),
+          .load_width = static_cast<size_t>(load_width),
+          .alu_ops = static_cast<size_t>(alu_ops)};
+}
+
+size_t insns_per_link(const KernelParams& k) { return 2 + k.alu_ops; }
+size_t link_repeats(const KernelParams& k) { return compute_iterations(kBodyInsns, insns_per_link(k)); }
+
+}  // namespace
+
+// A serial dependent chain in which the load is deliberately misaligned
+// against the store it depends on:
+//
+//   str  x0,  [sp, #slot]                 store_width bytes
+//   ldr  x3,  [sp, #slot + load_offset]   load_width bytes
+//   add  x0,  x3, #1
+//   <alu_ops-1 further adds>
+//
+// Per-link cost is the forward latency plus alu_ops. Sweeping the offset
+// and the two widths asks what the fast path actually requires: whether
+// an overlapping-but-not-identical access qualifies, and whether the two
+// sides must be the same width.
+//
+// A machine that only forwards on a byte-exact, same-width match shows a
+// sharp minimum at offset 0 with matched widths and the full fallback
+// everywhere else. A machine that forwards any load contained in the
+// store shows a flat curve.
+//
+// Both directions are constrained, and the constraints are not
+// cosmetic. `validated_params` rejects any point where the load misses
+// byte 0 of the store: the chain is carried by adding 1, so only the low
+// byte changes every link, and a load that misses it reads a constant.
+// That silently converts the benchmark from a latency measurement into
+// an issue-throughput measurement, which looks *fast* and is meaningless.
+struct StoreLoadOverlap : Benchmark {
+  std::vector<sljit_label*> link_labels_;
+  size_t link_bytes_ = 0;
+
+  [[nodiscard]] std::string name() const override { return "store_load_overlap"; }
+
+  // Every point in this rectangle is valid for every width pair, so the
+  // default sweep never trips the byte-0 rejection. Wider offsets are
+  // reachable from the CLI and will be rejected if they go too far.
+  [[nodiscard]] SweepAxes axes() const override {
+    return {
+        Axis::values("load_offset_bytes", {-2, -1, 0}),
+        Axis::values("store_width", {4, 8}),
+        Axis::values("load_width", {4, 8}),
+    };
+  }
+
+  [[nodiscard]] BenchOptions options() const override { return {BenchOption{.name = "alu_ops", .default_value = 1}}; }
+
+  [[nodiscard]] size_t sites_per_kernel(const Params& p) const override { return link_repeats(validated_params(p)); }
+
+  [[nodiscard]] size_t iterations(const Params& p) const override {
+    return compute_iterations(kOpBudget, sites_per_kernel(p) * insns_per_link(validated_params(p)));
+  }
+
+  void emit_kernel(sljit_compiler* c, const Params& p) override {
+    auto k = validated_params(p);
+    size_t repeats = link_repeats(k);
+    size_t iters = iterations(p);
+
+    sljit_emit_enter(c, 0, SLJIT_ARGS0V(), 4, 0, static_cast<sljit_s32>(kSlot) + 1024);
+    sljit_emit_op1(c, SLJIT_MOV, kAcc, 0, SLJIT_IMM, 1);
+    sljit_get_local_base(c, kBase, 0, kSlot);
+
+    const sljit_s32 st_op = k.store_width == 4 ? SLJIT_MOV_U32 : SLJIT_MOV;
+    const sljit_s32 ld_op = k.load_width == 4 ? SLJIT_MOV_U32 : SLJIT_MOV;
+    const auto ld_off = static_cast<sljit_sw>(k.load_offset);
+
+    link_labels_.clear();
+    link_bytes_ = (2 + k.alu_ops) * kInsnBytes;
+
+    emit_outer_loop(c, kCounter, iters, [&] {
+      for (size_t r = 0; r < repeats; ++r) {
+        if constexpr (kUniformInsnWidth) {
+          link_labels_.push_back(sljit_emit_label(c));
+        }
+        sljit_emit_op1(c, st_op, SLJIT_MEM1(kBase), 0, kAcc, 0);
+        sljit_emit_op1(c, ld_op, kTmp, 0, SLJIT_MEM1(kBase), ld_off);
+        sljit_emit_op2(c, SLJIT_ADD, kAcc, 0, kTmp, 0, SLJIT_IMM, kChainCarryImm);
+        for (size_t a = 1; a < k.alu_ops; ++a) {
+          sljit_emit_op2(c, SLJIT_ADD, kAcc, 0, kAcc, 0, SLJIT_IMM, kChainCarryImm);
+        }
+      }
+    });
+
+    sljit_emit_return_void(c);
+  }
+
+  // An unaligned offset can push sljit off the scaled-immediate encoding
+  // and into a two-instruction address computation. That extra op is off
+  // the critical path, so it would not change the latency much, but it
+  // would break the "one link is exactly N instructions" accounting the
+  // per-site normalization relies on. Fail the row instead.
+  void verify_layout(sljit_compiler* c) override {
+    (void)c;
+    if constexpr (kUniformInsnWidth) {
+      verify_uniform_spacing(link_labels_, link_bytes_, /*strict=*/true, "store_load_overlap");
+    }
+  }
+};
+
+FERRET_BENCHMARK("store_load_overlap", StoreLoadOverlap);
+
+}  // namespace ferret

--- a/docs/benchmarks/store_load_distance.md
+++ b/docs/benchmarks/store_load_distance.md
@@ -1,0 +1,131 @@
+# `store_load_distance` — how far apart a store and its load may sit
+
+A serial dependent chain whose store and load are pushed a controlled
+number of instructions apart. Per-link cost is the store-to-load forward
+latency plus `alu_ops`; subtract `alu_ops` to read the forward cost on
+its own.
+
+Where the curve returns to zero measures the width of the window the
+mechanism needs the pair to fall _outside_ of.
+
+## Kernel structure
+
+```text
+  loop_top:
+    ┌─ one link, repeated to fill a constant instruction budget ─┐
+    │   str  x0, [base, #slot]              ◄── chain in         │
+    │   <separation filler instructions>                         │
+    │   ldr  x3, [base, #slot]                                   │
+    │   add  x0, x3, #1                                          │
+    │   <alu_ops-1 further adds>            ────► chain out      │
+    └────────────────────────────────────────────────────────────┘
+    SUB counter, 1 ; JNZ loop_top
+```
+
+The dependency is `add → str` data `→ ldr` result `→ add`, unbroken.
+Nothing else is on the critical path: the address is `base + immediate`,
+available immediately.
+
+Annotated:
+
+- **The loop body is sized to a constant instruction count, not a
+  constant link count.** Otherwise sweeping `separation` would also
+  sweep the L1I footprint, and instruction-cache pressure would
+  masquerade as a distance effect.
+- **`alu_ops` defaults to 16**, unusually high, because it buys a
+  latency shadow for the filler work to hide in. Without it the row
+  stops measuring latency and starts measuring issue width.
+- **Every filler kind is exactly one instruction**, so `separation` is
+  both an instruction count and the emitted byte stride ÷ 4.
+  `verify_layout` asserts this with strict equality per link.
+
+## Per-benchmark options
+
+`--alu_ops=N` (default `16`, minimum `1`). Latency budget, and the
+calibration knob: cost must move by exactly one cycle per added op. A
+slope that isn't 1.0 means the chain is not serial and nothing else in
+the row means what it claims.
+
+## CLI surface
+
+| flag                 | meaning                                                                 |
+| -------------------- | ----------------------------------------------------------------------- |
+| `--separation=A..B`  | Contiguous range, default `0..16`. Instructions between store and load. |
+| `--separation=v1,v2` | Explicit list.                                                          |
+| `--filler=v1,v2,…`   | `0` alu, `1` nop, `2` store, `3` load, `4` branch, `5` base_write.      |
+| `--alu_ops=N`        | See above.                                                              |
+
+See [`../cli.md`](../cli.md) for global flags.
+
+### Filler kinds
+
+| value | kind         | what it asks                                                  |
+| ----- | ------------ | ------------------------------------------------------------- |
+| `0`   | `alu`        | independent ADD, rotating destinations — the neutral baseline |
+| `1`   | `nop`        | occupies a decode slot and nothing else                       |
+| `2`   | `store`      | independent store, distinct address per position              |
+| `3`   | `load`       | independent load from a never-stored region                   |
+| `4`   | `branch`     | taken branch to the next instruction — ends a fetch block     |
+| `5`   | `base_write` | rewrites the address base register **with its own value**     |
+
+`base_write` is the odd one out: the address is unchanged, only the
+architectural register is written. Those rows address the chain slot
+through a general register, since the stack pointer is not ours to
+rewrite. If a mechanism keyed on the register _name_ has to invalidate
+when that name is written, this is where it shows.
+
+Rotating the filler destination registers matters. A single shared
+destination makes load fillers look artificially cheap and skews the
+whole curve — an easy mistake that produces a plausible-looking wrong
+answer.
+
+## Reading the curves
+
+Subtract `alu_ops` from `cycles_per_site`.
+
+- **A minimum at separation 0 that does _not_ continue at 1** means two
+  distinct mechanisms: one for immediately adjacent pairs, another that
+  needs them further apart.
+- **A linear ramp back toward zero** is the signature of a window the
+  pair must escape. If the cost fits `P × (1 − d/W)` for
+  `d = separation + 1`, then the x-intercept is `W` — the width of that
+  window in instructions — and `P` is the fallback penalty.
+- **`alu`, `nop`, `store` and `load` agreeing** means only the slot
+  count matters, not what occupies it. Any kind that deviates is doing
+  something structural — a taken branch ending a fetch block, for
+  instance.
+- **`base_write` pinned near the fallback at every separation** means
+  writing the base register invalidates the match.
+
+## Caveats
+
+- **The chain must never load a repeating value.** A per-PC last-value
+  load predictor will sever the chain and the row will report issue
+  throughput as a latency -- roughly 0.4 cycles per link instead of the
+  real number. The `alu_ops` carry increment is what keeps every load
+  result fresh; see the dependent-chain section of
+  [`../writing-a-benchmark.md`](../writing-a-benchmark.md) and validate
+  with `scripts/chain_slope.py`.
+- **The first parameter point of a sweep reads high with `--warmup=1`.**
+  It shows up as a spurious spike at `separation=0`. Use `--warmup=2` or
+  more; the CI runner does.
+- **`separation` is swept linearly, not geometrically.** The structure
+  is a handful of instructions wide, so a log2 axis would step straight
+  over it. Plots default to a linear x-axis for the same reason.
+- **This benchmark does not probe capacity.** The chain is serial, so
+  exactly one store/load pair is in flight. How many pairs can be
+  tracked at once needs concurrently live chains — a different kernel.
+- **Large separations with memory fillers are rejected.** Filler stores
+  and loads walk one 128-byte line per position, so they eventually
+  leave the single-instruction addressing window; the point is rejected
+  rather than silently measured with an extra address computation.
+- **A rejected point aborts the whole sweep**, it is not skipped.
+- **The layout check is AArch64-only** — x86_64 instruction lengths vary,
+  so a uniform per-link stride does not hold there by construction.
+- **Apple Silicon pinning.** See the project README's discipline section.
+
+## Related docs
+
+- Companion benchmarks: [`store_load_footprint.md`](store_load_footprint.md),
+  [`store_load_overlap.md`](store_load_overlap.md).
+- Construction rationale: [`writing-a-benchmark.md`](../writing-a-benchmark.md).

--- a/docs/benchmarks/store_load_footprint.md
+++ b/docs/benchmarks/store_load_footprint.md
@@ -1,0 +1,147 @@
+# `store_load_footprint` — store-to-load forward latency
+
+A strictly serial dependent chain threaded through memory. Each link
+stores the chain value to a stack slot, reads it straight back, and
+carries it to the next link through an ALU op. The per-link cost is the
+machine's store-to-load forward latency plus `alu_ops`.
+
+A core that forwards through the store queue pays its full forwarding
+latency per link. A core that resolves the load at rename time — memory
+renaming — pays close to nothing, and the chain collapses to little more
+than the ALU op.
+
+## Kernel structure
+
+```text
+  local area:  addresses × stride_bytes bytes of sljit stack locals
+               (SLJIT_SP + 0, + stride, + 2×stride, …)
+
+  loop_top:
+    ┌─ rotation r = 0 … repeats-1 ──────────────────────────────┐
+    │   i = 0:   str  x0, [base, #0]              ◄── chain in  │
+    │            ldr  x3, [base, #0]                            │
+    │            add  x0, x3, #1                                │
+    │   i = 1:   str  x0, [base, #1×stride]                     │
+    │            ldr  x3, [base, #1×stride]                     │
+    │            add  x0, x3, #1                                │
+    │            …                                              │
+    │   i = N-1: str  x0, [base, #(N-1)×stride]                 │
+    │            ldr  x3, [base, #(N-1)×stride]                 │
+    │            add  x0, x3, #1              ────► chain out   │
+    └───────────────────────────────────────────────────────────┘
+    SUB counter, 1 ; JNZ loop_top
+
+  base_reg selects the register NAME each side uses for the one address:
+    0   str [sp,#i]  / ldr [sp,#i]
+    1   str [xN,#i]  / ldr [xN,#i]
+    2   str [sp,#i]  / ldr [xN,#i]      <- same bytes, different name
+    3   str [xN,#i]  / ldr [sp,#i]
+  xN comes from sljit_get_local_base and provably holds exactly SP;
+  it is hoisted out of the loop so all four forms emit an identical
+  instruction sequence and differ only in the encoded register field.
+```
+
+The dependency is `add → str` data `→ ldr` result `→ add`, unbroken
+across every link and every rotation. Nothing else in the link is on the
+critical path: both addresses are `base + immediate`, available
+immediately.
+
+Annotated:
+
+- **The load targets a different register than the store's source.**
+  Sharing one register would leave the chain value constant for the
+  whole run and make a same-register peephole indistinguishable from a
+  genuinely fast forward. `alu_ops=0` is rejected for this reason — it
+  would force the two registers to coincide, which is a different
+  experiment. On an M4 Pro that variant measures ~4.8 cycles per link
+  against ~2.0 for `alu_ops=1`.
+- **The rotation repeats to a fixed 512 links per iteration**, so
+  `addresses=1` isn't three instructions drowning in loop overhead. Both
+  ends of the axis do identical total work.
+- **Layout is verified post-codegen.** On AArch64 `verify_layout()`
+  asserts every link is exactly `(2 + alu_ops) × 4` bytes. sljit
+  silently prepends an `ADDI` to re-base once an offset leaves the
+  single-instruction window, which would inflate per-link latency by a
+  whole instruction with no other symptom.
+
+## Per-benchmark options
+
+`--alu_ops=N` (default `1`, minimum `1`).
+
+Number of ALU ops carrying the loaded value to the next link. This is a
+calibration knob, not a tuning knob: since each op is a 1-cycle
+dependent `ADD`, fitting cycles-per-link against `alu_ops` must give a
+slope of exactly 1.0, and the intercept is the forward latency. **A
+slope that isn't 1.0 means the chain is not serial and nothing else in
+the row means what it claims.** Run this before trusting any number
+here.
+
+## CLI surface
+
+| flag                  | meaning                                                                          |
+| --------------------- | -------------------------------------------------------------------------------- |
+| `--addresses=A..B`    | Geometric sweep, default `k=1` (same as log₂). Default `1..256`.                 |
+| `--addresses=A..B@k`  | Geometric sweep with `k` samples per octave.                                     |
+| `--stride_bytes=A..B` | Log₂ sweep, default `8..128`. Byte distance between consecutive slots.           |
+| `--base_reg=0,1,2,3`  | Addressing form for store/load. See the kernel diagram. Default sweeps all four. |
+| `--alu_ops=N`         | See above. Default `1`.                                                          |
+
+See [`../cli.md`](../cli.md) for global flags.
+
+## Reading the curves
+
+Subtract `alu_ops` from `cycles_per_site` to get the raw forward
+latency.
+
+| Observation                          | Reading                                                                                                                                                                                                  |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Latency well under an L1D hit        | The load isn't reaching the cache — forwarding is being resolved early.                                                                                                                                  |
+| Latency at the L1D hit cost or above | Conventional store-queue forwarding, no early resolution.                                                                                                                                                |
+| Curve moves with `stride_bytes`      | Handling is line- or page-granular rather than per-address.                                                                                                                                              |
+| `base_reg=0` below `base_reg=1`      | Stack-specific handling; SP-relative addressing is a special case.                                                                                                                                       |
+| `base_reg=0` and `1` coincide        | Whatever is happening is not keyed to the stack pointer.                                                                                                                                                 |
+| `base_reg=2,3` far above `0` and `1` | The match is on the register NAME, not the address. Forms 2 and 3 reach identical bytes through a register that provably holds SP, so a gap here means the comparison happens before any address exists. |
+
+## Caveats
+
+- **The chain must never load a repeating value.** A per-PC last-value
+  load predictor will sever the chain and the row will report issue
+  throughput as a latency -- roughly 0.4 cycles per link instead of the
+  real number. The `alu_ops` carry increment is what keeps every load
+  result fresh; see the dependent-chain section of
+  [`../writing-a-benchmark.md`](../writing-a-benchmark.md) and validate
+  with `scripts/chain_slope.py`.
+- **Neither axis probes capacity.** The chain is serial, so exactly one
+  store/load pair is ever in flight — there is nothing to exhaust.
+  Sweeping `addresses` changes _which_ slot a link uses, not how many
+  pairs are tracked at once, so a flat curve here is not evidence of a
+  large tracking structure. A capacity probe needs concurrently live
+  pairs, i.e. independent interleaved chains with one register each,
+  which is a different kernel.
+- **What `addresses` does establish**: that the behaviour survives an
+  arbitrary rotating set of slots rather than only a repeat of the
+  immediately preceding store, and — because the whole default sweep is
+  L1D-resident — that no feature of the curve is a cache-capacity
+  effect.
+- **Addressing window.** `(addresses − 1) × stride_bytes` must not
+  exceed 32744. AArch64 encodes an 8-byte-aligned `LDR`/`STR` immediate
+  offset in 12 bits scaled by 8 (reach 32760), and SP-relative offsets
+  additionally carry `SLJIT_LOCALS_OFFSET_BASE` (16 bytes). Points past
+  the window are rejected rather than silently measured with an extra
+  instruction per link. The bound is applied on x86_64 too, where
+  `disp32` imposes no comparable limit, so both architectures sweep an
+  identical parameter space.
+- **The layout check is AArch64-only.** x86_64 `LDR`/`STR` displacement
+  width varies with the offset (`disp8` vs `disp32`), so a uniform
+  per-link byte stride does not hold there by construction. The kernel
+  still emits and runs; it just doesn't carry the guarantee.
+- **A rejected point aborts the whole sweep**, it is not skipped. Keep
+  CLI overrides inside the addressing window.
+- **Apple Silicon pinning.** See the project README's discipline
+  section — probe and benchmark land on _some_ P-core, not necessarily
+  the same one.
+
+## Related docs
+
+- Construction rationale: [`writing-a-benchmark.md`](../writing-a-benchmark.md).
+- Project two-step workflow: [project README](../../README.md).

--- a/docs/benchmarks/store_load_overlap.md
+++ b/docs/benchmarks/store_load_overlap.md
@@ -1,0 +1,112 @@
+# `store_load_overlap` — what counts as "the same access"
+
+A serial dependent chain in which the load is deliberately misaligned
+against the store it depends on, in address and in width. Per-link cost
+is the forward latency plus `alu_ops`.
+
+This asks what the fast path actually requires: whether an
+overlapping-but-not-identical access qualifies, and whether the two
+sides must be the same width.
+
+## Kernel structure
+
+```text
+  xB = SP + slot                       hoisted out of the loop
+
+  loop_top:
+    ┌─ one link ───────────────────────────────────────────────┐
+    │   str  x0, [xB, #0]              store_width bytes       │
+    │   ldr  x3, [xB, #load_offset]    load_width bytes        │
+    │   add  x0, x3, #1                                        │
+    │   <alu_ops-1 further adds>                               │
+    └──────────────────────────────────────────────────────────┘
+    SUB counter, 1 ; JNZ loop_top
+
+           store writes:  [ 0 .. store_width )
+           load reads:    [ load_offset .. load_offset+load_width )
+```
+
+Annotated:
+
+- **Addressing is through `xB`, which points AT the slot**, so the
+  store's offset is `0` and the load's is just `load_offset`. Addressing
+  from `SLJIT_SP` instead would make the load's offset `576+delta` —
+  unaligned and past the 256-byte unscaled `LDUR`/`STUR` window — so
+  sljit would prepend an address computation and the link would no
+  longer be a fixed instruction count. `verify_layout` catches that.
+- **The slot sits mid-cache-line.** A negative offset from a
+  line-aligned slot would cross a 128-byte boundary, and a line split
+  costs several times the forwarding penalty — enough to swamp the
+  effect under test entirely.
+
+## The byte-0 rule, and why points get rejected
+
+The chain is carried by adding `1`, so **only byte 0 of the stored value
+is guaranteed to change on every link**. A load that misses byte 0 reads
+an effectively constant value; the dependency dies; the loop runs at
+issue throughput. That reads _fast_ and means nothing.
+
+So `validated_params` rejects any point where the load does not cover
+byte 0 — formally `-load_width < load_offset <= 0`. This is not
+fussiness: without it the benchmark silently reports a throughput number
+in a latency column, which is the most dangerous kind of wrong.
+
+The default axes are chosen so every combination in the rectangle is
+valid at every width pair, because **a rejected point aborts the whole
+sweep rather than being skipped**.
+
+## Per-benchmark options
+
+`--alu_ops=N` (default `1`, minimum `1`). One op is the floor: it
+carries the loaded value back to the store's source register without the
+two registers coinciding.
+
+## CLI surface
+
+| flag                        | meaning                                              |
+| --------------------------- | ---------------------------------------------------- |
+| `--load_offset_bytes=v1,v2` | Load address minus store address. Default `-2,-1,0`. |
+| `--store_width=4,8`         | Store access width in bytes. Default sweeps both.    |
+| `--load_width=4,8`          | Load access width in bytes. Default sweeps both.     |
+| `--alu_ops=N`               | See above.                                           |
+
+See [`../cli.md`](../cli.md) for global flags.
+
+## Reading the curves
+
+| Observation                                           | Reading                                                                    |
+| ----------------------------------------------------- | -------------------------------------------------------------------------- |
+| Only `offset=0` with matched widths is fast           | The fast path needs a byte-exact match; overlap is not enough.             |
+| A load fully contained in the store is still slow     | Containment does not qualify either — the accesses must be identical.      |
+| Matched 4-byte pair slow while matched 8-byte is fast | The mechanism is specific to full register width, not to width _matching_. |
+| Everything flat                                       | Forwarding is address-range based, as a store queue would do.              |
+
+The width axes are what separate "must match each other" from "must both
+be 64-bit" — a matched narrow pair distinguishes the two, and only
+sweeping both widths independently exposes it.
+
+## Caveats
+
+- **The chain must never load a repeating value.** A per-PC last-value
+  load predictor will sever the chain and the row will report issue
+  throughput as a latency -- roughly 0.4 cycles per link instead of the
+  real number. The `alu_ops` carry increment is what keeps every load
+  result fresh; see the dependent-chain section of
+  [`../writing-a-benchmark.md`](../writing-a-benchmark.md) and validate
+  with `scripts/chain_slope.py`.
+- **The first parameter point of a sweep reads high with `--warmup=1`.**
+  Use `--warmup=2` or more; the CI runner does.
+- **Offsets are restricted to the byte-0 window** for the reason above.
+  Wider offsets are reachable from the CLI and will be rejected, loudly,
+  rather than measured.
+- **Only 4- and 8-byte accesses.** Narrower widths would need a
+  different chain-carry scheme to keep the dependency alive.
+- **The layout check is AArch64-only** — x86_64 displacement width varies
+  with the offset, so a uniform per-link stride does not hold there.
+- **Apple Silicon pinning.** See the project README's discipline section.
+
+## Related docs
+
+- Companion benchmarks: [`store_load_footprint.md`](store_load_footprint.md),
+  [`store_load_distance.md`](store_load_distance.md).
+- Construction rationale: [`writing-a-benchmark.md`](../writing-a-benchmark.md).

--- a/docs/writing-a-benchmark.md
+++ b/docs/writing-a-benchmark.md
@@ -181,6 +181,69 @@ Key idioms:
 - **`emit_nops(c, n)`** — pads each branch out to the requested
   `spacing_bytes` using arch-correct NOP encodings (see `padding.hpp`).
 
+## Dependent-chain benchmarks: two ways to measure a lie
+
+A benchmark that times a dependent chain reports latency only while the
+chain is actually serial. Both ways it can silently stop being serial
+make the result read _faster_ than the truth, which is the direction
+that looks like a discovery rather than a bug.
+
+### The loaded value must change on every link
+
+Apple cores carry a per-PC last-value load predictor (the structure
+behind the published FLOP attack, present from M3/A17). If a static load
+instruction returns the same value on consecutive executions, the
+predictor supplies it and the dependent chain is severed: the loop then
+runs at issue throughput and the benchmark reports that as a latency.
+
+Measured on an M4 Pro with a pointer chase, the size of the lie:
+
+```text
+chase over N nodes, unrolled 32x     N=1,2,4,8,16,32  ->  ~0.4 cycles/load
+                                     N=3,5,6,7,...    ->   3.0 cycles/load
+```
+
+The fast rows are exactly the N that divide the unroll factor — those are
+the cases where each static load PC lands on the same node every time and
+so returns a constant. Change the unroll to 30 and the fast set becomes
+the divisors of 30. It is keyed on the load's PC, not on the address.
+
+So: never let a load in a measured chain return a repeating value. The
+`store_load_*` benchmarks carry their chain with `kChainCarryImm`
+(`bench_helpers.hpp`), a non-zero increment, precisely so no load result
+can repeat. `store_load_overlap` goes further and _rejects_ parameter
+points where the load would miss the byte the increment touches, because
+those rows would read a constant.
+
+### The carry op must not be a disguised move
+
+`ADD xd, xn, #0` is a canonical register-move form and is eliminated to
+zero cycles. That breaks the "each carry op costs exactly one cycle"
+accounting that per-link normalization relies on, so subtracting the op
+count over-corrects. `kChainCarryImm` is `static_assert`ed non-zero for
+this reason as well.
+
+### Check it, do not assume it
+
+The identity `cycles_per_site = F + alu_ops` has a testable consequence:
+the slope against `alu_ops` must be 1.0. `scripts/chain_slope.py` fits it
+and fails otherwise.
+
+```sh
+for a in 1 2 4 8 16; do
+  build/ferret run store_load_footprint --alu_ops=$a --freq=4.5GHz \
+      --reps=9 --warmup=2 --out=/tmp/slope-$a.csv
+done
+python3 scripts/chain_slope.py /tmp/slope-*.csv
+```
+
+A slope well below 1.0 means the chain was severed. A slope above 1.0
+means the carry ops cost more than a cycle each and `F` cannot be
+recovered by subtraction. Run this whenever you add a chain benchmark,
+change its carry op, or port to a new microarchitecture — and re-run it
+on a quiet machine, because a loaded machine can push the fit off by
+10% on its own.
+
 ## Smoke-testing a new benchmark
 
 After building:

--- a/include/ferret/bench_helpers.hpp
+++ b/include/ferret/bench_helpers.hpp
@@ -18,6 +18,32 @@ extern "C" {
 
 namespace ferret {
 
+// Immediate a store->load dependent chain adds to its value on every
+// link. It MUST be non-zero, for two independent reasons, and both
+// failure modes are silent and read *faster* than the truth:
+//
+//  1. Load value prediction. Apple cores carry a per-PC last-value load
+//     predictor. If a static load instruction returns the same value on
+//     consecutive executions, the predictor supplies it and severs the
+//     dependent chain: the loop then runs at issue throughput and the
+//     benchmark reports that as if it were latency. Measured on an M4
+//     Pro, a chain whose loaded value never changes reads 0.35 cycles
+//     per link against a true 3.00 — an 8x error, in the direction that
+//     looks like a discovery. Incrementing by a non-zero amount keeps
+//     every load's result fresh, so the predictor can never fire.
+//
+//  2. Move elimination. `ADD xd, xn, #0` is a canonical register-move
+//     form and is eliminated to zero cycles. That breaks the "each ALU
+//     op on the chain costs exactly one cycle" accounting that per-link
+//     cost normalization depends on, so subtracting the op count would
+//     over-subtract.
+//
+// Any non-zero value works; 1 keeps the op a plain ADD.
+constexpr sljit_sw kChainCarryImm = 1;
+static_assert(kChainCarryImm != 0,
+              "a zero carry immediate lets the load value predictor sever the chain and turns every "
+              "dependent-chain benchmark into an issue-throughput measurement");
+
 // Emits the canonical ferret outer-loop scaffold around a body lambda:
 //
 //   MOV counter_reg, iters

--- a/scripts/chain_slope.py
+++ b/scripts/chain_slope.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Validate that a dependent-chain benchmark's chain is actually serial.
+
+Usage: python scripts/chain_slope.py run-alu1.csv run-alu2.csv ...
+
+Every store->load benchmark reports a per-link cost of the form
+
+    cycles_per_site = F + alu_ops
+
+where F is the store-to-load forward cost. That identity has a testable
+consequence: plotting cycles_per_site against alu_ops must give a slope
+of exactly 1.0, because each carry op is one dependent ADD. This script
+fits that line and fails if the slope is off.
+
+Why it matters. A slope below 1.0 means the chain is not fully serial,
+and the usual cause is nasty: Apple cores carry a per-PC last-value load
+predictor, so if a static load ever returns the same value twice the
+predictor severs the chain and the loop runs at issue throughput. The
+benchmark then reports roughly 0.4 cycles per link where the truth is
+3.0 -- an error that looks like a discovery. A slope above 1.0 means the
+carry ops are costing more than a cycle each, so subtracting alu_ops to
+recover F under-corrects.
+
+Feed it CSVs from otherwise-identical runs that differ only in
+--alu_ops. Rows are grouped by every axis column they share, and each
+group is fitted separately.
+"""
+
+from __future__ import annotations
+
+import csv
+import sys
+
+# Slope must be 1.0. Real measurements wobble, so allow a small band.
+TOLERANCE = 0.05
+
+# Below this the chain is not a chain any more: cycles/link has stopped
+# tracking alu_ops, which is what a severed dependency looks like.
+SEVERED_SLOPE = 0.5
+
+METADATA = frozenset(
+    {
+        "benchmark",
+        "seed",
+        "ticks_min",
+        "ticks_median",
+        "iters",
+        "sites_per_iter",
+        "reps",
+        "ns_per_site_min",
+        "ns_per_site_median",
+        "cycles_per_site_min",
+        "cycles_per_site_median",
+        "freq_hz",
+    }
+)
+
+
+def _fit(points):
+    """Least-squares slope/intercept of y against x."""
+    n = len(points)
+    mx = sum(x for x, _ in points) / n
+    my = sum(y for _, y in points) / n
+    den = sum((x - mx) ** 2 for x, _ in points)
+    if den == 0.0:
+        return None
+    slope = sum((x - mx) * (y - my) for x, y in points) / den
+    return slope, my - slope * mx
+
+
+def load(paths):
+    """Group rows by their axis columns; return {key: [(alu_ops, cycles)]}."""
+    groups: dict[tuple, list] = {}
+    for path in paths:
+        with open(path, newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                if not row.get("cycles_per_site_min"):
+                    continue  # JIT failure, or no --freq was supplied
+                if "alu_ops" not in row:
+                    raise SystemExit(f"{path}: no alu_ops column; this benchmark has no chain to check")
+                axes = tuple(sorted((k, v) for k, v in row.items() if k not in METADATA and k != "alu_ops"))
+                groups.setdefault(axes, []).append((float(row["alu_ops"]), float(row["cycles_per_site_min"])))
+    return groups
+
+
+def main(argv):
+    if len(argv) < 2:  # noqa: PLR2004
+        print("usage: chain_slope.py FILE.csv [FILE.csv ...]", file=sys.stderr)
+        return 2
+
+    groups = load(argv[1:])
+    if not groups:
+        print("chain_slope.py: no usable rows (need --freq so cycles_per_site_min is populated)", file=sys.stderr)
+        return 2
+
+    failed = 0
+    for axes, points in sorted(groups.items()):
+        label = " ".join(f"{k}={v}" for k, v in axes) or "(no axes)"
+        if len({x for x, _ in points}) < 2:  # noqa: PLR2004
+            print(f"SKIP  {label}: only one alu_ops value, nothing to fit")
+            continue
+        fitted = _fit(points)
+        if fitted is None:
+            print(f"SKIP  {label}: degenerate fit")
+            continue
+        slope, intercept = fitted
+
+        if slope < SEVERED_SLOPE:
+            verdict, note, fatal = "FAIL", "chain severed -- cycles/link barely tracks alu_ops", True
+        elif slope > 1.0 + TOLERANCE:
+            verdict, note, fatal = "FAIL", "carry ops cost more than a cycle each", True
+        elif slope < 1.0 - TOLERANCE:
+            verdict, note, fatal = "WARN", "sublinear: part of the load latency overlaps the chain", False
+        else:
+            verdict, note, fatal = "ok  ", "", False
+
+        failed += int(fatal)
+        detail = f" -- {note}" if note else ""
+        print(f"{verdict}  {label}: slope={slope:.3f} forward_cost={intercept:.2f} ({len(points)} points){detail}")
+        if note:
+            # F is not a single number here, so show how it moves.
+            per = "  ".join(f"alu={int(x)}:{y - x:.2f}" for x, y in sorted(points))
+            print(f"        forward cost per point: {per}")
+
+    if failed:
+        print(
+            f"\nchain_slope.py: {failed} group(s) failed.\n"
+            "  slope near zero  -> the dependent chain was severed, most often by load\n"
+            "                      value prediction when a static load returns a constant.\n"
+            "                      Those rows report issue throughput, not latency.\n"
+            "  slope above 1.0  -> each carry op costs more than a cycle, so recovering\n"
+            "                      the forward cost by subtracting alu_ops under-corrects.\n"
+            "A WARN row is not a benchmark bug: a slope moderately below 1.0 means the\n"
+            "machine overlaps some of the load's setup with the chain, so the forward\n"
+            "cost is a range rather than a constant. Quote it per alu_ops, not once.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/ferret_plot/registry.py
+++ b/scripts/ferret_plot/registry.py
@@ -47,6 +47,30 @@ DEFAULTS: dict[str, BenchmarkDefaults] = {
         heatmap_x="branches",
         heatmap_y="history_len",
     ),
+    "store_load_distance": BenchmarkDefaults(
+        # separation is a contiguous 0..16 range, not a log2 sweep, so a
+        # log x-axis would crush exactly the region of interest.
+        line_x="separation",
+        line_xscale="linear",
+        heatmap_x="separation",
+        heatmap_y="filler",
+    ),
+    "store_load_overlap": BenchmarkDefaults(
+        line_x="load_offset_bytes",
+        line_xscale="linear",
+        heatmap_x="load_offset_bytes",
+        heatmap_y="load_width",
+        facet_col="store_width",
+    ),
+    "store_load_footprint": BenchmarkDefaults(
+        line_x="addresses",
+        heatmap_x="addresses",
+        heatmap_y="stride_bytes",
+        # base_reg is the SP-vs-general-register comparison; keeping the
+        # two on separate subplots is what makes a gap between them read
+        # at a glance.
+        facet_col="base_reg",
+    ),
 }
 
 

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -24,7 +24,7 @@ ruff check --fix scripts/ tests/python/
 # CMake: format CMakeLists.txt and any *.cmake modules in-tree.
 mapfile -t CMAKE_FILES < <(
   find . \
-    \( -path ./build -o -path ./.git -o -path ./_deps \) -prune -o \
+    \( -path './build*' -o -path ./.git -o -name '_deps' \) -prune -o \
     \( -name 'CMakeLists.txt' -o -name '*.cmake' \) -type f -print
 )
 if [ "${#CMAKE_FILES[@]}" -gt 0 ]; then

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -32,7 +32,7 @@ mapfile -t CXX_LINT_FILES < <(
 # CMake files mirror format.sh's set so check + apply stay symmetric.
 mapfile -t CMAKE_FILES < <(
   find . \
-    \( -path ./build -o -path ./.git -o -path ./_deps \) -prune -o \
+    \( -path './build*' -o -path ./.git -o -name '_deps' \) -prune -o \
     \( -name 'CMakeLists.txt' -o -name '*.cmake' \) -type f -print
 )
 
@@ -55,7 +55,7 @@ echo "==> prettier --check"
 prettier --check '**/*.md'
 
 echo "==> markdownlint-cli2"
-markdownlint-cli2 '**/*.md' '#build' '#_deps' '#node_modules' '#docs/superpowers'
+markdownlint-cli2 '**/*.md' '#build*/**' '#**/_deps/**' '#**/node_modules/**' '#docs/superpowers/**'
 
 echo "==> clang-tidy"
 # clang-tidy from nixpkgs is unwrapped, so the C++ stdlib search paths

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -183,3 +183,8 @@ esac
 run_benchmark "direct_branch_footprint" "line" "" "$FREQ" "--branches=16..32768@2 --spacing_bytes=${DIRECT_BRANCH_SPACING_LO}..128"
 run_benchmark "nested_call_depth" "line" "" "$FREQ"
 run_benchmark "branch_history_footprint" "surface" "" "$FREQ" "--branches=16..1024@2 --history_len=1..1024@2"
+run_benchmark "store_load_footprint" "line" "" "$FREQ"
+# warmup=2: the first parameter point of a sweep reads high with a single
+# warmup call, which shows up as a spurious spike at separation=0.
+run_benchmark "store_load_distance" "line" "" "$FREQ" "--warmup=2"
+run_benchmark "store_load_overlap" "line" "" "$FREQ" "--warmup=2"

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -27,10 +27,11 @@ run_benchmark() {
   local extra_output="${3:-}"
   local freq="${4:-}"
   local extra_args="${5:-}"
+  local warmup="${6:-$WARMUP}"
   local csv="$OUT_DIR/${ARTIFACT_PREFIX}${bench}.csv"
   local html="$OUT_DIR/${ARTIFACT_PREFIX}${bench}.html"
   local md="$OUT_DIR/${ARTIFACT_PREFIX}${bench}.md"
-  local args=(run "$bench" --reps="$REPS" --warmup="$WARMUP" --out="$csv")
+  local args=(run "$bench" --reps="$REPS" --warmup="$warmup" --out="$csv")
 
   echo "==> running $bench full sweep"
   if [[ -n "$freq" ]]; then
@@ -185,6 +186,8 @@ run_benchmark "nested_call_depth" "line" "" "$FREQ"
 run_benchmark "branch_history_footprint" "surface" "" "$FREQ" "--branches=16..1024@2 --history_len=1..1024@2"
 run_benchmark "store_load_footprint" "line" "" "$FREQ"
 # warmup=2: the first parameter point of a sweep reads high with a single
-# warmup call, which shows up as a spurious spike at separation=0.
-run_benchmark "store_load_distance" "line" "" "$FREQ" "--warmup=2"
-run_benchmark "store_load_overlap" "line" "" "$FREQ" "--warmup=2"
+# warmup call, which shows up as a spurious spike at separation=0. Passed
+# as the warmup argument, not through extra_args -- run_benchmark already
+# supplies --warmup and the CLI rejects the flag twice.
+run_benchmark "store_load_distance" "line" "" "$FREQ" "" "2"
+run_benchmark "store_load_overlap" "line" "" "$FREQ" "" "2"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,30 @@ target_link_libraries(
 )
 gtest_discover_tests(test_direct_branch_footprint)
 
+add_executable(test_store_load_footprint test_store_load_footprint.cpp)
+target_sources(test_store_load_footprint PRIVATE $<TARGET_OBJECTS:ferret_benchmarks>)
+target_link_libraries(
+  test_store_load_footprint PRIVATE ferret_core ferret_benchmarks sljit::sljit GTest::gtest GTest::gtest_main
+                                    ferret_warnings
+)
+gtest_discover_tests(test_store_load_footprint)
+
+add_executable(test_store_load_distance test_store_load_distance.cpp)
+target_sources(test_store_load_distance PRIVATE $<TARGET_OBJECTS:ferret_benchmarks>)
+target_link_libraries(
+  test_store_load_distance PRIVATE ferret_core ferret_benchmarks sljit::sljit GTest::gtest GTest::gtest_main
+                                   ferret_warnings
+)
+gtest_discover_tests(test_store_load_distance)
+
+add_executable(test_store_load_overlap test_store_load_overlap.cpp)
+target_sources(test_store_load_overlap PRIVATE $<TARGET_OBJECTS:ferret_benchmarks>)
+target_link_libraries(
+  test_store_load_overlap PRIVATE ferret_core ferret_benchmarks sljit::sljit GTest::gtest GTest::gtest_main
+                                  ferret_warnings
+)
+gtest_discover_tests(test_store_load_overlap)
+
 add_executable(test_jit test_jit.cpp)
 target_link_libraries(test_jit PRIVATE ferret_core sljit::sljit GTest::gtest GTest::gtest_main ferret_warnings)
 gtest_discover_tests(test_jit)

--- a/tests/python/fixtures.py
+++ b/tests/python/fixtures.py
@@ -199,3 +199,102 @@ def bhf_df(
                 _add_freq(row, ns, freq_hz=4.0e9)
             rows.append(row)
     return pd.DataFrame(rows)
+
+
+def slf_df(
+    *,
+    addresses: tuple[int, ...] = (1, 2, 4, 8),
+    strides: tuple[int, ...] = (8, 16, 32),
+    base_regs: tuple[int, ...] = (0, 1),
+    with_freq: bool = True,
+) -> pd.DataFrame:
+    """store_load_footprint synthetic frame."""
+    rows = []
+    for a in addresses:
+        for s in strides:
+            for br in base_regs:
+                ns = 0.44 + a * 0.001 + s * 0.0005 + br * 0.002
+                row = {
+                    "benchmark": "store_load_footprint",
+                    "addresses": a,
+                    "stride_bytes": s,
+                    "base_reg": br,
+                    "alu_ops": 1,
+                    "seed": 1,
+                    "ticks_min": 1000 + a * s,
+                    "ticks_median": 1000 + a * s,
+                    "iters": 1,
+                    "sites_per_iter": 512,
+                    "reps": 7,
+                    "ns_per_site_min": ns,
+                    "ns_per_site_median": ns,
+                }
+                if with_freq:
+                    _add_freq(row, ns, freq_hz=4.5e9)
+                rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def sld_df(
+    *,
+    separations: tuple[int, ...] = (0, 1, 2, 4, 8),
+    fillers: tuple[int, ...] = (0, 1, 2, 3, 4, 5),
+    with_freq: bool = True,
+) -> pd.DataFrame:
+    """store_load_distance synthetic frame."""
+    rows = []
+    for sep in separations:
+        for f in fillers:
+            ns = 3.5 + sep * 0.01 + f * 0.005
+            row = {
+                "benchmark": "store_load_distance",
+                "separation": sep,
+                "filler": f,
+                "alu_ops": 16,
+                "seed": 1,
+                "ticks_min": 1000 + sep,
+                "ticks_median": 1000 + sep,
+                "iters": 1,
+                "sites_per_iter": 227,
+                "reps": 7,
+                "ns_per_site_min": ns,
+                "ns_per_site_median": ns,
+            }
+            if with_freq:
+                _add_freq(row, ns, freq_hz=4.5e9)
+            rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def slo_df(
+    *,
+    offsets: tuple[int, ...] = (-2, -1, 0),
+    store_widths: tuple[int, ...] = (4, 8),
+    load_widths: tuple[int, ...] = (4, 8),
+    with_freq: bool = True,
+) -> pd.DataFrame:
+    """store_load_overlap synthetic frame."""
+    rows = []
+    for off in offsets:
+        for sw in store_widths:
+            for lw in load_widths:
+                ns = 0.44 if (off == 0 and sw == 8 and lw == 8) else 2.4
+                row = {
+                    "benchmark": "store_load_overlap",
+                    "load_offset_bytes": off,
+                    "store_width": sw,
+                    "load_width": lw,
+                    "alu_ops": 1,
+                    "seed": 1,
+                    "ticks_min": 1000,
+                    "ticks_median": 1000,
+                    "iters": 1,
+                    "sites_per_iter": 1365,
+                    "reps": 7,
+                    "ns_per_site_min": ns,
+                    "ns_per_site_median": ns,
+                }
+                if with_freq:
+                    _add_freq(row, ns, freq_hz=4.5e9)
+                rows.append(row)
+    return pd.DataFrame(rows)

--- a/tests/python/test_benchmark_ci_contract.py
+++ b/tests/python/test_benchmark_ci_contract.py
@@ -21,6 +21,9 @@ BENCHMARKS = (
     "direct_branch_footprint",
     "nested_call_depth",
     "branch_history_footprint",
+    "store_load_footprint",
+    "store_load_distance",
+    "store_load_overlap",
 )
 
 
@@ -48,6 +51,15 @@ def test_benchmark_runner_covers_full_sweep_html_outputs():
     assert "DIRECT_BRANCH_SPACING_LO=4" in text
     assert "DIRECT_BRANCH_SPACING_LO=8" in text
     assert 'run_benchmark "nested_call_depth" "line" "" "$FREQ"' in text
+    # store_load_footprint's default axes are already the intended sweep
+    # (addresses x stride_bytes x base_reg, 90 points), so CI passes no
+    # axis overrides.
+    assert 'run_benchmark "store_load_footprint" "line" "" "$FREQ"' in text
+    # Both distance and overlap need warmup=2: with a single warmup call the
+    # first parameter point of the sweep reads high and fakes a spike at
+    # separation=0 / offset=-2.
+    assert 'run_benchmark "store_load_distance" "line" "" "$FREQ" "--warmup=2"' in text
+    assert 'run_benchmark "store_load_overlap" "line" "" "$FREQ" "--warmup=2"' in text
     assert (
         'run_benchmark "branch_history_footprint" "surface" "" "$FREQ" "--branches=16..1024@2 --history_len=1..1024@2"'
     ) in text

--- a/tests/python/test_benchmark_ci_contract.py
+++ b/tests/python/test_benchmark_ci_contract.py
@@ -223,3 +223,22 @@ esac
     assert "| os |" in summary
     cpu_section = summary.split("## Runner CPU", 1)[1].split("##", 1)[0]
     assert "unknown" not in cpu_section, f"CPU model was not detected: {cpu_section}"
+
+
+def test_lint_and_format_skip_side_build_trees():
+    """AGENTS.md tells contributors to keep side builds in build-*/ trees
+    (sanitizers, Android, portable). Those trees contain vendored CMake
+    from FetchContent, which cmake-lint would reject. Pruning only
+    ./build would let any side tree break the lint gate."""
+    prune = r"\( -path './build*' -o -path ./.git -o -name '_deps' \) -prune -o"
+    for script in ("format.sh", "lint.sh"):
+        text = (ROOT / "scripts" / script).read_text(encoding="utf-8")
+        assert prune in text, f"{script} must prune build* and any nested _deps"
+        assert "-path ./build -o" not in text, f"{script} still prunes only the canonical build/"
+
+    # markdownlint and prettier walk the tree too, and vendored FetchContent
+    # markdown under build-*/_deps/ fails both.
+    lint = (ROOT / "scripts" / "lint.sh").read_text(encoding="utf-8")
+    assert "'#build*/**'" in lint and "'#**/_deps/**'" in lint, "markdownlint must skip side-build trees"
+    ignore = (ROOT / ".prettierignore").read_text(encoding="utf-8")
+    assert "build-*/" in ignore, ".prettierignore must cover side-build trees"

--- a/tests/python/test_benchmark_ci_contract.py
+++ b/tests/python/test_benchmark_ci_contract.py
@@ -58,8 +58,12 @@ def test_benchmark_runner_covers_full_sweep_html_outputs():
     # Both distance and overlap need warmup=2: with a single warmup call the
     # first parameter point of the sweep reads high and fakes a spike at
     # separation=0 / offset=-2.
-    assert 'run_benchmark "store_load_distance" "line" "" "$FREQ" "--warmup=2"' in text
-    assert 'run_benchmark "store_load_overlap" "line" "" "$FREQ" "--warmup=2"' in text
+    assert 'run_benchmark "store_load_distance" "line" "" "$FREQ" "" "2"' in text
+    assert 'run_benchmark "store_load_overlap" "line" "" "$FREQ" "" "2"' in text
+    # extra_args must never carry a flag run_benchmark already supplies;
+    # the CLI rejects a repeated option outright.
+    assert '"--warmup=' not in text, "pass warmup as the 6th argument, not through extra_args"
+    assert '"--reps=' not in text, "pass reps via REPS, not through extra_args"
     assert (
         'run_benchmark "branch_history_footprint" "surface" "" "$FREQ" "--branches=16..1024@2 --history_len=1..1024@2"'
     ) in text
@@ -216,6 +220,16 @@ esac
     )
 
     calls = log_path.read_text(encoding="utf-8").splitlines()
+
+    # The real CLI rejects a repeated option ("At Most 1 required but
+    # received 2") and aborts the whole sweep. The fake ferret above
+    # accepts anything, so without this check a duplicated flag in
+    # run_benchmarks.sh reaches CI undetected.
+    for call in calls:
+        seen = [arg.split("=", 1)[0] for arg in call.split() if arg.startswith("--")]
+        dupes = {flag for flag in seen if seen.count(flag) > 1}
+        assert not dupes, f"repeated option(s) {sorted(dupes)} in: {call}"
+
     assert any("run dependent_chain_throughput" in call for call in calls)
     assert not any("--freq=" in call for call in calls if "dependent_chain_throughput" in call)
     for bench in ("direct_branch_footprint", "nested_call_depth", "branch_history_footprint"):

--- a/tests/python/test_chain_slope.py
+++ b/tests/python/test_chain_slope.py
@@ -1,0 +1,130 @@
+"""Tests for scripts/chain_slope.py.
+
+The script exists to catch a silent failure mode: a dependent chain that
+has been severed (typically by load value prediction) reports issue
+throughput as if it were latency, which reads *faster* than the truth.
+The detector is that cycles_per_site vs alu_ops must have slope 1.0.
+"""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = ROOT / "scripts" / "chain_slope.py"
+
+_spec = importlib.util.spec_from_file_location("chain_slope", SCRIPT)
+chain_slope = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(chain_slope)
+
+
+def write_csv(path, rows, *, axes=("addresses",)):
+    cols = ["benchmark", *axes, "alu_ops", "seed", "ns_per_site_min", "cycles_per_site_min"]
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=cols)
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+
+
+def row(alu, cycles, addresses=64):
+    return {
+        "benchmark": "store_load_footprint",
+        "addresses": addresses,
+        "alu_ops": alu,
+        "seed": 1,
+        "ns_per_site_min": cycles / 4.5,
+        "cycles_per_site_min": cycles,
+    }
+
+
+def test_serial_chain_passes(tmp_path):
+    # cycles = 1.0 * alu_ops + 1.0  -> slope exactly 1
+    p = tmp_path / "good.csv"
+    write_csv(p, [row(a, a + 1.0) for a in (1, 2, 4, 8, 16)])
+    assert chain_slope.main(["chain_slope.py", str(p)]) == 0
+
+
+def test_severed_chain_fails(tmp_path):
+    # A chain broken by value prediction stops tracking alu_ops: the loop
+    # runs at issue throughput, so the slope collapses.
+    p = tmp_path / "severed.csv"
+    write_csv(p, [row(a, 0.35 + 0.05 * a) for a in (1, 2, 4, 8, 16)])
+    assert chain_slope.main(["chain_slope.py", str(p)]) == 1
+
+
+def test_sublinear_slope_warns_but_does_not_fail(tmp_path):
+    # A slope moderately below 1.0 is a real machine behaviour: part of the
+    # load's setup overlaps the chain, so the forward cost shrinks as the
+    # latency shadow grows. Measured on an M5 Pro at slope 0.847. That is
+    # not a benchmark bug, so it must not be reported as a severed chain.
+    p = tmp_path / "sublinear.csv"
+    write_csv(p, [row(a, 0.85 * a + 8.4) for a in (1, 2, 4, 8, 16)])
+    assert chain_slope.main(["chain_slope.py", str(p)]) == 0
+
+
+def test_carry_op_costing_more_than_a_cycle_fails(tmp_path):
+    # Slope above 1.0 means subtracting alu_ops to recover the forward
+    # cost would under-correct.
+    p = tmp_path / "steep.csv"
+    write_csv(p, [row(a, 1.12 * a + 1.0) for a in (1, 2, 4, 8, 16)])
+    assert chain_slope.main(["chain_slope.py", str(p)]) == 1
+
+
+def test_groups_are_fitted_independently(tmp_path):
+    # One healthy group and one severed group in the same file: the file
+    # must fail, because a partial failure is still a failure.
+    p = tmp_path / "mixed.csv"
+    good = [row(a, a + 1.0, addresses=64) for a in (1, 2, 4, 8)]
+    bad = [row(a, 0.35 + 0.05 * a, addresses=128) for a in (1, 2, 4, 8)]
+    write_csv(p, good + bad)
+    assert chain_slope.main(["chain_slope.py", str(p)]) == 1
+
+    groups = chain_slope.load([str(p)])
+    assert len(groups) == 2, "rows must be grouped by their axis columns, not pooled"
+
+
+def test_multiple_files_are_pooled_into_one_fit(tmp_path):
+    # The normal workflow is one CSV per --alu_ops value.
+    paths = []
+    for a in (1, 2, 4, 8, 16):
+        q = tmp_path / f"alu{a}.csv"
+        write_csv(q, [row(a, a + 1.0)])
+        paths.append(str(q))
+    groups = chain_slope.load(paths)
+    assert len(groups) == 1
+    assert len(next(iter(groups.values()))) == 5
+    assert chain_slope.main(["chain_slope.py", *paths]) == 0
+
+
+def test_single_alu_ops_value_is_skipped_not_failed(tmp_path):
+    p = tmp_path / "one.csv"
+    write_csv(p, [row(16, 17.0)])
+    assert chain_slope.main(["chain_slope.py", str(p)]) == 0
+
+
+def test_rows_without_cycles_are_ignored(tmp_path):
+    # Rows are blank when --freq was omitted or the JIT failed.
+    p = tmp_path / "blank.csv"
+    rows = [row(a, a + 1.0) for a in (1, 2, 4)]
+    rows.append({**row(8, 0.0), "cycles_per_site_min": ""})
+    write_csv(p, rows)
+    assert chain_slope.main(["chain_slope.py", str(p)]) == 0
+
+
+def test_missing_alu_ops_column_is_an_error(tmp_path):
+    p = tmp_path / "noalu.csv"
+    with open(p, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=["benchmark", "branches", "cycles_per_site_min"])
+        w.writeheader()
+        w.writerow({"benchmark": "direct_branch_footprint", "branches": 8, "cycles_per_site_min": 2.0})
+    with pytest.raises(SystemExit):
+        chain_slope.load([str(p)])
+
+
+def test_usage_error_without_arguments():
+    assert chain_slope.main(["chain_slope.py"]) == 2

--- a/tests/python/test_registry.py
+++ b/tests/python/test_registry.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 from ferret_plot import registry as reg
 from ferret_plot.errors import PlotError
-from fixtures import bhf_df, dbf_df, dct_df, nced_df
+from fixtures import bhf_df, dbf_df, dct_df, nced_df, sld_df, slf_df, slo_df
 
 
 class TestDetectBenchmark:
@@ -78,6 +78,26 @@ class TestResolveDefaults:
         assert d.heatmap_x == "branches"
         assert d.heatmap_y == "history_len"
 
+    def test_sld_defaults(self):
+        d = reg.resolve_defaults(sld_df(), override=None)
+        assert d.line_x == "separation"
+        # A contiguous 0..16 sweep must not be plotted on a log axis.
+        assert d.line_xscale == "linear"
+        assert d.heatmap_y == "filler"
+
+    def test_slo_defaults(self):
+        d = reg.resolve_defaults(slo_df(), override=None)
+        assert d.line_x == "load_offset_bytes"
+        assert d.line_xscale == "linear"
+        assert d.facet_col == "store_width"
+
+    def test_slf_defaults(self):
+        d = reg.resolve_defaults(slf_df(), override=None)
+        assert d.line_x == "addresses"
+        assert d.heatmap_x == "addresses"
+        assert d.heatmap_y == "stride_bytes"
+        assert d.facet_col == "base_reg"
+
 
 class TestBenchmarkDefaults:
     """Verify the dataclass exposes every expected default field."""
@@ -124,3 +144,27 @@ class TestRegistryHonesty:
             col = getattr(d, attr)
             if col is not None:
                 assert col in df.columns, f"{attr}={col!r} not in bhf_df columns"
+
+    def test_sld_columns_present(self):
+        df = sld_df()
+        d = reg.DEFAULTS["store_load_distance"]
+        for attr in self._COLUMN_ATTRS:
+            col = getattr(d, attr)
+            if col is not None:
+                assert col in df.columns, f"{attr}={col!r} not in sld_df columns"
+
+    def test_slo_columns_present(self):
+        df = slo_df()
+        d = reg.DEFAULTS["store_load_overlap"]
+        for attr in self._COLUMN_ATTRS:
+            col = getattr(d, attr)
+            if col is not None:
+                assert col in df.columns, f"{attr}={col!r} not in slo_df columns"
+
+    def test_slf_columns_present(self):
+        df = slf_df()
+        d = reg.DEFAULTS["store_load_footprint"]
+        for attr in self._COLUMN_ATTRS:
+            col = getattr(d, attr)
+            if col is not None:
+                assert col in df.columns, f"{attr}={col!r} not in slf_df columns"

--- a/tests/test_store_load_distance.cpp
+++ b/tests/test_store_load_distance.cpp
@@ -1,0 +1,167 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+extern "C" {
+#include <sljitLir.h>
+}
+
+#include "ferret/benchmark.hpp"
+#include "ferret/jit.hpp"
+#include "sljit_test_helpers.hpp"
+
+using ferret::testing::CompilerHandle;
+using ferret::testing::find_option;
+
+namespace {
+
+ferret::Params make_params(int64_t separation, int64_t filler = 0, int64_t alu_ops = 16) {
+  ferret::Params p;
+  p.set("separation", separation);
+  p.set("filler", filler);
+  p.set("alu_ops", alu_ops);
+  p.set("seed", 1);
+  return p;
+}
+
+// Mirrors kBodyInsns in benchmarks/store_load_distance.cpp.
+constexpr size_t kBodyInsns = 4096;
+
+}  // namespace
+
+TEST(StoreLoadDistance, RegistryLookupReturnsBenchmark) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_distance");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->name(), "store_load_distance");
+}
+
+TEST(StoreLoadDistance, ExposesTwoAxesInCsvColumnOrder) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_distance");
+  ASSERT_NE(b, nullptr);
+  auto axes = b->axes();
+  ASSERT_EQ(axes.size(), 2u);
+  EXPECT_EQ(axes[0].name(), "separation");
+  EXPECT_EQ(axes[1].name(), "filler");
+}
+
+// Linear, not geometric: the structure under test is a handful of
+// instructions wide, so a log2 sweep would step straight over it.
+TEST(StoreLoadDistanceAxis, SeparationIsAContiguousRange) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_distance");
+  ASSERT_NE(b, nullptr);
+  auto vs = b->axes()[0].expand();
+  ASSERT_EQ(vs.size(), 17u);
+  EXPECT_EQ(vs.front(), 0);
+  EXPECT_EQ(vs.back(), 16);
+  for (size_t i = 1; i < vs.size(); ++i) {
+    EXPECT_EQ(vs[i], vs[i - 1] + 1) << "separation axis must not skip values";
+  }
+}
+
+TEST(StoreLoadDistanceAxis, FillerCoversEveryKind) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_distance");
+  ASSERT_NE(b, nullptr);
+  const std::vector<int64_t> expected{0, 1, 2, 3, 4, 5};
+  EXPECT_EQ(b->axes()[1].expand(), expected);
+}
+
+TEST(StoreLoadDistance, ExposesAluOpsOptionWithALatencyShadow) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_distance");
+  ASSERT_NE(b, nullptr);
+  auto opts = b->options();
+  ASSERT_EQ(opts.size(), 1u);
+  const auto* alu = find_option(opts, "alu_ops");
+  ASSERT_NE(alu, nullptr);
+  // Large enough that the filler work hides in the chain's latency
+  // instead of turning the row into an issue-width measurement.
+  EXPECT_EQ(alu->default_value, 16);
+}
+
+// The loop body is sized to a constant instruction count, so sweeping
+// separation must not also sweep the L1I footprint. Links shrink as each
+// one gets longer.
+TEST(StoreLoadDistance, LoopBodyInstructionCountIsHeldRoughlyConstant) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_distance");
+  ASSERT_NE(b, nullptr);
+  for (int64_t sep : {0, 1, 4, 16}) {
+    size_t links = b->sites_per_kernel(make_params(sep));
+    size_t insns = links * (2 + static_cast<size_t>(sep) + 16);
+    EXPECT_LE(insns, kBodyInsns) << "separation=" << sep;
+    EXPECT_GT(insns, kBodyInsns / 2) << "separation=" << sep;
+  }
+}
+
+TEST(StoreLoadDistance, IterationsIsPositiveAcrossTheSweep) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_distance");
+  ASSERT_NE(b, nullptr);
+  for (int64_t sep : {0, 1, 8, 16}) {
+    EXPECT_GT(b->iterations(make_params(sep)), 0u) << "separation=" << sep;
+  }
+}
+
+// ---- Parameter rejection ----
+
+TEST(StoreLoadDistance, RejectsNegativeSeparation) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_distance");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(-1)), std::invalid_argument);
+}
+
+TEST(StoreLoadDistance, RejectsUnknownFillerKind) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_distance");
+  ASSERT_NE(b, nullptr);
+  for (int64_t bad : {-1, 6}) {
+    CompilerHandle ch;
+    EXPECT_THROW(b->emit_kernel(ch.c, make_params(2, bad)), std::invalid_argument) << "filler=" << bad;
+  }
+}
+
+TEST(StoreLoadDistance, RejectsAluOpsBelowOne) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_distance");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(2, 0, /*alu_ops=*/0)), std::invalid_argument);
+}
+
+// Filler stores and loads walk one 128-byte line per position, so a very
+// large separation would push them past the single-instruction
+// addressing window and silently add an address computation.
+TEST(StoreLoadDistance, RejectsSeparationPastTheFillerAddressingWindow) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_distance");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(1024, /*filler=*/2)), std::invalid_argument);
+}
+
+// ---- Codegen ----
+
+// verify_layout is the oracle: it throws unless every link is exactly
+// (2 + separation + alu_ops) instructions, which is what proves each
+// filler kind costs one instruction and no offset needed re-basing.
+TEST(StoreLoadDistance, EveryFillerKindEmitsUniformLinks) {
+  for (int64_t filler = 0; filler <= 5; ++filler) {
+    for (int64_t sep : {0, 1, 8, 16}) {
+      auto b = ferret::BenchmarkRegistry::create("store_load_distance");
+      ASSERT_NE(b, nullptr);
+      ferret::JittedKernel k(*b, make_params(sep, filler));
+      EXPECT_TRUE(k.ok()) << "filler=" << filler << " separation=" << sep;
+    }
+  }
+}
+
+TEST(StoreLoadDistance, EmittedKernelRuns) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_distance");
+  ASSERT_NE(b, nullptr);
+  ferret::JittedKernel k(*b, make_params(2, 0, /*alu_ops=*/1));
+  ASSERT_TRUE(k.ok());
+  k.fn()();
+}
+
+// Note: there is deliberately no code-size test here. verify_layout
+// already asserts, with strict equality on per-link labels, that a link
+// is exactly (2 + separation + alu_ops) instructions -- which is a
+// stronger statement than any code-size delta, and it is exercised for
+// every filler kind by EveryFillerKindEmitsUniformLinks above.

--- a/tests/test_store_load_footprint.cpp
+++ b/tests/test_store_load_footprint.cpp
@@ -1,0 +1,266 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+extern "C" {
+#include <sljitLir.h>
+}
+
+#include "ferret/benchmark.hpp"
+#include "ferret/jit.hpp"
+#include "sljit_test_helpers.hpp"
+
+using ferret::testing::CompilerHandle;
+using ferret::testing::find_option;
+
+namespace {
+
+ferret::Params make_params(int64_t addresses, int64_t stride_bytes, int64_t base_reg = 0, int64_t alu_ops = 1) {
+  ferret::Params p;
+  p.set("addresses", addresses);
+  p.set("stride_bytes", stride_bytes);
+  p.set("base_reg", base_reg);
+  p.set("alu_ops", alu_ops);
+  p.set("seed", 1);
+  return p;
+}
+
+// Links emitted per outer-loop iteration; mirrors kUnrollLinks in
+// benchmarks/store_load_footprint.cpp.
+constexpr size_t kUnrollLinks = 512;
+
+}  // namespace
+
+// ---- Registry / shape ----
+
+TEST(StoreLoadFootprint, RegistryLookupReturnsBenchmark) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->name(), "store_load_footprint");
+}
+
+TEST(StoreLoadFootprint, ExposesThreeAxesInCsvColumnOrder) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  auto axes = b->axes();
+  ASSERT_EQ(axes.size(), 3u);
+  EXPECT_EQ(axes[0].name(), "addresses");
+  EXPECT_EQ(axes[1].name(), "stride_bytes");
+  EXPECT_EQ(axes[2].name(), "base_reg");
+}
+
+TEST(StoreLoadFootprint, AddressesAxisExpansionMatchesSpec) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  const std::vector<int64_t> expected{1, 2, 4, 8, 16, 32, 64, 128, 256};
+  EXPECT_EQ(b->axes()[0].expand(), expected);
+}
+
+TEST(StoreLoadFootprint, StrideBytesAxisExpansionMatchesSpec) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  const std::vector<int64_t> expected{8, 16, 32, 64, 128};
+  EXPECT_EQ(b->axes()[1].expand(), expected);
+}
+
+// Every default (addresses, stride_bytes) pair must stay inside the
+// single-instruction addressing window; the widest is 255 * 128.
+TEST(StoreLoadFootprint, DefaultAxisProductStaysInsideAddressingWindow) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  auto addresses = b->axes()[0].expand();
+  auto strides = b->axes()[1].expand();
+  for (int64_t a : addresses) {
+    for (int64_t s : strides) {
+      CompilerHandle ch;
+      EXPECT_NO_THROW(b->emit_kernel(ch.c, make_params(a, s))) << "addresses=" << a << " stride_bytes=" << s;
+    }
+  }
+}
+
+// 0 sp/sp, 1 gpr/gpr, 2 sp store + gpr load, 3 gpr store + sp load.
+// Forms 2 and 3 address identical bytes through a differently-named
+// register, which is what separates a name match from an address match.
+TEST(StoreLoadFootprint, BaseRegAxisCoversAllFourAddressingForms) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  const std::vector<int64_t> expected{0, 1, 2, 3};
+  EXPECT_EQ(b->axes()[2].expand(), expected);
+}
+
+TEST(StoreLoadFootprint, ExposesAluOpsOption) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  auto opts = b->options();
+  ASSERT_EQ(opts.size(), 1u);
+  const auto* alu = find_option(opts, "alu_ops");
+  ASSERT_NE(alu, nullptr);
+  EXPECT_EQ(alu->default_value, 1);
+}
+
+// ---- Normalization ----
+
+// The address rotation repeats to fill a constant number of links, so
+// per-link cost stays comparable across the whole `addresses` axis
+// instead of drowning in loop overhead at the small end.
+TEST(StoreLoadFootprint, SitesPerKernelIsConstantAcrossTheAddressesAxis) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  for (int64_t a : {1, 2, 4, 16, 64, 256}) {
+    EXPECT_EQ(b->sites_per_kernel(make_params(a, 8)), kUnrollLinks) << "addresses=" << a;
+  }
+}
+
+// The loop body is capped in instructions as well as links, so a large
+// alu_ops must shrink the unroll rather than growing the code. Without
+// this, alu_ops=64 would emit 132 KB of loop body and start competing
+// with the instruction cache.
+TEST(StoreLoadFootprint, LoopBodyIsCappedInInstructionsNotJustLinks) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  for (int64_t alu : {1, 4, 16, 32, 64}) {
+    size_t links = b->sites_per_kernel(make_params(64, 8, /*base_reg=*/0, alu));
+    size_t body = links * (2 + static_cast<size_t>(alu));
+    EXPECT_LE(body, 8192u) << "alu_ops=" << alu << " emits " << body << " instructions";
+  }
+}
+
+// The cap must not disturb the default sweep, which runs at alu_ops=1.
+TEST(StoreLoadFootprint, DefaultAluOpsKeepsTheFullUnroll) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  for (int64_t a : {1, 2, 4, 16, 64, 256}) {
+    EXPECT_EQ(b->sites_per_kernel(make_params(a, 8)), kUnrollLinks) << "addresses=" << a;
+  }
+}
+
+// Past kUnrollLinks the rotation no longer fits, so one rotation is the
+// floor and sites grow with `addresses`.
+TEST(StoreLoadFootprint, SitesPerKernelFallsBackToOneRotationWhenAddressesExceedUnroll) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->sites_per_kernel(make_params(1024, 8)), 1024u);
+}
+
+TEST(StoreLoadFootprint, IterationsAmortizesAtOpBudget) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->iterations(make_params(64, 8)), 20'000'000u / kUnrollLinks);
+  EXPECT_EQ(b->iterations(make_params(1, 8)), 20'000'000u / kUnrollLinks);
+}
+
+// ---- Parameter rejection ----
+
+TEST(StoreLoadFootprint, RejectsZeroAddresses) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(0, 8)), std::invalid_argument);
+}
+
+TEST(StoreLoadFootprint, RejectsStrideBelowOneWord) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(4, 4)), std::invalid_argument);
+}
+
+TEST(StoreLoadFootprint, RejectsStrideNotAWordMultiple) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(4, 12)), std::invalid_argument);
+}
+
+TEST(StoreLoadFootprint, RejectsBaseRegOutsideTheFourForms) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  for (int64_t bad : {-1, 4}) {
+    CompilerHandle ch;
+    EXPECT_THROW(b->emit_kernel(ch.c, make_params(4, 8, bad)), std::invalid_argument) << "base_reg=" << bad;
+  }
+}
+
+// Past the addressing window sljit would re-base with an extra
+// instruction per link, silently inflating the measured latency. The
+// parameter point is rejected instead.
+TEST(StoreLoadFootprint, RejectsOffsetPastAddressingWindow) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(512, 128)), std::invalid_argument);
+}
+
+// ---- Codegen ----
+
+// The widest default point, both addressing modes. verify_layout is the
+// oracle: it throws unless every link is exactly one store, one load and
+// alu_ops ALU instructions, which is what proves sljit encoded each
+// offset in a single instruction.
+TEST(StoreLoadFootprint, EmitsUniformLinksAtTheWidestDefaultPoint) {
+  for (int64_t base_reg : {0, 1, 2, 3}) {
+    auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+    ASSERT_NE(b, nullptr);
+    ferret::JittedKernel k(*b, make_params(256, 128, base_reg));
+    EXPECT_TRUE(k.ok()) << "base_reg=" << base_reg;
+  }
+}
+
+// Zero ALU ops would force the load to target the store's own source
+// register, which changes the stored value into a constant and makes a
+// same-register peephole look like fast forwarding. That is a different
+// experiment, so it is rejected rather than silently measured.
+TEST(StoreLoadFootprint, RejectsAluOpsBelowOne) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  for (int64_t alu : {0, -1}) {
+    CompilerHandle ch;
+    EXPECT_THROW(b->emit_kernel(ch.c, make_params(4, 8, /*base_reg=*/0, alu)), std::invalid_argument)
+        << "alu_ops=" << alu;
+  }
+}
+
+TEST(StoreLoadFootprint, EmittedKernelRuns) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  ferret::Params p = make_params(4, 8);
+  // Keep the smoke run short — iterations() targets 20 M links.
+  p.set("addresses", 4);
+  ferret::JittedKernel k(*b, p);
+  ASSERT_TRUE(k.ok());
+  k.fn()();
+}
+
+#if defined(__aarch64__) || defined(_M_ARM64)
+// Both points emit exactly kUnrollLinks links with an identical
+// prologue, epilogue and loop scaffold, so the whole code-size delta is
+// one extra 4-byte ADD per link. This is what makes alu_ops usable as a
+// cycle-accounting calibration: one more op must mean one more
+// instruction, nothing else.
+TEST(StoreLoadFootprint, EachAluOpAddsExactlyOneInstructionPerLink) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  ferret::JittedKernel one(*b, make_params(64, 8, /*base_reg=*/0, /*alu_ops=*/1));
+  ASSERT_TRUE(one.ok());
+  ferret::JittedKernel two(*b, make_params(64, 8, /*base_reg=*/0, /*alu_ops=*/2));
+  ASSERT_TRUE(two.ok());
+  EXPECT_EQ(two.code_size() - one.code_size(), kUnrollLinks * 4u);
+}
+
+// Selecting the general-register base hoists one sljit_get_local_base
+// out of the loop and leaves the link body byte-identical, so the two
+// modes differ by a bounded constant rather than by per-link work.
+TEST(StoreLoadFootprint, BaseRegisterChoiceDoesNotChangePerLinkCode) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_footprint");
+  ASSERT_NE(b, nullptr);
+  ferret::JittedKernel sp(*b, make_params(256, 8, /*base_reg=*/0));
+  ASSERT_TRUE(sp.ok());
+  ferret::JittedKernel gpr(*b, make_params(256, 8, /*base_reg=*/1));
+  ASSERT_TRUE(gpr.ok());
+  size_t delta = gpr.code_size() - sp.code_size();
+  EXPECT_LE(delta, 16u) << "general-register base added per-link work, not just a hoisted base setup";
+}
+#endif

--- a/tests/test_store_load_overlap.cpp
+++ b/tests/test_store_load_overlap.cpp
@@ -1,0 +1,155 @@
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+extern "C" {
+#include <sljitLir.h>
+}
+
+#include "ferret/benchmark.hpp"
+#include "ferret/jit.hpp"
+#include "sljit_test_helpers.hpp"
+
+using ferret::testing::CompilerHandle;
+using ferret::testing::find_option;
+
+namespace {
+
+ferret::Params make_params(int64_t load_offset, int64_t store_width = 8, int64_t load_width = 8, int64_t alu_ops = 1) {
+  ferret::Params p;
+  p.set("load_offset_bytes", load_offset);
+  p.set("store_width", store_width);
+  p.set("load_width", load_width);
+  p.set("alu_ops", alu_ops);
+  p.set("seed", 1);
+  return p;
+}
+
+}  // namespace
+
+TEST(StoreLoadOverlap, RegistryLookupReturnsBenchmark) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_overlap");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->name(), "store_load_overlap");
+}
+
+TEST(StoreLoadOverlap, ExposesThreeAxesInCsvColumnOrder) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_overlap");
+  ASSERT_NE(b, nullptr);
+  auto axes = b->axes();
+  ASSERT_EQ(axes.size(), 3u);
+  EXPECT_EQ(axes[0].name(), "load_offset_bytes");
+  EXPECT_EQ(axes[1].name(), "store_width");
+  EXPECT_EQ(axes[2].name(), "load_width");
+}
+
+TEST(StoreLoadOverlap, AxisExpansionsMatchSpec) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_overlap");
+  ASSERT_NE(b, nullptr);
+  EXPECT_EQ(b->axes()[0].expand(), (std::vector<int64_t>{-2, -1, 0}));
+  EXPECT_EQ(b->axes()[1].expand(), (std::vector<int64_t>{4, 8}));
+  EXPECT_EQ(b->axes()[2].expand(), (std::vector<int64_t>{4, 8}));
+}
+
+// A rejected point aborts the whole sweep rather than being skipped, so
+// the default rectangle has to be valid at every combination.
+TEST(StoreLoadOverlap, EveryDefaultAxisCombinationIsAccepted) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_overlap");
+  ASSERT_NE(b, nullptr);
+  for (int64_t off : b->axes()[0].expand()) {
+    for (int64_t sw : b->axes()[1].expand()) {
+      for (int64_t lw : b->axes()[2].expand()) {
+        CompilerHandle ch;
+        EXPECT_NO_THROW(b->emit_kernel(ch.c, make_params(off, sw, lw)))
+            << "offset=" << off << " store_width=" << sw << " load_width=" << lw;
+      }
+    }
+  }
+}
+
+TEST(StoreLoadOverlap, ExposesAluOpsOption) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_overlap");
+  ASSERT_NE(b, nullptr);
+  auto opts = b->options();
+  ASSERT_EQ(opts.size(), 1u);
+  const auto* alu = find_option(opts, "alu_ops");
+  ASSERT_NE(alu, nullptr);
+  EXPECT_EQ(alu->default_value, 1);
+}
+
+// ---- Parameter rejection ----
+
+TEST(StoreLoadOverlap, RejectsWidthsOtherThanFourOrEight) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_overlap");
+  ASSERT_NE(b, nullptr);
+  for (int64_t w : {1, 2, 16}) {
+    {
+      CompilerHandle ch;
+      EXPECT_THROW(b->emit_kernel(ch.c, make_params(0, w, 8)), std::invalid_argument) << "store_width=" << w;
+    }
+    {
+      CompilerHandle ch;
+      EXPECT_THROW(b->emit_kernel(ch.c, make_params(0, 8, w)), std::invalid_argument) << "load_width=" << w;
+    }
+  }
+}
+
+// The chain is carried by adding 1, so only byte 0 of the stored value
+// is guaranteed to change every link. A load that misses byte 0 reads an
+// effectively constant value, the dependency dies, and the row would
+// report issue throughput -- which looks FAST and means nothing. Reject
+// rather than measure.
+TEST(StoreLoadOverlap, RejectsOffsetsThatWouldKillTheDependentChain) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_overlap");
+  ASSERT_NE(b, nullptr);
+  // Positive offset: the load starts above byte 0.
+  {
+    CompilerHandle ch;
+    EXPECT_THROW(b->emit_kernel(ch.c, make_params(1)), std::invalid_argument);
+  }
+  // Negative beyond the load's own width: the load ends at or below byte 0.
+  {
+    CompilerHandle ch;
+    EXPECT_THROW(b->emit_kernel(ch.c, make_params(-8, 8, 8)), std::invalid_argument);
+  }
+  {
+    CompilerHandle ch;
+    EXPECT_THROW(b->emit_kernel(ch.c, make_params(-4, 8, 4)), std::invalid_argument);
+  }
+}
+
+TEST(StoreLoadOverlap, RejectsAluOpsBelowOne) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_overlap");
+  ASSERT_NE(b, nullptr);
+  CompilerHandle ch;
+  EXPECT_THROW(b->emit_kernel(ch.c, make_params(0, 8, 8, /*alu_ops=*/0)), std::invalid_argument);
+}
+
+// ---- Codegen ----
+
+// An unaligned offset can push sljit past the scaled-immediate form. The
+// kernel addresses through a register pointing AT the slot so offsets
+// stay inside the 256-byte unscaled window; verify_layout proves it.
+TEST(StoreLoadOverlap, EveryDefaultCombinationEmitsUniformLinks) {
+  auto axes = ferret::BenchmarkRegistry::create("store_load_overlap")->axes();
+  for (int64_t off : axes[0].expand()) {
+    for (int64_t sw : axes[1].expand()) {
+      for (int64_t lw : axes[2].expand()) {
+        auto b = ferret::BenchmarkRegistry::create("store_load_overlap");
+        ASSERT_NE(b, nullptr);
+        ferret::JittedKernel k(*b, make_params(off, sw, lw));
+        EXPECT_TRUE(k.ok()) << "offset=" << off << " store_width=" << sw << " load_width=" << lw;
+      }
+    }
+  }
+}
+
+TEST(StoreLoadOverlap, EmittedKernelRuns) {
+  auto b = ferret::BenchmarkRegistry::create("store_load_overlap");
+  ASSERT_NE(b, nullptr);
+  ferret::JittedKernel k(*b, make_params(0));
+  ASSERT_TRUE(k.ok());
+  k.fn()();
+}


### PR DESCRIPTION
Three benchmarks probing whether a core resolves a load from an older store
without going to memory, and under what conditions — plus the tooling to keep
dependent-chain benchmarks honest.

| benchmark | axes | measures |
| --------- | ---- | -------- |
| `store_load_footprint` | `addresses` × `stride_bytes` × `base_reg` | forward latency; name-vs-address matching |
| `store_load_distance` | `separation` × `filler` | the separation window |
| `store_load_overlap` | `load_offset_bytes` × `store_width` × `load_width` | address/width match conditions |

## Results

Apple M4 Pro, 4.505 GHz:

```text
base_reg    0 sp/sp  1.99   1 gpr/gpr  1.97   2 sp->gpr 10.72   3 gpr->sp 10.71
separation  0:0.95  1:7.86  2:6.79  4:4.61  8:0.94  9:-0.02  12:-0.03
overlap     8/8 at offset 0 -> 1.98;  all 11 other width/offset combinations -> 10.9
```

Cross-checked on Apple M5 Pro (same mechanism, faster: 1.60 vs 9.25) and on a
Snapdragon 888 / Cortex-X1 via adb (no elimination at all — a plain store queue,
with all four `base_reg` forms identical at 5.0–6.3 cycles).

The `base_reg` axis is the discriminating one. Forms 2 and 3 reach identical
bytes through a register that provably holds the stack pointer, so a gap between
them and forms 0/1 means the hardware is matching on the register *name* rather
than on a computed address.

